### PR TITLE
Set up GitHub Actions CI with Playwright automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: Run tests
         run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 ._*
 
 # Custom folder icons
-Icon
+Icon
 
 # Volume root files
 .DocumentRevisions-V100
@@ -57,3 +57,11 @@ out/
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+### Node.js / npm
+node_modules/
+package-lock.json
+
+### CI / Testing
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Loom
 
+[![Tests](https://github.com/afjk/loom/actions/workflows/test.yml/badge.svg)](https://github.com/afjk/loom/actions/workflows/test.yml)
+
 A stateless dataflow engine for the browser. Build reactive visual, audio, and 3D content by composing pure functions.
 
 ---
@@ -8,9 +10,9 @@ A stateless dataflow engine for the browser. Build reactive visual, audio, and 3
 
 ## ステータス
 
-**第ゼロ段階：プロトタイプ実装完了**
+**第一段階：プロトタイプ実装完了、仕様確定**
 
-評価器コア（`src/loom.js`）と最小ノード5種（`clock`、`constant`、`sine`、`add`、`multiply`）の実装、テストスイート、デモが揃っています。GitHub Pages で動作確認できます。次は第一段階（イベント型と入力ノードの導入）を予定しています。
+第ゼロ段階および第一段階のプロトタイプ実装が完了。仕様書はバージョン 0.2.0 でクロスプラットフォーム評価セマンティクスを確定し、Phase 1.5（SceneSync アダプタ）および Phase 1.6（Unity 対応）の実装フェーズに進行可能となりました。
 
 ## 背景・モチベーション
 
@@ -107,6 +109,8 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 
 * 基本デモ：https://afjk.github.io/loom/examples/01-basic.html
 * 揺れる箱デモ：https://afjk.github.io/loom/examples/02-moving-box.html
+* ポインタ追従デモ：https://afjk.github.io/loom/examples/03-pointer.html
+* キー入力カウンタ：https://afjk.github.io/loom/examples/04-keydown.html
 * テスト結果：https://afjk.github.io/loom/test/loom.test.html
 
 ローカルで確認する場合は、ESM を使うため、ローカルファイル直接 (`file://`) ではなく HTTP サーバから配信する必要があります。
@@ -125,7 +129,15 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 
 * 揺れる箱デモ：`http://localhost:8000/examples/02-moving-box.html`
 
+* ポインタ追従デモ：`http://localhost:8000/examples/03-pointer.html`
+
+* キー入力カウンタ：`http://localhost:8000/examples/04-keydown.html`
+
 * テスト：`http://localhost:8000/test/loom.test.html`
+
+## CI と自動テスト
+
+GitHub Actions で自動テストを実行しています。ローカルで `npm test` を実行する場合は、`package.json` が必要ですが、これは CI 自動化専用です。`src/loom.js` は依存ライブラリゼロの単一ファイル配布であり、package.json は開発用ツール（Playwright、http-server）のみを含みます。
 
 ## ライセンス
 

--- a/ci/run-tests.mjs
+++ b/ci/run-tests.mjs
@@ -1,0 +1,115 @@
+import { spawn } from 'child_process';
+import { chromium } from 'playwright';
+import { globSync } from 'glob';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+async function runTests() {
+  let server = null;
+  let browser = null;
+
+  try {
+    // Start http-server on port 8080
+    console.log('Starting http-server on port 8080...');
+    server = spawn('npx', ['http-server', projectRoot, '-p', '8080', '-s'], {
+      stdio: 'ignore',
+      cwd: projectRoot,
+    });
+
+    // Wait for server to start
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Launch Chromium
+    console.log('Launching Chromium...');
+    browser = await chromium.launch();
+
+    // Find all test files
+    const testFiles = globSync('test/*.test.html', { cwd: projectRoot });
+    if (testFiles.length === 0) {
+      console.error('No test files found');
+      process.exit(1);
+    }
+
+    let totalPass = 0;
+    let totalFail = 0;
+    const failures = [];
+
+    // Run each test file
+    for (const testFile of testFiles) {
+      console.log(`\nRunning ${testFile}...`);
+      const url = `http://localhost:8080/${testFile}`;
+      const page = await browser.newPage();
+
+      try {
+        await page.goto(url, { waitUntil: 'networkidle' });
+
+        // Wait for results to appear (max 30 seconds)
+        let results = null;
+        const startTime = Date.now();
+        while (!results && Date.now() - startTime < 30000) {
+          results = await page.evaluate(() => window.__loomTestResults);
+          if (!results) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+          }
+        }
+
+        if (!results) {
+          console.error(`  ✗ Test results not found for ${testFile}`);
+          totalFail++;
+          failures.push({ file: testFile, error: 'Results timeout' });
+          continue;
+        }
+
+        const { pass = 0, fail = 0, failures: testFailures = [] } = results;
+        totalPass += pass;
+        totalFail += fail;
+
+        if (fail > 0) {
+          console.log(`  ✓ ${pass} passed, ✗ ${fail} failed`);
+          if (testFailures && testFailures.length > 0) {
+            testFailures.forEach(f => {
+              failures.push({ file: testFile, ...f });
+            });
+          }
+        } else {
+          console.log(`  ✓ ${pass} passed`);
+        }
+      } catch (error) {
+        console.error(`  ✗ Error running ${testFile}: ${error.message}`);
+        totalFail++;
+        failures.push({ file: testFile, error: error.message });
+      } finally {
+        await page.close();
+      }
+    }
+
+    // Print summary
+    console.log(`\n${'='.repeat(50)}`);
+    console.log(`Total: ${totalPass} passed, ${totalFail} failed`);
+    console.log(`${'='.repeat(50)}`);
+
+    if (failures.length > 0) {
+      console.log('\nFailures:');
+      failures.forEach(f => {
+        console.log(`  - ${f.file}: ${f.error || f.message}`);
+      });
+    }
+
+    process.exit(totalFail > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  } finally {
+    if (server) {
+      server.kill();
+    }
+    if (browser) {
+      await browser.close();
+    }
+  }
+}
+
+runTests();

--- a/ci/run-tests.mjs
+++ b/ci/run-tests.mjs
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process';
 import { chromium } from 'playwright';
-import { globSync } from 'glob';
+import { readdirSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -27,7 +27,10 @@ async function runTests() {
     browser = await chromium.launch();
 
     // Find all test files
-    const testFiles = globSync('test/*.test.html', { cwd: projectRoot });
+    const testDir = path.join(projectRoot, 'test');
+    const testFiles = readdirSync(testDir)
+      .filter(file => file.endsWith('.test.html'))
+      .map(file => `test/${file}`);
     if (testFiles.length === 0) {
       console.error('No test files found');
       process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "loom",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "test": "node ci/run-tests.mjs"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "loom",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node ci/run-tests.mjs"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1",
+    "playwright": "^1.40.0"
+  }
+}

--- a/test/loom.test.html
+++ b/test/loom.test.html
@@ -430,6 +430,7 @@
     // 実行とレポート
     const root = document.getElementById("results");
     let pass = 0, fail = 0;
+    const failures = [];
     for (const t of tests) {
       const div = document.createElement("div");
       div.className = "test-result";
@@ -442,6 +443,7 @@
         div.textContent = "❌ " + t.name + " — " + e.message;
         div.className += " test-fail";
         fail++;
+        failures.push({ name: t.name, message: e.message });
       }
       root.appendChild(div);
     }
@@ -456,6 +458,9 @@
       summary.textContent = `❌ ${pass} 成功, ${fail} 失敗`;
     }
     root.prepend(summary);
+
+    // Export results for CI automation
+    window.__loomTestResults = { pass, fail, failures };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Implements complete GitHub Actions CI infrastructure for automated testing using Playwright and Chromium.

## Changes

- **package.json**: Created with dev dependencies (playwright, http-server) and test script
- **ci/run-tests.mjs**: Playwright test runner that:
  - Starts http-server on port 8080
  - Launches Chromium browser
  - Runs each test file in test/*.test.html
  - Waits for window.__loomTestResults (max 30s timeout)
  - Aggregates and reports pass/fail counts
  - Exits with code 1 on failures, 0 on success
- **test/loom.test.html**: Modified to export `window.__loomTestResults` with { pass, fail, failures }
- **.github/workflows/test.yml**: GitHub Actions workflow running on pull_request, push to main, and workflow_dispatch
- **.gitignore**: Added node_modules/, playwright-report/, test-results/ exclusions
- **README.md**: 
  - Added CI badge
  - Updated status to Phase 1 completion
  - Listed all 4 demos (01-basic, 02-moving-box, 03-pointer, 04-keydown)
  - Added section explaining package.json is CI-only

## Test Plan

- [ ] Verify GitHub Actions workflow triggers on PR creation
- [ ] Check that all tests pass in CI environment
- [ ] Confirm CI badge displays correctly in README
- [ ] Verify src/loom.js still has zero runtime dependencies
- [ ] Test local `npm test` execution after installing dependencies

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbpeKD2Yaxtq3de6xEgBK4)_