### PR TITLE
CI セットアップ：Playwright によるブラウザテスト自動化（再投入）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 ._*
 
 # Custom folder icons
-Icon
+Icon
 
 # Volume root files
 .DocumentRevisions-V100
@@ -57,3 +57,11 @@ out/
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+### Node.js / npm
+node_modules/
+package-lock.json
+
+### CI / Testing
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Loom
 
+[![Tests](https://github.com/afjk/loom/actions/workflows/test.yml/badge.svg)](https://github.com/afjk/loom/actions/workflows/test.yml)
+
 A stateless dataflow engine for the browser. Build reactive visual, audio, and 3D content by composing pure functions.
 
 ---
@@ -132,6 +134,10 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 * キー入力カウンタ：`http://localhost:8000/examples/04-keydown.html`
 
 * テスト：`http://localhost:8000/test/loom.test.html`
+
+## CI と自動テスト
+
+GitHub Actions で自動テストを実行しています。ローカルで `npm test` を実行する場合は `package.json` が必要ですが、これは CI 自動化専用です。`src/loom.js` は依存ライブラリゼロの単一ファイル配布であり、`package.json` は開発用ツール（Playwright、http-server）のみを含みます。
 
 ## ライセンス
 

--- a/ci/run-tests.mjs
+++ b/ci/run-tests.mjs
@@ -1,0 +1,92 @@
+import { spawn } from 'child_process';
+import { chromium } from 'playwright';
+import { readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+async function runTests() {
+  let server = null;
+  let browser = null;
+
+  try {
+    console.log('Starting http-server on port 8080...');
+    server = spawn('npx', ['http-server', projectRoot, '-p', '8080', '-s'], {
+      stdio: 'ignore',
+      cwd: projectRoot,
+    });
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    console.log('Launching Chromium...');
+    browser = await chromium.launch();
+
+    const testDir = path.join(projectRoot, 'test');
+    const testFiles = readdirSync(testDir)
+      .filter(file => file.endsWith('.test.html'))
+      .map(file => `test/${file}`);
+
+    if (testFiles.length === 0) {
+      console.error('No test files found');
+      process.exit(1);
+    }
+
+    let totalPass = 0;
+    let totalFail = 0;
+    const failures = [];
+
+    for (const testFile of testFiles) {
+      console.log(`\nRunning ${testFile}...`);
+      const url = `http://localhost:8080/${testFile}`;
+      const page = await browser.newPage();
+
+      try {
+        await page.goto(url, { waitUntil: 'load', timeout: 15000 });
+
+        const results = await page.waitForFunction(
+          () => window.__loomTestResults,
+          { timeout: 30000 }
+        ).then(handle => handle.jsonValue());
+
+        const { pass = 0, fail = 0, failures: testFailures = [] } = results;
+        totalPass += pass;
+        totalFail += fail;
+
+        if (fail > 0) {
+          console.log(`  ✓ ${pass} passed, ✗ ${fail} failed`);
+          testFailures.forEach(f => failures.push({ file: testFile, ...f }));
+        } else {
+          console.log(`  ✓ ${pass} passed`);
+        }
+      } catch (error) {
+        console.error(`  ✗ Error: ${error.message}`);
+        totalFail++;
+        failures.push({ file: testFile, error: error.message });
+      } finally {
+        await page.close();
+      }
+    }
+
+    console.log(`\n${'='.repeat(50)}`);
+    console.log(`Total: ${totalPass} passed, ${totalFail} failed`);
+    console.log(`${'='.repeat(50)}`);
+
+    if (failures.length > 0) {
+      console.log('\nFailures:');
+      failures.forEach(f => {
+        console.log(`  - ${f.file}: ${f.name || ''} ${f.error || f.message || ''}`);
+      });
+    }
+
+    process.exit(totalFail > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  } finally {
+    if (server) server.kill();
+    if (browser) await browser.close();
+  }
+}
+
+runTests();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "loom",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node ci/run-tests.mjs"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1",
+    "playwright": "^1.48.0"
+  }
+}

--- a/test/loom.test.html
+++ b/test/loom.test.html
@@ -715,6 +715,7 @@
     // 実行とレポート
     const root = document.getElementById("results");
     let pass = 0, fail = 0;
+    const failures = [];
     for (const t of tests) {
       const div = document.createElement("div");
       div.className = "test-result";
@@ -727,6 +728,7 @@
         div.textContent = "❌ " + t.name + " — " + e.message;
         div.className += " test-fail";
         fail++;
+        failures.push({ name: t.name, message: e.message });
       }
       root.appendChild(div);
     }
@@ -741,6 +743,9 @@
       summary.textContent = `❌ ${pass} 成功, ${fail} 失敗`;
     }
     root.prepend(summary);
+
+    // Export results for CI automation
+    window.__loomTestResults = { pass, fail, failures };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

GitHub Actions + Playwright によるブラウザテスト自動化インフラを構築します。本 PR は Phase 1 実装完了後の自動テスト基盤整備で、Loom 本体コードには変更ありません。

## Changes

- **package.json** 追加：`playwright` 1.48.0、`http-server` 14.1.1 を devDependencies として指定、`npm test` スクリプト追加
- **ci/run-tests.mjs** 追加：Playwright + Chromium による自動テストランナー
  - http-server をポート 8080 で起動
  - test/*.test.html を自動走査
  - 各テストファイルを Chromium で実行
  - `window.__loomTestResults` 待機（max 30 秒）
  - 結果集約、exit code 1 で失敗を報告
- **.github/workflows/test.yml** 追加：GitHub Actions ワークフロー
  - Node 20 セットアップ
  - npm install + Playwright browsers インストール
  - `npm test` 実行
  - トリガー：pull_request、push to main、workflow_dispatch
- **test/loom.test.html** 修正：CI から結果を読み取るため
  - テスト失敗を `failures` 配列に収集
  - 最後に `window.__loomTestResults = { pass, fail, failures }` をエクスポート
- **.gitignore** 更新：`node_modules/`、`package-lock.json`、`playwright-report/`、`test-results/` 追加
- **README.md** 更新：
  - CI バッジ追加（GitHub Actions ワークフローへのリンク）
  - 「CI と自動テスト」セクション追加（package.json が CI 専用である旨を明記）

## 設計方針

1. **Loom 本体は変更なし** – `src/loom.js`、`examples/`、`docs/` はまったく変更していません
2. **GitHub Pages に干渉なし** – Pages は main ルートから Pages 設定で配信中。CI テストは別途追加するのみ
3. **外部依存ゼロ維持** – Loom 本体（src/loom.js）は ESM 単一ファイルで外部依存ゼロのまま。package.json は CI ツール専用
4. **意図的な赤スタート** – 現状の filter predicate 構文エラーが CI でも検出されることが正常動作の証拠

## Local Verification

```bash
npm install
npx playwright install chromium
npm test
```

**期待出力（抜粋）**：
```
Running test/loom.test.html...
  ✓ 45 passed, ✗ 1 failed

==================================================
Total: 45 passed, 1 failed
==================================================

Failures:
  - test/loom.test.html: filter: predicate 構文エラーで INVALID_GRAPH
```

- exit code：1（失敗）
- 失敗詳細：filter ノードの predicate 構文エラーで INVALID_GRAPH 発生（仕様側の課題、本 PR では対応外）

## Expected GitHub Actions Behavior

PR マージ後、GitHub Actions でも以下の動作が確認できます：

1. ✅ Install dependencies（npm install 成功）
2. ✅ Install Playwright browsers（Chromium バイナリダウンロード、10〜30 秒）
3. ❌ Run tests（45 pass / 1 fail、exit code 1 で失敗）

この「赤」状態は **正常動作の証拠** です。次の修正 PR で filter 構文エラーを修正→緑化予定。

## Next Steps

1. 本 PR をマージ
2. GitHub Actions が同じ結果（45/1）で赤になることを確認
3. 続いて filter predicate INVALID_GRAPH 修正 PR を投入
4. 修正後は CI が緑（46/0）になることを確認
5. その後、main ブランチに対して "Require status checks to pass before merging" を有効化

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbpeKD2Yaxtq3de6xEgBK4)_