### PR TITLE
Start Loom Scene Sync integration

### DIFF
--- a/docs/SCENESYNC.md
+++ b/docs/SCENESYNC.md
@@ -33,6 +33,27 @@ socket.on("message", (data) => {
 adapter.start();
 ```
 
+### Outbound helper usage
+
+Loom から SceneSync 互換メッセージを組み立てる場合は、手書きの object literal ではなく adapter の helper を使う。
+
+```javascript
+const graphMsg = adapter.createGraphSetMessage(
+  { object: "cube1" },
+  {
+    nodes: [
+      { id: "clock", type: "serverClock" },
+      { id: "pos", type: "sceneSetPosition", params: { target: "cube1" } }
+    ],
+    edges: [{ from: "clock.t", to: "pos.x" }]
+  }
+);
+
+socket.send(JSON.stringify(graphMsg));
+
+adapter.sendInput("scene", "pointer.move", { x: 120, y: 80 });
+```
+
 ---
 
 ## 2. メッセージプロトコル
@@ -234,6 +255,26 @@ adapter.clearGraph("scene");
 adapter.clearGraph({ object: "cube1" });
 ```
 
+### `patchGraph(scope, graph)` / `sendInput(scope, ref, payload)` （オプション）
+
+送信用 helper。どちらも送信前に scope と payload 形状を検証する。
+
+```javascript
+adapter.patchGraph("scene", nextGraph);
+adapter.sendInput("scene", "pointer.down", { x: 200, y: 120, button: 0 });
+```
+
+### `createGraphSetMessage(...)` などの message builder
+
+以下の helper は、送信の前にメッセージを保存・署名・batch 化したい場合に使う。
+
+- `createGraphSetMessage(scope, graph)`
+- `createGraphPatchMessage(scope, graph)`
+- `createGraphClearMessage(scope)`
+- `createGraphInputMessage(scope, ref, payload)`
+
+いずれも入力を検証し、`graph` / `payload` は shallow clone された object を返す。
+
 ---
 
 ## 5. オブジェクト単位グラフの利用
@@ -277,6 +318,33 @@ adapter.handleMessage({
   }
 });
 ```
+
+---
+
+## 6. 統合責務と source of truth
+
+Loom SceneSync 統合では、同じ target を「Loom が毎 frame 書く状態」と「remote sync が直接書く状態」に同時にしない方が安全。
+
+- **Loom authoritative**: `sceneSetPosition` / `sceneSetRotation` などを含む graph を SceneSync 経由で配布し、各 client が同じ graph を評価する。アニメーションや procedural motion 向き。
+- **SceneSync authoritative**: 他 peer や server から届いた transform/state をそのまま反映する。共同編集や drag 操作の確定値向き。
+
+推奨ルール:
+
+- 同一 target / 同一 property は一度に一つの系だけが ownership を持つ。
+- remote drag 中は Loom graph を clear または patch して sink を外し、drag 完了後に必要なら graph を戻す。
+- `scene-graph-input` は「状態そのもの」ではなく、「graph evaluation に必要な event」を配るために使う。
+- graph を受けて local 適用した結果を、そのまま再度 outbound 送信しない。feedback loop の原因になる。
+
+### 例: remote override 中だけ Loom movement を止める
+
+```javascript
+adapter.clearGraph({ object: "cube1" });
+applyRemoteTransform("cube1", incomingTransform);
+
+adapter.sendGraph({ object: "cube1" }, authoredMotionGraph);
+```
+
+この切り替え責務は transport 層または SceneSync セッション管理側が持ち、`LoomSceneSync` 自体は protocol 変換と graph 実行に専念させるのが最小で安全。
 
 各オブジェクトグラフは独立して評価される。
 

--- a/examples/07-scenesync-mock.html
+++ b/examples/07-scenesync-mock.html
@@ -197,13 +197,15 @@
     const adapter = new LoomSceneSync({
       LoomClass: Loom,
       send: (msg) => {
-        addLog(`SEND: ${msg.type} scope=${JSON.stringify(msg.scope)}`);
+        const body = msg.payload ?? msg.graph ?? {};
+        addLog(`SEND: ${msg.type} scope=${JSON.stringify(msg.scope)} body=${JSON.stringify(body)}`);
       },
       getServerTime,
       resolveTarget: (id) => objects[id] ?? null
     });
 
     addLog('Adapter initialized');
+    addLog('Ownership rule: avoid driving the same transform from both Loom sinks and remote sync at the same time');
 
     // Timeline: 1s - start scene graph
     setTimeout(() => {
@@ -226,6 +228,7 @@
         scope: 'scene',
         graph
       });
+      adapter.send(adapter.createGraphSetMessage('scene', graph));
 
       adapter.start();
       addLog('Adapter started - scene graph active');
@@ -266,6 +269,8 @@
         scope: { object: 'cube1' },
         graph
       });
+      adapter.send(adapter.createGraphSetMessage({ object: 'cube1' }, graph));
+      adapter.sendInput('scene', 'pointer.move', { x: 240, y: 160, source: 'mock-demo' });
 
       addLog('Object-specific graph activated');
     }, 5000);

--- a/src/loom-scenesync.js
+++ b/src/loom-scenesync.js
@@ -209,9 +209,7 @@ export class LoomSceneSync {
   }
 
   _injectAdapterId(graph) {
-    if (!graph || typeof graph !== "object" || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
-      throw new LoomError("INVALID_GRAPH", "graph must have nodes and edges arrays", { reason: "invalid graph" });
-    }
+    this._validateGraph(graph);
 
     // グラフをコピー（元を破壊しない）
     const nodes = graph.nodes.map(node => {
@@ -227,6 +225,23 @@ export class LoomSceneSync {
     });
 
     return { nodes, edges: graph.edges };
+  }
+
+  _validateGraph(graph) {
+    if (!graph || typeof graph !== "object" || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+      throw new LoomError("INVALID_GRAPH", "graph must have nodes and edges arrays", { reason: "invalid graph" });
+    }
+  }
+
+  _cloneGraph(graph) {
+    this._validateGraph(graph);
+    return {
+      nodes: graph.nodes.map(node => ({
+        ...node,
+        params: node.params ? { ...node.params } : node.params
+      })),
+      edges: graph.edges.map(edge => ({ ...edge }))
+    };
   }
 
   _handleGraphSet(msg) {
@@ -312,18 +327,62 @@ export class LoomSceneSync {
     }
   }
 
-  sendGraph(scope, graph) {
-    this.send({
+  createGraphSetMessage(scope, graph) {
+    this._validateScope(scope);
+    return {
       type: "scene-graph-set",
       scope,
-      graph
-    });
+      graph: this._cloneGraph(graph)
+    };
+  }
+
+  createGraphPatchMessage(scope, graph) {
+    this._validateScope(scope);
+    return {
+      type: "scene-graph-patch",
+      scope,
+      graph: this._cloneGraph(graph)
+    };
+  }
+
+  createGraphClearMessage(scope) {
+    this._validateScope(scope);
+    return {
+      type: "scene-graph-clear",
+      scope
+    };
+  }
+
+  createGraphInputMessage(scope, ref, payload = {}) {
+    this._validateScope(scope);
+    if (typeof ref !== "string" || ref.length === 0) {
+      throw new LoomError("INVALID_MESSAGE", "ref must be a non-empty string", { ref });
+    }
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new LoomError("INVALID_MESSAGE", "payload must be an object", { payload });
+    }
+
+    return {
+      type: "scene-graph-input",
+      scope,
+      ref,
+      payload: { ...payload }
+    };
+  }
+
+  sendGraph(scope, graph) {
+    this.send(this.createGraphSetMessage(scope, graph));
+  }
+
+  patchGraph(scope, graph) {
+    this.send(this.createGraphPatchMessage(scope, graph));
   }
 
   clearGraph(scope) {
-    this.send({
-      type: "scene-graph-clear",
-      scope
-    });
+    this.send(this.createGraphClearMessage(scope));
+  }
+
+  sendInput(scope, ref, payload = {}) {
+    this.send(this.createGraphInputMessage(scope, ref, payload));
   }
 }

--- a/test/loom-scenesync.test.html
+++ b/test/loom-scenesync.test.html
@@ -561,6 +561,83 @@
       assertEqual(t2, 2.0, 'adapter2 should use its own getServerTime');
     });
 
+    // Test 21: createGraphSetMessage は scope/graph を検証し複製を返す
+    test('createGraphSetMessage は scope/graph を検証し複製を返す', () => {
+      const adapter = new LoomSceneSync({
+        LoomClass: Loom,
+        send: () => {},
+        getServerTime: () => 0,
+        resolveTarget: () => null
+      });
+
+      const graph = {
+        nodes: [{ id: 'const', type: 'constant', params: { value: 5 } }],
+        edges: []
+      };
+
+      const msg = adapter.createGraphSetMessage('scene', graph);
+      graph.nodes[0].params.value = 9;
+
+      assertEqual(msg.type, 'scene-graph-set');
+      assertEqual(msg.scope, 'scene');
+      assertEqual(msg.graph.nodes[0].params.value, 5, 'message graph should be cloned');
+    });
+
+    // Test 22: sendGraph / patchGraph / clearGraph / sendInput は SceneSync 互換メッセージを送る
+    test('sendGraph / patchGraph / clearGraph / sendInput は SceneSync 互換メッセージを送る', () => {
+      const sent = [];
+      const adapter = new LoomSceneSync({
+        LoomClass: Loom,
+        send: (msg) => sent.push(msg),
+        getServerTime: () => 0,
+        resolveTarget: () => null
+      });
+
+      const graph = {
+        nodes: [{ id: 'const', type: 'constant', params: { value: 5 } }],
+        edges: []
+      };
+
+      adapter.sendGraph({ object: 'cube1' }, graph);
+      adapter.patchGraph('scene', graph);
+      adapter.clearGraph({ object: 'cube1' });
+      adapter.sendInput('scene', 'pointer.move', { x: 10, y: 20 });
+
+      assertEqual(sent.length, 4, 'should emit 4 messages');
+      assertEqual(sent[0].type, 'scene-graph-set');
+      assertEqual(sent[0].scope.object, 'cube1');
+      assertEqual(sent[1].type, 'scene-graph-patch');
+      assertEqual(sent[2].type, 'scene-graph-clear');
+      assertEqual(sent[3].type, 'scene-graph-input');
+      assertEqual(sent[3].ref, 'pointer.move');
+      assertEqual(sent[3].payload.x, 10);
+      assertEqual(sent[3].payload.y, 20);
+    });
+
+    // Test 23: createGraphInputMessage は ref/payload を検証する
+    test('createGraphInputMessage は ref/payload を検証する', () => {
+      const adapter = new LoomSceneSync({
+        LoomClass: Loom,
+        send: () => {},
+        getServerTime: () => 0,
+        resolveTarget: () => null
+      });
+
+      try {
+        adapter.createGraphInputMessage('scene', '', {});
+        throw new Error('Should have thrown');
+      } catch (e) {
+        assert(e.code === 'INVALID_MESSAGE', 'empty ref should throw INVALID_MESSAGE');
+      }
+
+      try {
+        adapter.createGraphInputMessage('scene', 'pointer.move', null);
+        throw new Error('Should have thrown');
+      } catch (e) {
+        assert(e.code === 'INVALID_MESSAGE', 'null payload should throw INVALID_MESSAGE');
+      }
+    });
+
     // Display results + set window.__loomTestResults for CI
     function displayResults() {
       const passed = results.filter(r => r.pass).length;


### PR DESCRIPTION
## Summary
- add SceneSync message builder helpers and validated outbound send helpers
- add focused adapter tests for outbound SceneSync serialization
- document integration ownership boundaries and show outbound helper usage in the mock example

## Testing
- `npm test` (blocked locally: `playwright` package not installed in this workspace)
- `node --input-type=module -e "import { Loom } from './src/loom.js'; import { LoomSceneSync } from './src/loom-scenesync.js'; const sent=[]; const adapter=new LoomSceneSync({LoomClass:Loom,send:(msg)=>sent.push(msg),getServerTime:()=>1,resolveTarget:()=>null}); const graph={nodes:[{id:'clock',type:'serverClock'}],edges:[]}; const msg=adapter.createGraphSetMessage('scene',graph); adapter.sendInput('scene','pointer.move',{x:1,y:2}); if(msg.type!=='scene-graph-set') throw new Error('bad set message'); if(sent[0].type!=='scene-graph-input') throw new Error('bad input send'); console.log('smoke-ok');"