### PR TITLE
Fix bugs in example demos

### DIFF
--- a/examples/08-lissajous.html
+++ b/examples/08-lissajous.html
@@ -72,10 +72,9 @@
     const canvas = document.getElementById("canvas");
     const ctx = canvas.getContext("2d");
 
-    // 半透明の黒で背景を描く（残像効果）
-    ctx.fillStyle = "rgba(0, 0, 0, 0.05)";
-
     function tick() {
+      // 背景を半透明黒で塗る（残像効果）
+      ctx.fillStyle = "rgba(0, 0, 0, 0.05)";
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
       const x = engine.getValue("mapX.out");

--- a/examples/13-clamp-map.html
+++ b/examples/13-clamp-map.html
@@ -97,9 +97,9 @@
     const freqDisplay = document.getElementById("freqDisplay");
 
     function tick() {
+      const time = engine.getValue("timer.t");
       const freq = engine.getValue("freqMap.out");
       const width = engine.getValue("widthMap.out");
-      const time = engine.time;
 
       bar.style.width = width + "px";
       timeDisplay.textContent = `時刻: ${time.toFixed(1)}s`;


### PR DESCRIPTION
- examples/08-lissajous.html: Move fillStyle reset inside tick() loop to fix background color being overwritten to green each frame. Now correctly shows green trailing points on black background with afterimage effect.

- examples/13-clamp-map.html: Replace non-existent engine.time with engine.getValue('timer.t'). Fixes TypeError that stopped animation loop. This follows Loom's stateless design principle of getting time via clock node.

examples/10-multi-phase.html: No changes needed - works correctly.

https://claude.ai/code/session_01CuiorqataeNkHx9JTBXyTW