### PR TITLE
Add three new example demos: lerp tween, color cycle, and circular motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 * Three.js デモ：https://afjk.github.io/loom/examples/06-three-cube.html
 * SceneSync モックデモ：https://afjk.github.io/loom/examples/07-scenesync-mock.html
 * Lissajous 曲線：https://afjk.github.io/loom/examples/08-lissajous.html
+* イージングポインタ追従：https://afjk.github.io/loom/examples/09-lerp-tween.html
 * 位相ずらし波：https://afjk.github.io/loom/examples/10-multi-phase.html
+* 色相循環 (Three.js)：https://afjk.github.io/loom/examples/11-color-cycle.html
+* 円運動：https://afjk.github.io/loom/examples/12-circular-motion.html
 * 範囲リマップ：https://afjk.github.io/loom/examples/13-clamp-map.html
 * テスト結果：https://afjk.github.io/loom/test/loom.test.html
 
@@ -167,7 +170,13 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 
 * Lissajous 曲線：`http://localhost:8000/examples/08-lissajous.html`
 
+* イージングポインタ追従：`http://localhost:8000/examples/09-lerp-tween.html`
+
 * 位相ずらし波：`http://localhost:8000/examples/10-multi-phase.html`
+
+* 色相循環 (Three.js)：`http://localhost:8000/examples/11-color-cycle.html`
+
+* 円運動：`http://localhost:8000/examples/12-circular-motion.html`
 
 * 範囲リマップ：`http://localhost:8000/examples/13-clamp-map.html`
 

--- a/examples/09-lerp-tween.html
+++ b/examples/09-lerp-tween.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Easing pointer follow - イージングでマウス追従</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    h1 {
+      color: #333;
+    }
+    .description {
+      color: #666;
+      margin: 20px 0;
+      line-height: 1.6;
+    }
+    canvas {
+      border: 2px solid #ccc;
+      background: #111;
+      border-radius: 4px;
+      display: block;
+      margin: 30px auto;
+      max-width: 100%;
+      cursor: crosshair;
+    }
+    .info {
+      font-family: monospace;
+      color: #666;
+      font-size: 12px;
+      margin-top: 16px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Easing pointer follow - イージングでマウス追従</h1>
+  <p class="description">
+    マウスポインタに滑らかに追従する点。<code>pointerPosition</code> でマウス位置を連続取得し、<code>clock</code> + <code>mod</code> で 0→1 のランプを生成、<code>lerp</code> で補間します。
+  </p>
+
+  <canvas id="canvas" width="800" height="500"></canvas>
+
+  <div class="info">
+    グラフ: (clock, pointerPosition) → mod → (lerp x, lerp y) → canvas
+  </div>
+
+  <script type="module">
+    import { Loom } from "../src/loom.js";
+
+    const graph = {
+      nodes: [
+        { id: "timer", type: "clock" },
+        { id: "pointerPos", type: "pointerPosition", params: { target: "#canvas" } },
+        { id: "ramp", type: "mod", params: { b: 1.0 } },
+        { id: "lerpX", type: "lerp" },
+        { id: "lerpY", type: "lerp" }
+      ],
+      edges: [
+        { from: "timer.t", to: "ramp.a" },
+        { from: "ramp.out", to: "lerpX.t" },
+        { from: "ramp.out", to: "lerpY.t" }
+      ]
+    };
+
+    const engine = new Loom(graph);
+    engine.evaluateAt(0);
+    engine.start();
+
+    const canvas = document.getElementById("canvas");
+    const ctx = canvas.getContext("2d");
+
+    function tick() {
+      // 背景を半透明黒で塗る（残像効果）
+      ctx.fillStyle = "rgba(0, 0, 0, 0.08)";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // ポインタ位置とランプ係数を取得
+      const pos = engine.getValue("pointerPos.pos") || { x: 400, y: 250 };
+      const t = engine.getValue("ramp.out");
+
+      // lerp 計算（中心 → ポインタ位置へイージング）
+      const centerX = 400;
+      const centerY = 250;
+      const x = centerX + (pos.x - centerX) * t;
+      const y = centerY + (pos.y - centerY) * t;
+
+      // 現在の点を描く
+      ctx.fillStyle = "#00ff00";
+      ctx.beginPath();
+      ctx.arc(x, y, 5, 0, Math.PI * 2);
+      ctx.fill();
+
+      requestAnimationFrame(tick);
+    }
+    tick();
+  </script>
+</body>
+</html>

--- a/examples/09-lerp-tween.html
+++ b/examples/09-lerp-tween.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Easing pointer follow - イージングでマウス追従</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    h1 {
+      color: #333;
+    }
+    .description {
+      color: #666;
+      margin: 20px 0;
+      line-height: 1.6;
+    }
+    canvas {
+      border: 2px solid #ccc;
+      background: #111;
+      border-radius: 4px;
+      display: block;
+      margin: 30px auto;
+      max-width: 100%;
+      cursor: crosshair;
+    }
+    .info {
+      font-family: monospace;
+      color: #666;
+      font-size: 12px;
+      margin-top: 16px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Easing pointer follow - イージングでマウス追従</h1>
+  <p class="description">
+    マウスポインタに滑らかに追従する点。<code>pointerPosition</code> でマウス位置を連続取得し、<code>clock</code> + <code>mod</code> で 0→1 のランプを生成、<code>lerp</code> で補間します。
+  </p>
+
+  <canvas id="canvas" width="800" height="500"></canvas>
+
+  <div class="info">
+    グラフ: (clock, pointerPosition) → mod → (lerp x, lerp y) → canvas
+  </div>
+
+  <script type="module">
+    import { Loom } from "../src/loom.js";
+
+    const graph = {
+      nodes: [
+        { id: "timer", type: "clock" },
+        { id: "pointerPos", type: "pointerPosition", params: { target: "#canvas" } },
+        { id: "center", type: "constant", params: { value: 400 } },
+        { id: "centerY", type: "constant", params: { value: 250 } },
+        { id: "ramp", type: "mod", params: { b: 1.0 } },
+        { id: "lerpX", type: "lerp" },
+        { id: "lerpY", type: "lerp" }
+      ],
+      edges: [
+        { from: "timer.t", to: "ramp.a" },
+        { from: "center.out", to: "lerpX.a" },
+        { from: "centerY.out", to: "lerpY.a" },
+        { from: "pointerPos.pos.x", to: "lerpX.b" },
+        { from: "pointerPos.pos.y", to: "lerpY.b" },
+        { from: "ramp.out", to: "lerpX.t" },
+        { from: "ramp.out", to: "lerpY.t" }
+      ]
+    };
+
+    const engine = new Loom(graph);
+    engine.evaluateAt(0);
+    engine.start();
+
+    const canvas = document.getElementById("canvas");
+    const ctx = canvas.getContext("2d");
+
+    function tick() {
+      // 背景を半透明黒で塗る（残像効果）
+      ctx.fillStyle = "rgba(0, 0, 0, 0.08)";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      const x = engine.getValue("lerpX.out");
+      const y = engine.getValue("lerpY.out");
+
+      // 現在の点を描く
+      ctx.fillStyle = "#00ff00";
+      ctx.beginPath();
+      ctx.arc(x, y, 5, 0, Math.PI * 2);
+      ctx.fill();
+
+      requestAnimationFrame(tick);
+    }
+    tick();
+  </script>
+</body>
+</html>

--- a/examples/11-color-cycle.html
+++ b/examples/11-color-cycle.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Color cycle - 位相ずらしで色相循環</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      width: 100vw;
+      height: 100vh;
+      font-family: sans-serif;
+      background: #000;
+      color: #fff;
+    }
+    #canvas-host {
+      width: 100%;
+      height: 100%;
+    }
+    #info {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      background: rgba(0, 0, 0, 0.7);
+      padding: 20px;
+      border-radius: 8px;
+      max-width: 400px;
+      line-height: 1.6;
+    }
+    h1 {
+      margin-bottom: 10px;
+      font-size: 20px;
+    }
+    p {
+      font-size: 14px;
+      color: #ccc;
+      margin: 8px 0;
+    }
+    code {
+      background: rgba(255, 255, 255, 0.1);
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: monospace;
+      font-size: 12px;
+    }
+  </style>
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="canvas-host"></div>
+  <div id="info">
+    <h1>Color cycle - 位相ずらしで色相循環</h1>
+    <p>R, G, B チャンネルそれぞれに位相を 2π/3 ずつずらした sine を当て、<code>map</code> で 0–1 範囲にリマップ。連続的に色相が回転する立方体を表示。</p>
+  </div>
+
+  <script type="module">
+    import * as THREE from "three";
+    import { Loom } from "../src/loom.js";
+    import { registerThreeNodes } from "../src/loom-three.js";
+
+    // Three.js のセットアップ
+    const host = document.getElementById("canvas-host");
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x1a1a1a);
+
+    const camera = new THREE.PerspectiveCamera(
+      60,
+      host.clientWidth / host.clientHeight,
+      0.1,
+      100
+    );
+    camera.position.set(0, 0, 5);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(host.clientWidth, host.clientHeight);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    host.appendChild(renderer.domElement);
+
+    // ライティング
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
+    scene.add(ambientLight);
+
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
+    directionalLight.position.set(5, 5, 5);
+    scene.add(directionalLight);
+
+    // 立方体の作成
+    const geometry = new THREE.BoxGeometry(1.5, 1.5, 1.5);
+    const material = new THREE.MeshPhongMaterial({ color: 0xffffff });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    // Loom のセットアップ
+    registerThreeNodes(Loom, { cube });
+
+    const graph = {
+      nodes: [
+        { id: "timer", type: "clock" },
+        { id: "sineR", type: "sine", params: { freq: 0.3, amplitude: 1, phase: 0 } },
+        { id: "sineG", type: "sine", params: { freq: 0.3, amplitude: 1, phase: 2.094 } },
+        { id: "sineB", type: "sine", params: { freq: 0.3, amplitude: 1, phase: 4.189 } },
+        { id: "mapR", type: "map", params: { inMin: -1, inMax: 1, outMin: 0, outMax: 1 } },
+        { id: "mapG", type: "map", params: { inMin: -1, inMax: 1, outMin: 0, outMax: 1 } },
+        { id: "mapB", type: "map", params: { inMin: -1, inMax: 1, outMin: 0, outMax: 1 } },
+        { id: "setColor", type: "setColor", params: { target: "cube" } }
+      ],
+      edges: [
+        { from: "timer.t", to: "sineR.t" },
+        { from: "timer.t", to: "sineG.t" },
+        { from: "timer.t", to: "sineB.t" },
+        { from: "sineR.out", to: "mapR.value" },
+        { from: "sineG.out", to: "mapG.value" },
+        { from: "sineB.out", to: "mapB.value" },
+        { from: "mapR.out", to: "setColor.r" },
+        { from: "mapG.out", to: "setColor.g" },
+        { from: "mapB.out", to: "setColor.b" }
+      ]
+    };
+
+    const engine = new Loom(graph);
+    engine.start();
+
+    // レスポンシブ対応
+    window.addEventListener("resize", () => {
+      const width = host.clientWidth;
+      const height = host.clientHeight;
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height);
+    });
+
+    // Three.js のレンダループ
+    function animate() {
+      cube.rotation.x += 0.002;
+      cube.rotation.y += 0.003;
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    }
+    animate();
+  </script>
+</body>
+</html>

--- a/examples/12-circular-motion.html
+++ b/examples/12-circular-motion.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Circular motion - sine と cosine で円運動</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    h1 {
+      color: #333;
+    }
+    .description {
+      color: #666;
+      margin: 20px 0;
+      line-height: 1.6;
+    }
+    canvas {
+      border: 2px solid #ccc;
+      background: #111;
+      border-radius: 4px;
+      display: block;
+      margin: 30px auto;
+      max-width: 100%;
+    }
+    .info {
+      font-family: monospace;
+      color: #666;
+      font-size: 12px;
+      margin-top: 16px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Circular motion - sine と cosine で円運動</h1>
+  <p class="description">
+    同じ周波数の <code>sine</code> と <code>cosine</code> を X, Y に当てると円になります。Lissajous (08) の 1:1 周波数比・位相差 π/2 の特殊形です。
+  </p>
+
+  <canvas id="canvas" width="600" height="600"></canvas>
+
+  <div class="info">
+    グラフ: clock → (sine@freq0.5, cosine@freq0.5) → map → canvas
+  </div>
+
+  <script type="module">
+    import { Loom } from "../src/loom.js";
+
+    const graph = {
+      nodes: [
+        { id: "timer", type: "clock" },
+        { id: "sineX", type: "sine", params: { freq: 0.5, amplitude: 1 } },
+        { id: "cosineY", type: "cosine", params: { freq: 0.5, amplitude: 1 } },
+        { id: "mapX", type: "map", params: { inMin: -1, inMax: 1, outMin: 100, outMax: 500 } },
+        { id: "mapY", type: "map", params: { inMin: -1, inMax: 1, outMin: 100, outMax: 500 } }
+      ],
+      edges: [
+        { from: "timer.t", to: "sineX.t" },
+        { from: "timer.t", to: "cosineY.t" },
+        { from: "sineX.out", to: "mapX.value" },
+        { from: "cosineY.out", to: "mapY.value" }
+      ]
+    };
+
+    const engine = new Loom(graph);
+    engine.evaluateAt(0);
+    engine.start();
+
+    const canvas = document.getElementById("canvas");
+    const ctx = canvas.getContext("2d");
+
+    function tick() {
+      // 背景を半透明黒で塗る（残像効果）
+      ctx.fillStyle = "rgba(0, 0, 0, 0.05)";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      const x = engine.getValue("mapX.out");
+      const y = engine.getValue("mapY.out");
+
+      // 現在の点を描く
+      ctx.fillStyle = "#00ff00";
+      ctx.beginPath();
+      ctx.arc(x, y, 4, 0, Math.PI * 2);
+      ctx.fill();
+
+      requestAnimationFrame(tick);
+    }
+    tick();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds three new interactive example demonstrations to showcase different capabilities of the Loom graph engine, along with corresponding documentation updates.

## Changes Made

### New Examples
- **09-lerp-tween.html**: Demonstrates easing and pointer following using `clock`, `pointerPosition`, `mod`, and `lerp` nodes to create smooth mouse-tracking animation on canvas
- **11-color-cycle.html**: Shows continuous hue rotation on a Three.js cube by applying phase-shifted sine waves (2π/3 offset) to R, G, B channels with `map` nodes for range remapping
- **12-circular-motion.html**: Illustrates circular motion using `sine` and `cosine` nodes at matching frequencies (a special case of Lissajous curves with 1:1 frequency ratio and π/2 phase difference)

### Documentation
- Updated README.md to include links to all three new examples in both the GitHub Pages and local development sections
- Maintained consistent formatting with existing example documentation

## Implementation Details
- All examples follow the established pattern of creating a Loom graph with nodes and edges, then using `engine.start()` and `getValue()` for real-time updates
- Examples use appropriate rendering targets: canvas 2D context for 09 and 12, Three.js for 11
- Each example includes descriptive HTML info sections explaining the mathematical/technical concepts
- Responsive design considerations included where applicable (resize handling in 11)

https://claude.ai/code/session_01SmeXaPHyduFtc4YMtAvKdh