### PR TITLE
Add Loom DSL parser (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ Graph DSL → JSON graph → Web Loom / Unity Loom で評価
 
 詳細な API・ノード仕様は [docs/SPEC.md](docs/SPEC.md) をご覧ください。
 
+## ライブエディタと DSL
+
+ライブエディタ（`editor/index.html`）では **JSON** モードと **DSL** モードを切り替えてグラフを編集できます。
+
+DSL（Domain Specific Language）は JSON より簡潔にグラフを記述するためのテキスト形式です。各代入文がノードに、識別子参照がエッジに自動変換されます。
+
+```
+# リサジュー曲線の DSL 例
+timer = clock()
+sineX = sine(timer, freq: 0.3)
+cosineY = cosine(timer, freq: 0.5)
+mapX = map(sineX, inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+mapY = map(cosineY, inMin: -1, inMax: 1, outMin: 50, outMax: 450)
+
+render point(x: mapX, y: mapY, color: "#00ff00", trail: 0.05)
+```
+
+パイプ演算子 `|>` を使えば処理の流れをより直線的に書けます：
+
+```
+timer = clock()
+x = timer |> sine(freq: 0.3) |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+```
+
+詳細な仕様は **[docs/DSL.md](docs/DSL.md)** をご覧ください。
+
 ## デモの確認方法
 
 GitHub Pages で公開されているデモを、ブラウザから直接確認できます。

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -1,0 +1,283 @@
+# Loom DSL 仕様書
+
+## 概要
+
+Loom DSL は JSON グラフをより簡潔に記述するためのテキスト形式です。各「代入文」が Loom のノードに対応し、識別子参照がエッジに、リテラル値がパラメータに変換されます。
+
+DSL → JSON グラフへの片方向変換のみサポートします（JSON → DSL は今後の予定）。
+
+```
+# DSL
+t = clock()
+wave = sine(t, freq: 0.3)
+
+# 等価な JSON
+{
+  "nodes": [
+    { "id": "t", "type": "clock" },
+    { "id": "wave", "type": "sine", "params": { "freq": 0.3 } }
+  ],
+  "edges": [
+    { "from": "t.t", "to": "wave.t" }
+  ]
+}
+```
+
+---
+
+## 構文
+
+### コメント
+
+`#` から行末まで。行の途中にも書けます。
+
+```
+# これはコメント
+t = clock()  # 時間ソース
+```
+
+### 代入文
+
+```
+識別子 = 式
+```
+
+左辺の識別子がノード ID になります。式は関数呼び出しまたはパイプ式です。
+
+```
+timer = clock()
+wave = sine(timer, freq: 0.5)
+```
+
+### 数値・文字列・真偽値リテラル
+
+| 種類 | 例 |
+|------|-----|
+| 数値 | `0.3`, `-1`, `100`, `4.5e-2` |
+| 文字列 | `"#00ff00"`, `"running"` |
+| 真偽値 | `true`, `false` |
+
+リテラルは関数引数として使われ、対応するノードの `params` に格納されます。
+
+### 識別子
+
+英字または `_` で始まり、英数字・`_` が続きます。
+
+```
+t, wave, mapX, slow_sine
+```
+
+式の中で識別子を参照すると、そのノードのデフォルト出力ポートからのエッジが自動生成されます。
+
+### 関数呼び出しと引数
+
+```
+関数名(引数リスト)
+```
+
+引数には **位置引数** と **名前付き引数** があります。
+
+```
+sine(t, freq: 0.3)        # t は位置引数、freq: 0.3 は名前付き引数
+clock()                    # 引数なし
+map(t, inMin: 0, inMax: 10, outMin: 100, outMax: 700)
+```
+
+### パイプ演算子
+
+`式 |> 関数呼び出し` で、左辺の式が右辺関数の第1引数として渡されます。
+
+```
+t |> sine(freq: 0.3)
+# 等価: sine(t, freq: 0.3)
+```
+
+チェーン可能です：
+
+```
+t |> sine(freq: 0.3) |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+```
+
+### render 文
+
+トップレベルに1つだけ書ける特殊な文です。エディタのキャンバス描画を設定します。
+
+```
+render point(x: mapX, y: mapY, color: "#00ff00", trail: 0.05)
+render bar(width: widthMap, color: "#00ccff", height: 40)
+```
+
+`point` と `bar` は Loom ノードではなく、エディタの描画設定に変換されます。
+
+### 改行と継続
+
+通常、改行は文の終わりです。以下の場合は継続とみなされます：
+
+1. **括弧内**: `(` が閉じていない間、改行は無視されます
+2. **パイプ継続**: 次の行が `|>` で始まる場合（直前の行との間に空行がない場合）
+
+```
+# 括弧内の複数行
+result = map(
+  t,
+  inMin: 0,
+  inMax: 10,
+  outMin: 100,
+  outMax: 700
+)
+
+# パイプ継続
+width = t
+  |> mod(b: 4)
+  |> smoothstep(edge0: 1, edge1: 3)
+  |> map(inMin: 0, inMax: 1, outMin: 100, outMax: 700)
+```
+
+**注意**: 空行が入るとパイプチェーンは終わります。空行の後に `|>` が来た場合は構文エラーになります。
+
+---
+
+## 引数のルール
+
+### デフォルトルール（全ノード共通）
+
+- 第1引数: 位置引数でも名前付き引数でも可
+- 第2引数以降: **名前付き必須**
+
+```
+sine(t, freq: 0.3)          # OK
+sine(t: t, freq: 0.3)       # OK（全部名前付き）
+sine(t, 0.3)                # エラー（freq に名前が必要）
+```
+
+### 可換ノード（add, multiply）
+
+全引数を位置引数で書けます。ただし **混在禁止**（全部位置引数か全部名前付き引数のどちらか）。
+
+```
+add(a, b)                   # OK（全部位置引数）
+add(a: x, b: y)             # OK（全部名前付き）
+add(a, b: y)                # エラー（混在禁止）
+```
+
+### 非可換ノード（subtract, divide, mod など）
+
+デフォルトルール通り。第1引数のみ位置引数で書けます。
+
+```
+subtract(x, b: y)           # OK（第1引数のみ位置）
+subtract(a: x, b: y)        # OK（全部名前付き）
+subtract(x, y)              # エラー（b に名前が必要）
+```
+
+### パイプ演算子と引数ルールの関係
+
+パイプ `|>` は第1引数を提供するため、呼び出し側の引数は第2引数以降になります。
+
+```
+x |> sine(freq: 0.3)        # OK（x は |> で第1引数, freq が第2引数）
+x |> add(y)                 # OK（add は可換、x と y は両方位置引数）
+```
+
+---
+
+## ノードのデフォルト出力ポート
+
+識別子を参照する際、自動的に「デフォルト出力ポート」が選択されます。
+
+| ノード型 | デフォルト出力ポート |
+|----------|---------------------|
+| `clock` | `t` |
+| `pointerPosition` | `pos` |
+| その他 | `out` |
+
+例：
+
+```
+t = clock()
+wave = sine(t, freq: 0.3)
+# t は clock の出力 → t.t として解決
+# wave は sine の出力 → wave.out として解決
+```
+
+---
+
+## エラー
+
+パースエラーは `LoomDSLError` としてスローされます。
+
+| プロパティ | 説明 |
+|-----------|------|
+| `message` | エラーメッセージ |
+| `line` | 行番号（1始まり）|
+| `column` | 列番号（1始まり）|
+| `code` | エラー種別 |
+
+### エラーコード一覧
+
+| コード | 説明 |
+|--------|------|
+| `UNEXPECTED_TOKEN` | 予期しないトークン |
+| `UNKNOWN_NODE_TYPE` | 未知のノード型 |
+| `MISSING_ARGUMENT_NAME` | 引数名が必要 |
+| `UNDEFINED_IDENTIFIER` | 未定義の識別子 |
+
+---
+
+## 例
+
+### リサジュー曲線
+
+```
+timer = clock()
+sineX = sine(timer, freq: 0.3)
+cosineY = cosine(timer, freq: 0.5)
+mapX = map(sineX, inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+mapY = map(cosineY, inMin: -1, inMax: 1, outMin: 50, outMax: 450)
+
+render point(x: mapX, y: mapY, color: "#00ff00", trail: 0.05)
+```
+
+### 円運動
+
+```
+timer = clock()
+x = sine(timer, freq: 0.5)
+y = cosine(timer, freq: 0.5)
+mapX = map(x, inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+mapY = map(y, inMin: -1, inMax: 1, outMin: 50, outMax: 450)
+
+render point(x: mapX, y: mapY, color: "#ff00ff", trail: 0.05)
+```
+
+### 範囲リマップ（clamp-map）
+
+```
+timer = clock()
+freqMap = map(timer, inMin: 0, inMax: 30, outMin: 0.1, outMax: 5, clamp: true)
+wave = sine(timer, freq: freqMap)
+widthMap = map(wave, inMin: -1, inMax: 1, outMin: 50, outMax: 750)
+
+render bar(width: widthMap, color: "#00ccff", height: 40)
+```
+
+### smoothstep フェード
+
+```
+timer = clock()
+mod = mod(timer, b: 4)
+smooth = smoothstep(mod, edge0: 1, edge1: 3)
+widthMap = map(smooth, inMin: 0, inMax: 1, outMin: 50, outMax: 600)
+
+render bar(width: widthMap, color: "#ffaa00", height: 60)
+```
+
+### lerp 行き来（ピンポン）
+
+```
+timer = clock()
+sine = sine(timer, freq: 0.3, amplitude: 0.5, offset: 0.5)
+lerp = lerp(a: 100, b: 700, t: sine)
+
+render point(x: lerp, y: 250, color: "#ff6688", trail: 0.1)
+```

--- a/editor/index.html
+++ b/editor/index.html
@@ -99,6 +99,33 @@
       text-transform: uppercase;
       letter-spacing: 0.5px;
       flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 0;
+    }
+
+    .mode-tab {
+      padding: 4px 12px;
+      background: transparent;
+      color: #666;
+      border: none;
+      border-radius: 4px 4px 0 0;
+      font-size: 12px;
+      font-family: inherit;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      cursor: pointer;
+      transition: color 0.15s, background 0.15s;
+    }
+
+    .mode-tab:hover {
+      color: #aaa;
+      background: #1a1a1a;
+    }
+
+    .mode-tab.active {
+      color: #fff;
+      background: #1a1a1a;
     }
 
     #editorPane {
@@ -106,7 +133,7 @@
       overflow: hidden;
     }
 
-    #editor {
+    .editor-textarea {
       width: 100%;
       height: 100%;
       padding: 12px;
@@ -118,6 +145,11 @@
       line-height: 1.5;
       resize: none;
       outline: none;
+      display: none;
+    }
+
+    .editor-textarea.active {
+      display: block;
     }
 
     #rightPane {
@@ -176,23 +208,23 @@
     }
 
     /* Scrollbar styling */
-    #editor::-webkit-scrollbar,
+    .editor-textarea::-webkit-scrollbar,
     #values::-webkit-scrollbar {
       width: 8px;
     }
 
-    #editor::-webkit-scrollbar-track,
+    .editor-textarea::-webkit-scrollbar-track,
     #values::-webkit-scrollbar-track {
       background: #2a2a2a;
     }
 
-    #editor::-webkit-scrollbar-thumb,
+    .editor-textarea::-webkit-scrollbar-thumb,
     #values::-webkit-scrollbar-thumb {
       background: #444;
       border-radius: 4px;
     }
 
-    #editor::-webkit-scrollbar-thumb:hover,
+    .editor-textarea::-webkit-scrollbar-thumb:hover,
     #values::-webkit-scrollbar-thumb:hover {
       background: #555;
     }
@@ -232,8 +264,12 @@
 
   <div id="container">
     <div class="pane" id="editorPane">
-      <div class="pane-label">JSON Graph</div>
-      <textarea id="editor" spellcheck="false"></textarea>
+      <div class="pane-label">
+        <button class="mode-tab active" data-mode="json">JSON</button>
+        <button class="mode-tab" data-mode="dsl">DSL</button>
+      </div>
+      <textarea id="editorJson" class="editor-textarea active" spellcheck="false"></textarea>
+      <textarea id="editorDsl"  class="editor-textarea"        spellcheck="false"></textarea>
     </div>
 
     <div class="pane" id="rightPane">
@@ -252,6 +288,7 @@
 
   <script type="module">
     import { Loom } from "../src/loom.js";
+    import { parseDSL } from "../src/loom-dsl.js";
     import { presets } from "./presets.js";
 
     // State
@@ -259,19 +296,49 @@
     let currentRender = null;
     let debounceTimer = null;
     const DEBOUNCE_MS = 250;
-    const STORAGE_KEY = "loom-editor-text";
+    const STORAGE_KEY_JSON = "loom-editor-text-json";
+    const STORAGE_KEY_DSL  = "loom-editor-text-dsl";
+    const STORAGE_KEY_MODE = "loom-editor-mode";
+
+    let currentMode = localStorage.getItem(STORAGE_KEY_MODE) || "json";
 
     // UI Elements
-    const editor = document.getElementById("editor");
+    const editorJson  = document.getElementById("editorJson");
+    const editorDsl   = document.getElementById("editorDsl");
     const presetSelect = document.getElementById("presetSelect");
-    const statusEl = document.getElementById("status");
-    const canvas = document.getElementById("preview");
-    const ctx = canvas.getContext("2d");
-    const valuesEl = document.getElementById("values");
+    const statusEl    = document.getElementById("status");
+    const canvas      = document.getElementById("preview");
+    const ctx         = canvas.getContext("2d");
+    const valuesEl    = document.getElementById("values");
+    const modeTabs    = document.querySelectorAll(".mode-tab");
+
+    function activeEditor() {
+      return currentMode === "json" ? editorJson : editorDsl;
+    }
+
+    function setMode(mode) {
+      currentMode = mode;
+      localStorage.setItem(STORAGE_KEY_MODE, mode);
+      modeTabs.forEach(tab => {
+        tab.classList.toggle("active", tab.dataset.mode === mode);
+      });
+      editorJson.classList.toggle("active", mode === "json");
+      editorDsl.classList.toggle("active",  mode === "dsl");
+      debouncedLoad();
+    }
+
+    modeTabs.forEach(tab => {
+      tab.addEventListener("click", () => setMode(tab.dataset.mode));
+    });
 
     // Initialize preset dropdown
     function initPresets() {
       presetSelect.innerHTML = "";
+      const blank = document.createElement("option");
+      blank.value = "";
+      blank.textContent = "— preset —";
+      presetSelect.appendChild(blank);
+
       Object.entries(presets).forEach(([key, preset]) => {
         const option = document.createElement("option");
         option.value = key;
@@ -280,53 +347,69 @@
       });
     }
 
-    // Handle preset selection
     presetSelect.addEventListener("change", (e) => {
       const key = e.target.value;
+      if (!key) return;
       const preset = presets[key];
-      if (preset) {
-        editor.value = JSON.stringify(preset.graph, null, 2);
-        localStorage.setItem(STORAGE_KEY, editor.value);
-        debouncedLoad();
+      if (!preset) return;
+
+      if (currentMode === "json") {
+        const text = JSON.stringify(preset.graph, null, 2);
+        editorJson.value = text;
+        localStorage.setItem(STORAGE_KEY_JSON, text);
+      } else {
+        const text = preset.dsl || "";
+        editorDsl.value = text;
+        localStorage.setItem(STORAGE_KEY_DSL, text);
       }
+      debouncedLoad();
     });
 
-    // Handle Tab key in textarea
-    editor.addEventListener("keydown", (e) => {
+    function handleKeydown(e) {
       if (e.key === "Tab") {
         e.preventDefault();
-        const start = editor.selectionStart;
-        const end = editor.selectionEnd;
-        const value = editor.value;
-        editor.value = value.substring(0, start) + "  " + value.substring(end);
-        editor.selectionStart = editor.selectionEnd = start + 2;
+        const ta = e.target;
+        const start = ta.selectionStart;
+        const end   = ta.selectionEnd;
+        ta.value = ta.value.substring(0, start) + "  " + ta.value.substring(end);
+        ta.selectionStart = ta.selectionEnd = start + 2;
       }
+    }
+
+    editorJson.addEventListener("keydown", handleKeydown);
+    editorDsl.addEventListener("keydown", handleKeydown);
+
+    editorJson.addEventListener("input", () => {
+      localStorage.setItem(STORAGE_KEY_JSON, editorJson.value);
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(debouncedLoad, DEBOUNCE_MS);
     });
 
-    // Handle editor changes with debounce
-    editor.addEventListener("input", () => {
+    editorDsl.addEventListener("input", () => {
+      localStorage.setItem(STORAGE_KEY_DSL, editorDsl.value);
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(debouncedLoad, DEBOUNCE_MS);
     });
 
     function debouncedLoad() {
       try {
-        const graphText = editor.value.trim();
-        if (!graphText) {
-          setStatus("error", "JSON: Empty graph");
-          return;
+        let graphForLoom, renderConfig;
+
+        if (currentMode === "json") {
+          const text = editorJson.value.trim();
+          if (!text) { setStatus("error", "JSON: Empty graph"); return; }
+          const parsed = JSON.parse(text);
+          renderConfig = parsed.render;
+          graphForLoom = { ...parsed };
+          delete graphForLoom.render;
+        } else {
+          const text = editorDsl.value.trim();
+          if (!text) { setStatus("error", "DSL: Empty"); return; }
+          const parsed = parseDSL(text);
+          renderConfig = parsed.render;
+          graphForLoom = { nodes: parsed.nodes, edges: parsed.edges };
         }
 
-        const parsed = JSON.parse(graphText);
-
-        // Extract render config if present
-        const renderConfig = parsed.render;
-
-        // Create a copy without render field for Loom
-        const graphForLoom = { ...parsed };
-        delete graphForLoom.render;
-
-        // Load the graph
         if (!engine) {
           engine = new Loom(graphForLoom);
           engine.start();
@@ -334,14 +417,12 @@
           engine.load(graphForLoom);
         }
 
-        // Update render config
         currentRender = renderConfig || null;
-
-        // Save to localStorage
-        localStorage.setItem(STORAGE_KEY, editor.value);
         setStatus("running", "running");
       } catch (e) {
-        if (e.name === "SyntaxError") {
+        if (e.name === "LoomDSLError") {
+          setStatus("error", `DSL [${e.line}:${e.column}] ${e.message}`);
+        } else if (e.name === "SyntaxError") {
           setStatus("error", `JSON: ${e.message}`);
         } else if (e.code) {
           setStatus("error", `${e.code}: ${e.message}`);
@@ -357,12 +438,8 @@
     }
 
     function formatValue(val) {
-      if (val === null || val === undefined) {
-        return "null";
-      }
-      if (typeof val === "number") {
-        return val.toFixed(3);
-      }
+      if (val === null || val === undefined) return "null";
+      if (typeof val === "number") return val.toFixed(3);
       if (typeof val === "object") {
         if (Array.isArray(val)) {
           return "[" + val.map(v => typeof v === "number" ? v.toFixed(3) : v).join(", ") + "]";
@@ -378,87 +455,57 @@
     }
 
     function resolveValue(ref) {
-      // If already a number, return it directly
-      if (typeof ref === "number") {
-        return ref;
-      }
-
-      if (ref === null || ref === undefined) {
-        return null;
-      }
-
+      if (typeof ref === "number") return ref;
+      if (ref === null || ref === undefined) return null;
       if (!engine) return null;
-
-      // Check if it's a numeric literal string
       const numVal = parseFloat(ref);
-      if (!isNaN(numVal) && String(ref).trim() === String(numVal)) {
-        return numVal;
-      }
-
+      if (!isNaN(numVal) && String(ref).trim() === String(numVal)) return numVal;
       return engine.getValue(ref);
     }
 
     function tick() {
-      // Update canvas
       if (engine && canvas && ctx) {
         if (currentRender) {
-          // Apply trail effect if specified
           const trail = currentRender.trail !== undefined ? currentRender.trail : 0.1;
           if (trail > 0) {
             ctx.fillStyle = `rgba(0, 0, 0, ${trail})`;
             ctx.fillRect(0, 0, canvas.width, canvas.height);
           }
 
-          // Draw based on render type
           if (currentRender.type === "point") {
             const x = resolveValue(currentRender.x);
             const y = resolveValue(currentRender.y);
             const color = currentRender.color || "#00ff00";
-
             if (x !== null && y !== null && typeof x === "number" && typeof y === "number") {
               ctx.fillStyle = color;
               ctx.beginPath();
               ctx.arc(x, y, 4, 0, Math.PI * 2);
               ctx.fill();
             } else {
-              // Fallback to center
               ctx.fillStyle = color;
               ctx.beginPath();
               ctx.arc(canvas.width / 2, canvas.height / 2, 4, 0, Math.PI * 2);
               ctx.fill();
             }
           } else if (currentRender.type === "bar") {
-            const width = resolveValue(currentRender.width);
-            const color = currentRender.color || "#00ccff";
+            const width  = resolveValue(currentRender.width);
+            const color  = currentRender.color || "#00ccff";
             const height = currentRender.height !== undefined ? currentRender.height : 40;
-            const y = currentRender.y !== undefined ? resolveValue(currentRender.y) : (canvas.height - height) / 2;
-
+            const y      = currentRender.y !== undefined ? resolveValue(currentRender.y) : (canvas.height - height) / 2;
             if (width !== null && typeof width === "number" && y !== null && typeof y === "number") {
               ctx.fillStyle = color;
               ctx.fillRect(0, y, width, height);
             }
           }
         } else {
-          // Clear canvas with semi-transparent black
           ctx.fillStyle = "rgba(0, 0, 0, 0.1)";
           ctx.fillRect(0, 0, canvas.width, canvas.height);
         }
       }
 
-      // Update values table
       if (engine && engine._currentGraph) {
         const lines = [];
         for (const node of engine._currentGraph.nodes) {
-          const nodeType = engine._currentGraph.nodes.find(n => n.id === node.id);
-          if (!nodeType) continue;
-
-          // Get node type to get output ports
-          const graph = engine._currentGraph;
-          const nodeTypeDef = graph.nodes.find(n => n.id === node.id);
-          if (!nodeTypeDef) continue;
-
-          // We need access to NODE_TYPES but it's internal to loom.js
-          // Instead, iterate through what values exist
           const keys = Array.from(engine._values.keys());
           for (const key of keys) {
             if (key.startsWith(node.id + ".")) {
@@ -468,45 +515,36 @@
             }
           }
         }
-
         valuesEl.innerHTML = lines.join("");
       }
 
       requestAnimationFrame(tick);
     }
 
-    // Initialize
     function init() {
       initPresets();
 
-      // Load from localStorage or use default preset
-      let savedText = localStorage.getItem(STORAGE_KEY);
-      if (!savedText) {
-        // Use first preset as default
-        const firstKey = Object.keys(presets)[0];
-        savedText = JSON.stringify(presets[firstKey].graph, null, 2);
-        presetSelect.value = firstKey;
+      // Restore saved content for both editors
+      const savedJson = localStorage.getItem(STORAGE_KEY_JSON);
+      const savedDsl  = localStorage.getItem(STORAGE_KEY_DSL);
+
+      if (savedJson) {
+        editorJson.value = savedJson;
       } else {
-        // Try to detect which preset is loaded
-        try {
-          const parsed = JSON.parse(savedText);
-          for (const [key, preset] of Object.entries(presets)) {
-            if (JSON.stringify(parsed) === JSON.stringify(preset.graph)) {
-              presetSelect.value = key;
-              break;
-            }
-          }
-        } catch (e) {
-          // Ignore
-        }
+        const firstKey = Object.keys(presets)[0];
+        editorJson.value = JSON.stringify(presets[firstKey].graph, null, 2);
       }
 
-      editor.value = savedText;
+      if (savedDsl) {
+        editorDsl.value = savedDsl;
+      } else {
+        const firstKey = Object.keys(presets)[0];
+        editorDsl.value = presets[firstKey].dsl || "";
+      }
 
-      // Initial load
-      debouncedLoad();
+      // Apply saved mode
+      setMode(currentMode);
 
-      // Start animation loop
       tick();
     }
 

--- a/editor/presets.js
+++ b/editor/presets.js
@@ -22,7 +22,15 @@ export const presets = {
         color: "#00ff00",
         trail: 0.05
       }
-    }
+    },
+    dsl: `timer = clock()
+sineX = sine(timer, freq: 0.3)
+cosineY = cosine(timer, freq: 0.5)
+mapX = map(sineX, inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+mapY = map(cosineY, inMin: -1, inMax: 1, outMin: 50, outMax: 450)
+
+render point(x: mapX, y: mapY, color: "#00ff00", trail: 0.05)
+`
   },
 
   circular: {
@@ -48,7 +56,15 @@ export const presets = {
         color: "#ff00ff",
         trail: 0.05
       }
-    }
+    },
+    dsl: `timer = clock()
+sineX = sine(timer, freq: 0.5)
+cosineY = cosine(timer, freq: 0.5)
+mapX = map(sineX, inMin: -1, inMax: 1, outMin: 100, outMax: 700)
+mapY = map(cosineY, inMin: -1, inMax: 1, outMin: 50, outMax: 450)
+
+render point(x: mapX, y: mapY, color: "#ff00ff", trail: 0.05)
+`
   },
 
   "clamp-map": {
@@ -72,7 +88,14 @@ export const presets = {
         color: "#00ccff",
         height: 40
       }
-    }
+    },
+    dsl: `timer = clock()
+freqMap = map(timer, inMin: 0, inMax: 30, outMin: 0.1, outMax: 5, clamp: true)
+wave = sine(timer, freq: freqMap)
+widthMap = map(wave, inMin: -1, inMax: 1, outMin: 50, outMax: 750)
+
+render bar(width: widthMap, color: "#00ccff", height: 40)
+`
   },
 
   "smoothstep-fade": {
@@ -95,7 +118,14 @@ export const presets = {
         color: "#ffaa00",
         height: 60
       }
-    }
+    },
+    dsl: `timer = clock()
+mod = mod(timer, b: 4)
+smooth = smoothstep(mod, edge0: 1, edge1: 3)
+widthMap = map(smooth, inMin: 0, inMax: 1, outMin: 50, outMax: 600)
+
+render bar(width: widthMap, color: "#ffaa00", height: 60)
+`
   },
 
   "lerp-ping-pong": {
@@ -117,6 +147,12 @@ export const presets = {
         color: "#ff6688",
         trail: 0.1
       }
-    }
+    },
+    dsl: `timer = clock()
+sine = sine(timer, freq: 0.3, amplitude: 0.5, offset: 0.5)
+lerp = lerp(a: 100, b: 700, t: sine)
+
+render point(x: lerp, y: 250, color: "#ff6688", trail: 0.1)
+`
   }
 };

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -1,0 +1,444 @@
+// Loom DSL パーサ – 依存ゼロの ESM モジュール
+
+import { NODE_TYPES } from './loom.js';
+
+export class LoomDSLError extends Error {
+  constructor(message, line, column, code) {
+    super(message);
+    this.name = 'LoomDSLError';
+    this.line = line;
+    this.column = column;
+    this.code = code;
+  }
+}
+
+function defaultOutputPort(nodeTypeName) {
+  const def = NODE_TYPES[nodeTypeName];
+  if (!def || !def.outputs || def.outputs.length === 0) return 'out';
+  if (def.outputs.length === 1) return def.outputs[0].name;
+  const found = def.outputs.find(o => o.name === 'out');
+  return found ? 'out' : def.outputs[0].name;
+}
+
+// ─── Tokenizer ────────────────────────────────────────────────────────────────
+
+const TT = {
+  IDENT: 'IDENT', NUMBER: 'NUMBER', STRING: 'STRING', BOOL: 'BOOL',
+  ASSIGN: 'ASSIGN', COLON: 'COLON', COMMA: 'COMMA',
+  LPAREN: 'LPAREN', RPAREN: 'RPAREN', PIPE: 'PIPE',
+  NEWLINE: 'NEWLINE', EOF: 'EOF',
+};
+
+function tokenize(src) {
+  const tokens = [];
+  let pos = 0, line = 1, lineStart = 0;
+
+  function col() { return pos - lineStart + 1; }
+  function peek() { return src[pos]; }
+  function advance() {
+    const c = src[pos++];
+    if (c === '\n') { line++; lineStart = pos; }
+    return c;
+  }
+  function dslErr(msg) {
+    throw new LoomDSLError(msg, line, col(), 'UNEXPECTED_TOKEN');
+  }
+
+  while (pos < src.length) {
+    const sl = line, sc = col();
+    const ch = peek();
+
+    if (ch === '#') { while (pos < src.length && peek() !== '\n') pos++; continue; }
+    if (ch === '\n') { advance(); tokens.push({ type: TT.NEWLINE, line: sl, col: sc }); continue; }
+    if (ch === ' ' || ch === '\t' || ch === '\r') { pos++; continue; }
+
+    // number (positive – unary minus not supported at expression level, handled inline)
+    if (/\d/.test(ch)) {
+      let num = '';
+      while (pos < src.length && /[\d.]/.test(peek())) num += advance();
+      if (pos < src.length && /[eE]/.test(peek())) {
+        num += advance();
+        if (pos < src.length && /[+\-]/.test(peek())) num += advance();
+        while (pos < src.length && /\d/.test(peek())) num += advance();
+      }
+      tokens.push({ type: TT.NUMBER, value: parseFloat(num), line: sl, col: sc });
+      continue;
+    }
+
+    // negative number
+    if (ch === '-' && pos + 1 < src.length && /\d/.test(src[pos + 1])) {
+      advance();
+      let num = '-';
+      while (pos < src.length && /[\d.]/.test(peek())) num += advance();
+      if (pos < src.length && /[eE]/.test(peek())) {
+        num += advance();
+        if (pos < src.length && /[+\-]/.test(peek())) num += advance();
+        while (pos < src.length && /\d/.test(peek())) num += advance();
+      }
+      tokens.push({ type: TT.NUMBER, value: parseFloat(num), line: sl, col: sc });
+      continue;
+    }
+
+    // string
+    if (ch === '"') {
+      advance();
+      let str = '';
+      while (pos < src.length && peek() !== '"') {
+        if (peek() === '\n') dslErr('Unterminated string literal');
+        str += advance();
+      }
+      if (pos >= src.length) dslErr('Unterminated string literal');
+      advance();
+      tokens.push({ type: TT.STRING, value: str, line: sl, col: sc });
+      continue;
+    }
+
+    // identifier / keyword
+    if (/[a-zA-Z_]/.test(ch)) {
+      let id = '';
+      while (pos < src.length && /[a-zA-Z0-9_]/.test(peek())) id += advance();
+      if (id === 'true')  { tokens.push({ type: TT.BOOL, value: true,  line: sl, col: sc }); continue; }
+      if (id === 'false') { tokens.push({ type: TT.BOOL, value: false, line: sl, col: sc }); continue; }
+      tokens.push({ type: TT.IDENT, value: id, line: sl, col: sc });
+      continue;
+    }
+
+    if (ch === '=') { advance(); tokens.push({ type: TT.ASSIGN, line: sl, col: sc }); continue; }
+    if (ch === ':') { advance(); tokens.push({ type: TT.COLON,  line: sl, col: sc }); continue; }
+    if (ch === ',') { advance(); tokens.push({ type: TT.COMMA,  line: sl, col: sc }); continue; }
+    if (ch === '(') { advance(); tokens.push({ type: TT.LPAREN, line: sl, col: sc }); continue; }
+    if (ch === ')') { advance(); tokens.push({ type: TT.RPAREN, line: sl, col: sc }); continue; }
+    if (ch === '|') {
+      advance();
+      if (pos >= src.length || peek() !== '>') dslErr("Expected '>' after '|'");
+      advance();
+      tokens.push({ type: TT.PIPE, line: sl, col: sc });
+      continue;
+    }
+
+    dslErr(`Unexpected character: ${ch}`);
+  }
+  tokens.push({ type: TT.EOF, line, col: col() });
+  return tokens;
+}
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+function parse(tokens) {
+  let pos = 0;
+
+  function peek(off = 0) { return tokens[Math.min(pos + off, tokens.length - 1)]; }
+  function consume() { return tokens[pos++]; }
+  function pErr(msg, code, tok) {
+    const t = tok || peek();
+    throw new LoomDSLError(msg, t.line, t.col, code || 'UNEXPECTED_TOKEN');
+  }
+  function expect(type) {
+    const t = peek();
+    if (t.type !== type) pErr(`Expected ${type}, got ${t.type}`, 'UNEXPECTED_TOKEN', t);
+    return consume();
+  }
+  function skipNewlines() { while (peek().type === TT.NEWLINE) consume(); }
+
+  const stmts = [];
+  while (true) {
+    skipNewlines();
+    if (peek().type === TT.EOF) break;
+    stmts.push(parseStatement());
+  }
+  return stmts;
+
+  function parseStatement() {
+    const t = peek();
+
+    // render statement
+    if (t.type === TT.IDENT && t.value === 'render') {
+      consume();
+      const call = parseCall();
+      expectEnd();
+      return { type: 'render', call };
+    }
+
+    // assignment: IDENT = expr
+    if (t.type === TT.IDENT && peek(1).type === TT.ASSIGN) {
+      const name = consume().value;
+      consume(); // =
+      const expr = parsePipe();
+      expectEnd();
+      return { type: 'assign', name, expr };
+    }
+
+    pErr(`Expected assignment or render statement`, 'UNEXPECTED_TOKEN', t);
+  }
+
+  function expectEnd() {
+    if (peek().type === TT.NEWLINE) { consume(); return; }
+    if (peek().type === TT.EOF) return;
+    pErr(`Expected newline or EOF, got ${peek().type}`);
+  }
+
+  function parsePipe() {
+    let expr = parseAtom();
+
+    while (true) {
+      if (peek().type === TT.PIPE) {
+        consume();
+        skipNewlines();
+        expr = { type: 'pipe', left: expr, call: parseCall() };
+        continue;
+      }
+
+      // continuation: single newline followed by |>
+      if (peek().type === TT.NEWLINE) {
+        let ahead = pos + 1;
+        // skip over consecutive NEWLINEs
+        let extraNewlines = 0;
+        while (ahead < tokens.length && tokens[ahead].type === TT.NEWLINE) {
+          extraNewlines++;
+          ahead++;
+        }
+        if (extraNewlines > 0) break; // blank line → chain ends
+        if (tokens[ahead] && tokens[ahead].type === TT.PIPE) {
+          consume(); // consume NEWLINE
+          consume(); // consume PIPE
+          skipNewlines();
+          expr = { type: 'pipe', left: expr, call: parseCall() };
+          continue;
+        }
+      }
+
+      break;
+    }
+
+    return expr;
+  }
+
+  function parseAtom() {
+    const t = peek();
+    if (t.type === TT.NUMBER) { consume(); return { type: 'number', value: t.value, line: t.line, col: t.col }; }
+    if (t.type === TT.STRING) { consume(); return { type: 'string', value: t.value, line: t.line, col: t.col }; }
+    if (t.type === TT.BOOL)   { consume(); return { type: 'bool',   value: t.value, line: t.line, col: t.col }; }
+    if (t.type === TT.IDENT) {
+      if (peek(1).type === TT.LPAREN) return parseCall();
+      consume();
+      return { type: 'ident', name: t.value, line: t.line, col: t.col };
+    }
+    pErr(`Unexpected token: ${t.type}${t.value !== undefined ? ` (${t.value})` : ''}`, 'UNEXPECTED_TOKEN', t);
+  }
+
+  function parseCall() {
+    const nt = peek();
+    if (nt.type !== TT.IDENT) pErr('Expected function name', 'UNEXPECTED_TOKEN', nt);
+    const name = consume().value;
+    expect(TT.LPAREN);
+    skipNewlines();
+
+    const args = [];
+    while (peek().type !== TT.RPAREN && peek().type !== TT.EOF) {
+      skipNewlines();
+      if (peek().type === TT.RPAREN) break;
+
+      if (peek().type === TT.IDENT && peek(1).type === TT.COLON) {
+        const argName = consume().value;
+        consume(); // :
+        skipNewlines();
+        args.push({ named: true, name: argName, value: parseAtom() });
+      } else {
+        args.push({ named: false, value: parseAtom() });
+      }
+
+      skipNewlines();
+      if (peek().type === TT.COMMA) { consume(); skipNewlines(); }
+    }
+
+    expect(TT.RPAREN);
+    return { type: 'call', name, args, line: nt.line, col: nt.col };
+  }
+}
+
+// ─── Graph Builder ────────────────────────────────────────────────────────────
+
+function buildGraph(stmts) {
+  const nodes = [];
+  const edges = [];
+  let renderConfig = null;
+  let anonCounter = 0;
+  const scope = {}; // identifier → nodeId
+
+  function anonId() { return `_anon_${++anonCounter}`; }
+
+  function gErr(msg, code, line, col) {
+    throw new LoomDSLError(msg, line || 0, col || 0, code || 'UNKNOWN_NODE_TYPE');
+  }
+
+  function resolveIdent(name, line, col) {
+    if (!(name in scope)) {
+      throw new LoomDSLError(`Undefined identifier: ${name}`, line, col, 'UNDEFINED_IDENTIFIER');
+    }
+    const nodeId = scope[name];
+    const node = nodes.find(n => n.id === nodeId);
+    return `${nodeId}.${defaultOutputPort(node.type)}`;
+  }
+
+  // Build a node from a call AST node.
+  // pipeFrom: string ref "nodeId.portName" to wire as the first input (from |>)
+  // resultId: desired node ID (for top-level assignments); null for anon
+  function buildNode(call, resultId, pipeFrom) {
+    const fnName = call.name;
+    const typeDef = NODE_TYPES[fnName];
+    if (!typeDef) {
+      throw new LoomDSLError(`Unknown node type: ${fnName}`, call.line, call.col, 'UNKNOWN_NODE_TYPE');
+    }
+
+    const id = resultId || anonId();
+    const nodeObj = { id, type: fnName };
+    nodes.push(nodeObj);
+
+    const inputNames = typeDef.inputs.map(i => i.name);
+    const isComm = typeDef.commutative === true;
+
+    const positional = call.args.filter(a => !a.named);
+    const named      = call.args.filter(a =>  a.named);
+
+    // Validation ──────────────────────────────────────────────────────────────
+    // Commutative: explicit args must be ALL positional or ALL named (no mix)
+    if (isComm && positional.length > 0 && named.length > 0) {
+      throw new LoomDSLError(
+        `Node '${fnName}' is commutative: arguments must be all positional or all named`,
+        call.line, call.col, 'MISSING_ARGUMENT_NAME'
+      );
+    }
+
+    // Non-commutative (default rule): at most the first explicit arg may be positional;
+    // if pipeFrom is set, that already fills arg[0], so no explicit positional allowed.
+    if (!isComm) {
+      const allowedPositional = pipeFrom ? 0 : 1;
+      if (positional.length > allowedPositional) {
+        const bad = positional[allowedPositional].value;
+        throw new LoomDSLError(
+          `Argument at position ${allowedPositional + (pipeFrom ? 1 : 2)} for '${fnName}' requires a name`,
+          bad.line || call.line, bad.col || call.col, 'MISSING_ARGUMENT_NAME'
+        );
+      }
+    }
+    // ─────────────────────────────────────────────────────────────────────────
+
+    let inputIdx = 0;
+
+    function wire(expr, portName) {
+      if (expr.type === 'ident') {
+        edges.push({ from: resolveIdent(expr.name, expr.line, expr.col), to: `${id}.${portName}` });
+      } else if (expr.type === 'call') {
+        const innerId = buildExpr(expr, null, null);
+        const innerNode = nodes.find(n => n.id === innerId);
+        edges.push({ from: `${innerId}.${defaultOutputPort(innerNode.type)}`, to: `${id}.${portName}` });
+      } else {
+        if (!nodeObj.params) nodeObj.params = {};
+        nodeObj.params[portName] = expr.value;
+      }
+    }
+
+    // pipeFrom → first input port
+    if (pipeFrom) {
+      const portName = inputNames[inputIdx++];
+      if (!portName) gErr(`Too many arguments for '${fnName}'`, 'UNEXPECTED_TOKEN', call.line, call.col);
+      edges.push({ from: pipeFrom, to: `${id}.${portName}` });
+    }
+
+    // positional explicit args
+    for (const arg of positional) {
+      const portName = inputNames[inputIdx++];
+      if (!portName) gErr(`Too many positional arguments for '${fnName}'`, 'UNEXPECTED_TOKEN', call.line, call.col);
+      wire(arg.value, portName);
+    }
+
+    // named explicit args
+    for (const arg of named) {
+      wire(arg.value, arg.name);
+    }
+
+    return id;
+  }
+
+  // Recursively build an expression, returning the resulting nodeId.
+  function buildExpr(expr, resultId, pipeFrom) {
+    if (expr.type === 'call') {
+      return buildNode(expr, resultId, pipeFrom);
+    }
+    if (expr.type === 'pipe') {
+      // Recursively evaluate the left side
+      const leftId = buildExpr(expr.left, null, null);
+      const leftNode = nodes.find(n => n.id === leftId);
+      const leftRef = `${leftId}.${defaultOutputPort(leftNode.type)}`;
+      return buildNode(expr.call, resultId, leftRef);
+    }
+    if (expr.type === 'ident') {
+      if (!(expr.name in scope)) {
+        throw new LoomDSLError(`Undefined identifier: ${expr.name}`, expr.line, expr.col, 'UNDEFINED_IDENTIFIER');
+      }
+      return scope[expr.name];
+    }
+    throw new LoomDSLError(`Cannot use literal as expression`, expr.line || 0, expr.col || 0, 'UNEXPECTED_TOKEN');
+  }
+
+  // render call → config object
+  function buildRenderConfig(call) {
+    const fnName = call.name;
+    if (fnName !== 'point' && fnName !== 'bar') {
+      throw new LoomDSLError(`Unknown render function: ${fnName}`, call.line, call.col, 'UNKNOWN_NODE_TYPE');
+    }
+
+    const named = {};
+    for (const arg of call.args) {
+      if (!arg.named) {
+        throw new LoomDSLError(`render arguments must be named`, call.line, call.col, 'MISSING_ARGUMENT_NAME');
+      }
+      named[arg.name] = arg.value;
+    }
+
+    function rv(expr) {
+      if (!expr) return undefined;
+      if (expr.type === 'number') return expr.value;
+      if (expr.type === 'string') return expr.value;
+      if (expr.type === 'ident')  return resolveIdent(expr.name, expr.line, expr.col);
+      throw new LoomDSLError(`Invalid render argument`, expr.line, expr.col, 'UNEXPECTED_TOKEN');
+    }
+
+    if (fnName === 'point') {
+      const cfg = { type: 'point' };
+      if (named.x) cfg.x = rv(named.x);
+      if (named.y) cfg.y = rv(named.y);
+      cfg.color = named.color ? named.color.value : '#00ff00';
+      cfg.trail = named.trail !== undefined ? named.trail.value : 0.1;
+      return cfg;
+    } else {
+      const cfg = { type: 'bar' };
+      if (named.width) cfg.width = rv(named.width);
+      cfg.color  = named.color  ? named.color.value  : '#00ccff';
+      cfg.height = named.height !== undefined ? named.height.value : 40;
+      if (named.y !== undefined) cfg.y = rv(named.y);
+      return cfg;
+    }
+  }
+
+  for (const stmt of stmts) {
+    if (stmt.type === 'render') {
+      renderConfig = buildRenderConfig(stmt.call);
+    } else if (stmt.type === 'assign') {
+      const nodeId = buildExpr(stmt.expr, stmt.name, null);
+      scope[stmt.name] = nodeId;
+    }
+  }
+
+  const result = { nodes, edges };
+  if (renderConfig) result.render = renderConfig;
+  return result;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function parseDSL(text) {
+  const tokens = tokenize(text);
+  const ast = parse(tokens);
+  return buildGraph(ast);
+}

--- a/src/loom.js
+++ b/src/loom.js
@@ -342,7 +342,7 @@ class RestrictedDSLEvaluator {
 }
 
 // ノード型レジストリ
-const NODE_TYPES = {
+export const NODE_TYPES = {
   // Phase 0 ノード
   clock: {
     category: 'source',
@@ -385,6 +385,7 @@ const NODE_TYPES = {
   },
   add: {
     category: 'transform',
+    commutative: true,
     inputs: [
       { name: 'a', type: 'number', default: 0, kind: 'behavior' },
       { name: 'b', type: 'number', default: 0, kind: 'behavior' }
@@ -398,6 +399,7 @@ const NODE_TYPES = {
   },
   multiply: {
     category: 'transform',
+    commutative: true,
     inputs: [
       { name: 'a', type: 'number', default: 1, kind: 'behavior' },
       { name: 'b', type: 'number', default: 1, kind: 'behavior' }

--- a/test/loom-dsl.test.html
+++ b/test/loom-dsl.test.html
@@ -231,6 +231,7 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
     // ── Run tests ─────────────────────────────────────────────────────────────
     const el = document.getElementById("results");
     let pass = 0, fail = 0;
+    const failures = [];
 
     for (const { name, fn } of results) {
       const div = document.createElement("div");
@@ -244,6 +245,7 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
         div.classList.add("test-fail");
         div.textContent = `❌ ${name}: ${e.message}`;
         fail++;
+        failures.push({ name, message: e.message });
       }
       el.appendChild(div);
     }
@@ -253,7 +255,7 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
     summary.textContent = `${pass} passed, ${fail} failed`;
     el.appendChild(summary);
 
-    window.__loomDSLTestResults = { pass, fail };
+    window.__loomTestResults = { pass, fail, failures };
   </script>
 </body>
 </html>

--- a/test/loom-dsl.test.html
+++ b/test/loom-dsl.test.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Loom DSL テスト</title>
+  <style>
+    body {
+      font-family: monospace;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    h1 { color: #333; }
+    h2 { color: #666; margin-top: 30px; font-size: 18px; }
+    #results { margin: 20px 0; }
+    .test-result { padding: 8px 12px; margin: 4px 0; border-radius: 4px; font-size: 14px; }
+    .test-pass { background: #e8f5e9; color: #2e7d32; }
+    .test-fail { background: #ffebee; color: #c62828; }
+    .summary { margin-top: 20px; padding: 16px; border-radius: 4px; font-size: 18px; font-weight: bold; }
+    .summary-pass { background: #c8e6c9; color: #1b5e20; }
+    .summary-fail { background: #ffcdd2; color: #b71c1c; }
+  </style>
+</head>
+<body>
+  <h1>Loom DSL テスト</h1>
+  <div id="results"></div>
+  <script type="module">
+    import { parseDSL, LoomDSLError } from "../src/loom-dsl.js";
+    import { presets } from "../editor/presets.js";
+
+    const results = [];
+    function test(name, fn) { results.push({ name, fn }); }
+
+    function assert(cond, msg) {
+      if (!cond) throw new Error(msg || "assertion failed");
+    }
+    function assertEqual(a, b, msg) {
+      const av = JSON.stringify(a), bv = JSON.stringify(b);
+      if (av !== bv) throw new Error(msg || `expected ${bv}, got ${av}`);
+    }
+    function assertThrows(fn, code) {
+      try { fn(); }
+      catch (e) {
+        if (e.code === code) return;
+        throw new Error(`expected LoomDSLError code ${code}, got ${e.code || e.message}`);
+      }
+      throw new Error(`expected throw with code ${code}, but no error thrown`);
+    }
+    function hasEdge(edges, from, to) {
+      return edges.some(e => e.from === from && e.to === to);
+    }
+    function hasNode(nodes, id, type) {
+      return nodes.some(n => n.id === id && n.type === type);
+    }
+
+    // ── Test 1: simple assignment ─────────────────────────────────────────────
+    test("1. 単純な代入: t = clock()", () => {
+      const g = parseDSL("t = clock()");
+      assert(hasNode(g.nodes, "t", "clock"), "clock node exists");
+      assertEqual(g.edges, []);
+    });
+
+    // ── Test 2: named argument ────────────────────────────────────────────────
+    test("2. 名前付き引数: sine(t, freq: 0.3)", () => {
+      const g = parseDSL(`t = clock()\nwave = sine(t, freq: 0.3)`);
+      assert(hasNode(g.nodes, "wave", "sine"), "sine node");
+      assert(hasEdge(g.edges, "t.t", "wave.t"), "t → wave.t edge");
+      assertEqual(g.nodes.find(n => n.id === "wave").params, { freq: 0.3 });
+    });
+
+    // ── Test 3: single pipe ───────────────────────────────────────────────────
+    test("3. パイプ単一: t |> sine(freq: 0.3)", () => {
+      const g = parseDSL(`t = clock()\nwave = t |> sine(freq: 0.3)`);
+      assert(hasNode(g.nodes, "wave", "sine"), "sine node");
+      assert(hasEdge(g.edges, "t.t", "wave.t"), "t → wave.t edge");
+      assertEqual(g.nodes.find(n => n.id === "wave").params, { freq: 0.3 });
+    });
+
+    // ── Test 4: pipe chain (3+ stages) ───────────────────────────────────────
+    test("4. パイプチェーン 3段: t |> sine |> map", () => {
+      const dsl = `t = clock()
+result = t |> sine(freq: 0.3) |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 700)`;
+      const g = parseDSL(dsl);
+      assert(hasNode(g.nodes, "result", "map"), "map node");
+      // intermediate sine node should exist
+      const sineNode = g.nodes.find(n => n.type === "sine");
+      assert(sineNode, "sine node exists");
+      assert(hasEdge(g.edges, "t.t", `${sineNode.id}.t`), "t → sine.t");
+      assert(hasEdge(g.edges, `${sineNode.id}.out`, "result.value"), "sine → map");
+    });
+
+    // ── Test 5: multi-line continuation with indent ───────────────────────────
+    test("5. インデント継続 (|> を次行に)", () => {
+      const dsl = `t = clock()
+result = t
+  |> sine(freq: 0.3)
+  |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 700)`;
+      const g = parseDSL(dsl);
+      assert(hasNode(g.nodes, "result", "map"), "map node");
+      const sineNode = g.nodes.find(n => n.type === "sine");
+      assert(sineNode, "sine node");
+      assert(hasEdge(g.edges, `${sineNode.id}.out`, "result.value"), "sine → map");
+    });
+
+    // ── Test 6: multi-line args inside parens ─────────────────────────────────
+    test("6. 括弧内の改行", () => {
+      const dsl = `t = clock()
+result = map(
+  t,
+  inMin: 0,
+  inMax: 10,
+  outMin: 100,
+  outMax: 700
+)`;
+      const g = parseDSL(dsl);
+      assert(hasNode(g.nodes, "result", "map"), "map node");
+      assert(hasEdge(g.edges, "t.t", "result.value"), "t → result");
+      const mp = g.nodes.find(n => n.id === "result").params;
+      assertEqual(mp.inMin, 0);
+      assertEqual(mp.outMax, 700);
+    });
+
+    // ── Test 7: comment lines are skipped ────────────────────────────────────
+    test("7. コメント行のスキップ", () => {
+      const dsl = `# 時間ソース
+t = clock()  # クロック
+# 波形
+wave = sine(t, freq: 0.5)`;
+      const g = parseDSL(dsl);
+      assert(hasNode(g.nodes, "t", "clock"));
+      assert(hasNode(g.nodes, "wave", "sine"));
+    });
+
+    // ── Test 8: blank line breaks pipe chain ──────────────────────────────────
+    test("8. 空行でチェーンが切れる (エラー)", () => {
+      const dsl = `t = clock()
+result = t
+
+  |> sine(freq: 0.3)`;
+      // blank line before |> – the |> on the next line starts a new statement → error
+      assertThrows(() => parseDSL(dsl), 'UNEXPECTED_TOKEN');
+    });
+
+    // ── Test 9: commutative positional args ───────────────────────────────────
+    test("9. 可換ノードの位置引数: add(a, b)", () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.5)
+result = add(t, wave)`;
+      const g = parseDSL(dsl);
+      assert(hasNode(g.nodes, "result", "add"), "add node");
+      assert(hasEdge(g.edges, "t.t", "result.a"), "t → result.a");
+      assert(hasEdge(g.edges, "wave.out", "result.b"), "wave → result.b");
+    });
+
+    // ── Test 10: non-commutative positional arg error ─────────────────────────
+    test("10. 非可換ノードで位置引数 → エラー", () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.5)
+result = subtract(t, wave)`;
+      assertThrows(() => parseDSL(dsl), 'MISSING_ARGUMENT_NAME');
+    });
+
+    // ── Test 11: render statement ─────────────────────────────────────────────
+    test("11. render 文: render point(x: x, y: y)", () => {
+      const dsl = `t = clock()
+x = sine(t, freq: 0.3)
+y = cosine(t, freq: 0.5)
+render point(x: x, y: y, color: "#00ff00", trail: 0.05)`;
+      const g = parseDSL(dsl);
+      assert(g.render, "render config exists");
+      assertEqual(g.render.type, "point");
+      assertEqual(g.render.color, "#00ff00");
+      assertEqual(g.render.trail, 0.05);
+      assert(g.render.x.includes("x."), "x ref");
+      assert(g.render.y.includes("y."), "y ref");
+    });
+
+    // ── Test 12: identifier reference and edge generation ────────────────────
+    test("12. 識別子参照とエッジ生成", () => {
+      const dsl = `t = clock()
+a = sine(t, freq: 0.3)
+b = cosine(a, freq: 0.5)`;
+      const g = parseDSL(dsl);
+      assert(hasEdge(g.edges, "t.t", "a.t"), "t → a.t");
+      assert(hasEdge(g.edges, "a.out", "b.t"), "a.out → b.t");
+    });
+
+    // ── Test 13: numeric literal goes to params ───────────────────────────────
+    test("13. 数値リテラルの params 格納", () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.3, amplitude: 2)`;
+      const g = parseDSL(dsl);
+      const params = g.nodes.find(n => n.id === "wave").params;
+      assertEqual(params.freq, 0.3);
+      assertEqual(params.amplitude, 2);
+    });
+
+    // ── Test 14: undefined identifier error ──────────────────────────────────
+    test("14. 未定義識別子 → エラー", () => {
+      assertThrows(() => parseDSL("wave = sine(undef, freq: 0.3)"), 'UNDEFINED_IDENTIFIER');
+    });
+
+    // ── Test 15: lissajous full preset equivalence ────────────────────────────
+    test("15. lissajous プリセット: DSL ≡ JSON グラフ", () => {
+      const preset = presets.lissajous;
+      const g = parseDSL(preset.dsl);
+
+      // Check all node types exist
+      const types = g.nodes.map(n => n.type);
+      assert(types.includes("clock"), "clock node");
+      assert(types.includes("sine"), "sine node");
+      assert(types.includes("cosine"), "cosine node");
+      const mapNodes = g.nodes.filter(n => n.type === "map");
+      assertEqual(mapNodes.length, 2, "two map nodes");
+
+      // Check render config
+      assert(g.render, "render present");
+      assertEqual(g.render.type, "point");
+      assertEqual(g.render.color, "#00ff00");
+      assertEqual(g.render.trail, 0.05);
+
+      // Check edge count: clock→sine, clock→cosine, sine→mapX, cosine→mapY = 4 edges
+      assertEqual(g.edges.length, 4, "4 edges total");
+
+      // Verify node params
+      const sineNode = g.nodes.find(n => n.type === "sine");
+      assertEqual(sineNode.params.freq, 0.3);
+      const cosineNode = g.nodes.find(n => n.type === "cosine");
+      assertEqual(cosineNode.params.freq, 0.5);
+    });
+
+    // ── Run tests ─────────────────────────────────────────────────────────────
+    const el = document.getElementById("results");
+    let pass = 0, fail = 0;
+
+    for (const { name, fn } of results) {
+      const div = document.createElement("div");
+      div.className = "test-result";
+      try {
+        fn();
+        div.classList.add("test-pass");
+        div.textContent = `✅ ${name}`;
+        pass++;
+      } catch (e) {
+        div.classList.add("test-fail");
+        div.textContent = `❌ ${name}: ${e.message}`;
+        fail++;
+      }
+      el.appendChild(div);
+    }
+
+    const summary = document.createElement("div");
+    summary.className = `summary ${fail === 0 ? "summary-pass" : "summary-fail"}`;
+    summary.textContent = `${pass} passed, ${fail} failed`;
+    el.appendChild(summary);
+
+    window.__loomDSLTestResults = { pass, fail };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- src/loom-dsl.js: tokenizer + recursive-descent parser + graph builder
  - parseDSL(text) → {nodes, edges, render?}
  - LoomDSLError with line/column/code
  - Pipe operator |>, named args, commutative node positional args
  - render point/bar statement support
- src/loom.js: export NODE_TYPES, add commutative:true to add/multiply
- editor/index.html: JSON/DSL tab switching with separate localStorage keys
- editor/presets.js: add dsl field to all 5 presets
- test/loom-dsl.test.html: 15 parser tests
- docs/DSL.md: full DSL specification
- README.md: DSL introduction and example

https://claude.ai/code/session_019AAU7TE1tAGmgwgWG7mS1S