### PR TITLE
Add DOM sink nodes and richer sink demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 * 色相循環 (Three.js)：https://afjk.github.io/loom/examples/11-color-cycle.html
 * 円運動：https://afjk.github.io/loom/examples/12-circular-motion.html
 * 範囲リマップ：https://afjk.github.io/loom/examples/13-clamp-map.html
+* DOM Transform Sink デモ：https://afjk.github.io/loom/examples/14-dom-transform-sink.html
+* Threshold Class Sink デモ：https://afjk.github.io/loom/examples/15-threshold-class-sink.html
 * **ライブエディタ（シンプル版）**：https://afjk.github.io/loom/editor/
 * **ライブエディタ（Pro 版）**：https://afjk.github.io/loom/editor-pro/dist/
 * テスト結果：https://afjk.github.io/loom/test/loom.test.html
@@ -223,6 +225,8 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 * 円運動：`http://localhost:8000/examples/12-circular-motion.html`
 
 * 範囲リマップ：`http://localhost:8000/examples/13-clamp-map.html`
+* DOM Transform Sink デモ：`http://localhost:8000/examples/14-dom-transform-sink.html`
+* Threshold Class Sink デモ：`http://localhost:8000/examples/15-threshold-class-sink.html`
 
 * **ライブエディタ（シンプル版）**：`http://localhost:8000/editor/`
 * **ライブエディタ（Pro 版）**：`http://localhost:8000/editor-pro/dist/`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -175,7 +175,7 @@ Loom の核は、以下の仕組みです：
 - ✅ `engine.dispatchEvent(ref, payload)` API
 - ✅ 入力ノード4種：`pointerClick`、`pointerPosition`、`keyDown`、`keyUp`
 - ✅ イベント変換ノード3種：`filter`、`sample`、`merge`
-- ✅ DOM シンクノード4種：`setText`、`setStyle`、`setAttr`、`log`
+- ✅ DOM シンクノード7種：`setText`、`setStyle`、`setAttr`、`setClass`、`setCssVar`、`setTransform2D`、`log`
 - ✅ 既存ノードはそのまま動作（後方互換）
 
 ### 実装外（第二段階以降）
@@ -811,6 +811,44 @@ predicate は `load()` 時にパースして抽象構文木（AST）に変換し
 
 複数の Event ストリームを1本にまとめる。同一フレームに両方発生した場合、出力配列は `a` の全ペイロード、その後に `b` の全ペイロード、という順序で連結される。下流ノードはこの順序を前提にしてよい。
 
+### 5.12.1 greaterThan
+
+**カテゴリ：** 変換部品
+
+**入力：**
+- `value`（型：`number`、デフォルト：`0`）
+- `threshold`（型：`number`、デフォルト：`0`）
+
+**出力：**
+- `out`（型：`boolean`）
+
+**パラメータ：**
+- `value`（型：`number`、デフォルト：`0`）
+- `threshold`（型：`number`、デフォルト：`0`）
+
+**説明：**
+
+`value > threshold` を評価し、真偽値を返す。しきい値判定をシンプルに記述するためのノード。
+
+### 5.12.2 lessThan
+
+**カテゴリ：** 変換部品
+
+**入力：**
+- `value`（型：`number`、デフォルト：`0`）
+- `threshold`（型：`number`、デフォルト：`0`）
+
+**出力：**
+- `out`（型：`boolean`）
+
+**パラメータ：**
+- `value`（型：`number`、デフォルト：`0`）
+- `threshold`（型：`number`、デフォルト：`0`）
+
+**説明：**
+
+`value < threshold` を評価し、真偽値を返す。`greaterThan` と対で使える比較ノード。
+
 ### 5.13 setText
 
 **カテゴリ：** シンク部品
@@ -844,6 +882,62 @@ DOM 要素のテキスト内容を更新する。`document.querySelector(target)
 **説明：**
 
 DOM 要素の CSS スタイルを更新する。`el.style[property] = String(value) + unit` として設定されます。例えば `value=50`、`property="width"`、`unit="px"` なら、`el.style.width = "50px"` となります。要素が見つからない場合、何もしない（エラーにしない）。
+
+### 5.14.1 setClass
+
+**カテゴリ：** シンク部品
+
+**入力：**
+- `enabled`（型：`boolean`、デフォルト：`true`）
+
+**出力：** なし（シンクノードは副作用専用のため出力を持たない）
+
+**パラメータ：**
+- `target`（型：`string`、デフォルト：`""`）：CSS セレクタ
+- `className`（型：`string`、デフォルト：`""`）：付け外しするクラス名
+
+**説明：**
+
+`element.classList.toggle(className, Boolean(enabled))` を実行してクラスを付与/削除する。対象要素がない場合、`className` が空の場合は何もしない。
+
+### 5.14.2 setCssVar
+
+**カテゴリ：** シンク部品
+
+**入力：**
+- `value`（型：`any`、デフォルト：`0`）
+
+**出力：** なし（シンクノードは副作用専用のため出力を持たない）
+
+**パラメータ：**
+- `target`（型：`string`、デフォルト：`""`）：CSS セレクタ
+- `name`（型：`string`、デフォルト：`""`）：CSS カスタムプロパティ名
+- `unit`（型：`string`、デフォルト：`""`）：単位文字列
+
+**説明：**
+
+CSS custom property を更新する。`name` が `--` で始まらない場合は自動で `--` を補う。`value` が `null` / `undefined` の場合や対象要素がない場合は何もしない。
+
+### 5.14.3 setTransform2D
+
+**カテゴリ：** シンク部品
+
+**入力：**
+- `x`（型：`number`、デフォルト：`0`）
+- `y`（型：`number`、デフォルト：`0`）
+- `scale`（型：`number`、デフォルト：`1`）
+- `rotate`（型：`number`、デフォルト：`0`）
+
+**出力：** なし（シンクノードは副作用専用のため出力を持たない）
+
+**パラメータ：**
+- `target`（型：`string`、デフォルト：`""`）：CSS セレクタ
+- `unit`（型：`string`、デフォルト：`"px"`）：translate の単位
+- `rotateUnit`（型：`string`、デフォルト：`"deg"`）：rotate の単位
+
+**説明：**
+
+`style.transform` を `translate(...) scale(...) rotate(...)` 形式でまとめて設定する。`setStyle` でも transform は設定できるが、`setTransform2D` は 2D 変形を分かりやすく扱うための専用シンク。対象要素がない場合は何もしない。
 
 ### 5.15 setAttr
 

--- a/examples/14-dom-transform-sink.html
+++ b/examples/14-dom-transform-sink.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>DOM Transform Sink Demo</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: radial-gradient(circle at 20% 20%, #151a2a, #090b12 55%); color: #e7ebff; font-family: Inter, sans-serif; }
+    #card { --glow: 0.35; --hue: 210; width: 280px; padding: 20px; border-radius: 16px; background: hsl(var(--hue), 80%, 55%); box-shadow: 0 12px 42px hsla(var(--hue), 90%, 60%, var(--glow)); transform-origin: center; text-align: center; color: #0a1022; font-weight: 700; }
+    #readout { font-family: ui-monospace, monospace; font-size: 13px; margin-top: 8px; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div id="card">
+    DOM Transform Sink
+    <div id="readout">starting...</div>
+  </div>
+
+  <script type="module">
+    import { Loom } from "../src/loom.js";
+
+    const graph = {
+      nodes: [
+        { id: "t", type: "clock" },
+        { id: "sx", type: "sine", params: { freq: 0.15, amplitude: 1 } },
+        { id: "cy", type: "cosine", params: { freq: 0.12, amplitude: 1 } },
+        { id: "scaleWave", type: "sine", params: { freq: 0.08, amplitude: 1 } },
+        { id: "rotWave", type: "sine", params: { freq: 0.05, amplitude: 1 } },
+        { id: "hueWave", type: "sine", params: { freq: 0.06, amplitude: 1 } },
+
+        { id: "mapX", type: "map", params: { inMin: -1, inMax: 1, outMin: -120, outMax: 120 } },
+        { id: "mapY", type: "map", params: { inMin: -1, inMax: 1, outMin: -80, outMax: 80 } },
+        { id: "mapScale", type: "map", params: { inMin: -1, inMax: 1, outMin: 0.9, outMax: 1.15 } },
+        { id: "mapRotate", type: "map", params: { inMin: -1, inMax: 1, outMin: -18, outMax: 18 } },
+        { id: "mapGlow", type: "map", params: { inMin: -1, inMax: 1, outMin: 0.2, outMax: 0.75 } },
+        { id: "mapHue", type: "map", params: { inMin: -1, inMax: 1, outMin: 180, outMax: 320 } },
+
+        { id: "transform", type: "setTransform2D", params: { target: "#card", unit: "px", rotateUnit: "deg" } },
+        { id: "setGlow", type: "setCssVar", params: { target: "#card", name: "glow" } },
+        { id: "setHue", type: "setCssVar", params: { target: "#card", name: "--hue" } },
+        { id: "text", type: "setText", params: { target: "#readout" } }
+      ],
+      edges: [
+        { from: "t.t", to: "sx.t" }, { from: "t.t", to: "cy.t" }, { from: "t.t", to: "scaleWave.t" }, { from: "t.t", to: "rotWave.t" }, { from: "t.t", to: "hueWave.t" },
+        { from: "sx.out", to: "mapX.value" }, { from: "cy.out", to: "mapY.value" }, { from: "scaleWave.out", to: "mapScale.value" }, { from: "rotWave.out", to: "mapRotate.value" },
+        { from: "scaleWave.out", to: "mapGlow.value" }, { from: "hueWave.out", to: "mapHue.value" },
+        { from: "mapX.out", to: "transform.x" }, { from: "mapY.out", to: "transform.y" }, { from: "mapScale.out", to: "transform.scale" }, { from: "mapRotate.out", to: "transform.rotate" },
+        { from: "mapGlow.out", to: "setGlow.value" }, { from: "mapHue.out", to: "setHue.value" },
+        { from: "mapHue.out", to: "text.value" }
+      ]
+    };
+
+    new Loom(graph).start();
+  </script>
+</body>
+</html>

--- a/examples/15-threshold-class-sink.html
+++ b/examples/15-threshold-class-sink.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Threshold Class Sink Demo</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0d1117; color: #c9d1d9; font-family: sans-serif; }
+    #meter { width: 320px; }
+    .track { height: 18px; border-radius: 999px; background: #1f2937; overflow: hidden; border: 1px solid #2b3442; }
+    #fill { height: 100%; width: 0%; background: linear-gradient(90deg, #36cfc9, #5b8cff); }
+    #lamp { margin-top: 16px; padding: 12px 14px; border-radius: 10px; background: #1c2534; border: 1px solid #334155; transition: 150ms; }
+    #lamp.is-hot { background: #4d1f1f; border-color: #f97316; box-shadow: 0 0 24px rgba(249, 115, 22, 0.6); color: #ffd5bd; }
+  </style>
+</head>
+<body>
+  <div id="meter">
+    <div class="track"><div id="fill"></div></div>
+    <div id="lamp">normal</div>
+  </div>
+
+  <script type="module">
+    import { Loom } from "../src/loom.js";
+
+    const graph = {
+      nodes: [
+        { id: "t", type: "clock" },
+        { id: "wave", type: "sine", params: { freq: 0.35, amplitude: 1 } },
+        { id: "norm", type: "map", params: { inMin: -1, inMax: 1, outMin: 0, outMax: 1, clamp: true } },
+        { id: "percent", type: "map", params: { inMin: 0, inMax: 1, outMin: 0, outMax: 100, clamp: true } },
+        { id: "isHot", type: "greaterThan", params: { threshold: 0.7 } },
+        { id: "fillWidth", type: "setStyle", params: { target: "#fill", property: "width", unit: "%" } },
+        { id: "hotClass", type: "setClass", params: { target: "#lamp", className: "is-hot" } },
+        { id: "label", type: "setText", params: { target: "#lamp" } }
+      ],
+      edges: [
+        { from: "t.t", to: "wave.t" },
+        { from: "wave.out", to: "norm.value" },
+        { from: "norm.out", to: "percent.value" },
+        { from: "percent.out", to: "fillWidth.value" },
+        { from: "norm.out", to: "isHot.value" },
+        { from: "isHot.out", to: "hotClass.enabled" },
+        { from: "percent.out", to: "label.value" }
+      ]
+    };
+
+    new Loom(graph).start();
+  </script>
+</body>
+</html>

--- a/src/loom.js
+++ b/src/loom.js
@@ -586,6 +586,32 @@ export const NODE_TYPES = {
       return { out: Math.cos(t * freq * 2 * Math.PI + phase) * amplitude + offset };
     }
   },
+  greaterThan: {
+    category: 'transform',
+    inputs: [
+      { name: 'value', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'threshold', type: 'number', default: 0, kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }],
+    params: [
+      { name: 'value', type: 'number', default: 0 },
+      { name: 'threshold', type: 'number', default: 0 }
+    ],
+    evaluate: (inputs, params, ctx) => ({ out: inputs.value > inputs.threshold })
+  },
+  lessThan: {
+    category: 'transform',
+    inputs: [
+      { name: 'value', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'threshold', type: 'number', default: 0, kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }],
+    params: [
+      { name: 'value', type: 'number', default: 0 },
+      { name: 'threshold', type: 'number', default: 0 }
+    ],
+    evaluate: (inputs, params, ctx) => ({ out: inputs.value < inputs.threshold })
+  },
 
   // Phase 1 入力ノード
   pointerClick: {
@@ -823,6 +849,67 @@ export const NODE_TYPES = {
       if (!params.target || !params.property) return {};
       const el = document.querySelector(params.target);
       if (el) el.style[params.property] = String(inputs.value) + params.unit;
+      return {};
+    }
+  },
+  setClass: {
+    category: 'sink',
+    inputs: [
+      { name: 'enabled', type: 'boolean', default: true, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'target', type: 'string', default: '' },
+      { name: 'className', type: 'string', default: '' }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      if (!params.target || !params.className) return {};
+      const el = document.querySelector(params.target);
+      if (!el) return {};
+      el.classList.toggle(params.className, Boolean(inputs.enabled));
+      return {};
+    }
+  },
+  setCssVar: {
+    category: 'sink',
+    inputs: [
+      { name: 'value', type: 'any', default: 0, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'target', type: 'string', default: '' },
+      { name: 'name', type: 'string', default: '' },
+      { name: 'unit', type: 'string', default: '' }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      if (!params.target || !params.name) return {};
+      if (inputs.value === null || inputs.value === undefined) return {};
+      const el = document.querySelector(params.target);
+      if (!el) return {};
+      const cssVarName = params.name.startsWith('--') ? params.name : `--${params.name}`;
+      el.style.setProperty(cssVarName, String(inputs.value) + params.unit);
+      return {};
+    }
+  },
+  setTransform2D: {
+    category: 'sink',
+    inputs: [
+      { name: 'x', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'y', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'scale', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'rotate', type: 'number', default: 0, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'target', type: 'string', default: '' },
+      { name: 'unit', type: 'string', default: 'px' },
+      { name: 'rotateUnit', type: 'string', default: 'deg' }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      if (!params.target) return {};
+      const el = document.querySelector(params.target);
+      if (!el) return {};
+      el.style.transform = `translate(${inputs.x}${params.unit}, ${inputs.y}${params.unit}) scale(${inputs.scale}) rotate(${inputs.rotate}${params.rotateUnit})`;
       return {};
     }
   },

--- a/test/loom.test.html
+++ b/test/loom.test.html
@@ -956,6 +956,149 @@
       // エラーが発生しなければ成功
       assert(true);
     });
+    test("setClass が class を付与/削除し、存在しない selector でも throw しない", () => {
+      const div = document.createElement("div");
+      div.id = "sink-test-class";
+      document.body.appendChild(div);
+      try {
+        const graph = {
+          nodes: [
+            { id: "flag", type: "constant", params: { value: true } },
+            { id: "sink", type: "setClass", params: { target: "#sink-test-class", className: "is-hot" } }
+          ],
+          edges: [{ from: "flag.out", to: "sink.enabled" }]
+        };
+        const engine = new Loom(graph);
+        engine.evaluateAt(0);
+        assert(div.classList.contains("is-hot"), "class should be added");
+
+        engine.load({
+          nodes: [
+            { id: "flag", type: "constant", params: { value: false } },
+            { id: "sink", type: "setClass", params: { target: "#sink-test-class", className: "is-hot" } }
+          ],
+          edges: [{ from: "flag.out", to: "sink.enabled" }]
+        });
+        engine.evaluateAt(0);
+        assert(!div.classList.contains("is-hot"), "class should be removed");
+
+        const engine2 = new Loom({
+          nodes: [
+            { id: "flag", type: "constant", params: { value: true } },
+            { id: "sink", type: "setClass", params: { target: "#no-such-target", className: "is-hot" } }
+          ],
+          edges: [{ from: "flag.out", to: "sink.enabled" }]
+        });
+        engine2.evaluateAt(0);
+        assert(true);
+      } finally {
+        document.body.removeChild(div);
+      }
+    });
+    test("setCssVar が CSS 変数を設定し、name の -- 補完と非存在 selector を扱う", () => {
+      const div = document.createElement("div");
+      div.id = "sink-test-cssvar";
+      document.body.appendChild(div);
+      try {
+        const engine = new Loom({
+          nodes: [
+            { id: "v", type: "constant", params: { value: 10 } },
+            { id: "sink", type: "setCssVar", params: { target: "#sink-test-cssvar", name: "--x", unit: "px" } }
+          ],
+          edges: [{ from: "v.out", to: "sink.value" }]
+        });
+        engine.evaluateAt(0);
+        assertEqual(div.style.getPropertyValue("--x"), "10px");
+
+        const engine2 = new Loom({
+          nodes: [
+            { id: "v", type: "constant", params: { value: 20 } },
+            { id: "sink", type: "setCssVar", params: { target: "#sink-test-cssvar", name: "x", unit: "px" } }
+          ],
+          edges: [{ from: "v.out", to: "sink.value" }]
+        });
+        engine2.evaluateAt(0);
+        assertEqual(div.style.getPropertyValue("--x"), "20px");
+
+        const engine3 = new Loom({
+          nodes: [
+            { id: "v", type: "constant", params: { value: 1 } },
+            { id: "sink", type: "setCssVar", params: { target: "#no-such-target", name: "x", unit: "px" } }
+          ],
+          edges: [{ from: "v.out", to: "sink.value" }]
+        });
+        engine3.evaluateAt(0);
+        assert(true);
+      } finally {
+        document.body.removeChild(div);
+      }
+    });
+    test("setTransform2D が transform を設定し、未接続入力で default を使う", () => {
+      const div = document.createElement("div");
+      div.id = "sink-test-transform";
+      document.body.appendChild(div);
+      try {
+        const engine = new Loom({
+          nodes: [
+            { id: "x", type: "constant", params: { value: 10 } },
+            { id: "y", type: "constant", params: { value: 20 } },
+            { id: "s", type: "constant", params: { value: 1.5 } },
+            { id: "r", type: "constant", params: { value: 45 } },
+            { id: "sink", type: "setTransform2D", params: { target: "#sink-test-transform" } }
+          ],
+          edges: [
+            { from: "x.out", to: "sink.x" },
+            { from: "y.out", to: "sink.y" },
+            { from: "s.out", to: "sink.scale" },
+            { from: "r.out", to: "sink.rotate" }
+          ]
+        });
+        engine.evaluateAt(0);
+        assertEqual(div.style.transform, "translate(10px, 20px) scale(1.5) rotate(45deg)");
+
+        const engine2 = new Loom({
+          nodes: [
+            { id: "x", type: "constant", params: { value: 8 } },
+            { id: "sink", type: "setTransform2D", params: { target: "#sink-test-transform" } }
+          ],
+          edges: [{ from: "x.out", to: "sink.x" }]
+        });
+        engine2.evaluateAt(0);
+        assertEqual(div.style.transform, "translate(8px, 0px) scale(1) rotate(0deg)");
+
+        const engine3 = new Loom({
+          nodes: [{ id: "sink", type: "setTransform2D", params: { target: "#no-such-target" } }],
+          edges: []
+        });
+        engine3.evaluateAt(0);
+        assert(true);
+      } finally {
+        document.body.removeChild(div);
+      }
+    });
+    test("greaterThan / lessThan が期待通りで、edge 接続値を使う", () => {
+      const engine = new Loom({
+        nodes: [
+          { id: "gt1", type: "greaterThan", params: { value: 2, threshold: 1 } },
+          { id: "gt2", type: "greaterThan", params: { value: 1, threshold: 2 } },
+          { id: "lt1", type: "lessThan", params: { value: 1, threshold: 2 } },
+          { id: "lt2", type: "lessThan", params: { value: 2, threshold: 1 } },
+          { id: "v", type: "constant", params: { value: 5 } },
+          { id: "th", type: "constant", params: { value: 3 } },
+          { id: "gtEdge", type: "greaterThan" }
+        ],
+        edges: [
+          { from: "v.out", to: "gtEdge.value" },
+          { from: "th.out", to: "gtEdge.threshold" }
+        ]
+      });
+      engine.evaluateAt(0);
+      assertEqual(engine.getValue("gt1.out"), true);
+      assertEqual(engine.getValue("gt2.out"), false);
+      assertEqual(engine.getValue("lt1.out"), true);
+      assertEqual(engine.getValue("lt2.out"), false);
+      assertEqual(engine.getValue("gtEdge.out"), true);
+    });
 
     test("複数シンクノードがそれぞれ DOM を更新する", () => {
       const div1 = document.createElement("div");


### PR DESCRIPTION
### Motivation

- Expand Loom's DOM sink capabilities so UI updates are driven solely by sink nodes and examples demonstrate the pattern.
- Provide simple threshold transform nodes to make class-based UI toggles easy in graphs.
- Keep to the existing design rule that side-effects live in sink nodes and avoid direct DOM mutations from the JS animation loop.

### Description

- Added transform nodes `greaterThan` and `lessThan` to `NODE_TYPES` in `src/loom.js` returning boolean `out` based on `value` vs `threshold` and supporting edge→params→default resolution.
- Added sink nodes `setClass`, `setCssVar`, and `setTransform2D` to `src/loom.js` implementing the specified safe DOM operations and leaving outputs empty (no side-effect outputs).
- Added automated test cases to `test/loom.test.html` covering `setClass`, `setCssVar`, `setTransform2D`, and `greaterThan`/`lessThan` behavior including non-existent selector safety and default handling for partially connected inputs.
- Added two examples `examples/14-dom-transform-sink.html` and `examples/15-threshold-class-sink.html` showing DOM driven entirely by Loom graphs, and updated `README.md` and `docs/SPEC.md` with links and node specifications; verified Editor Pro completion reads `NODE_TYPES` dynamically so no manual completion edits were required.

### Testing

- Added browser-based tests in `test/loom.test.html` exercising the new nodes; these tests are intended to run under the repository's CI that uses Playwright.
- Ran `npm test` locally but it failed to start browsers due to missing Playwright browser binaries (error: `npx playwright install` required), so CI/playwright-enabled environment is needed to execute the new tests end-to-end.
- Verified static integration: files added/modified were committed and examples load `new Loom(graph).start()` only (no direct DOM update loops), and Editor Pro completion code was inspected to confirm no manual completion changes necessary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8020035a08320bfaa0a9776c6e9a2)