### PR TITLE
docs: clarify Loom's stateless-by-default philosophy and explicit temporal state

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ A browser dataflow engine with stateless transforms and explicit time-based stat
 
 ブラウザで動くデータフロー実行エンジン。純粋関数ノードを基本にしつつ、必要な箇所だけを `state` ノードとして明示し、リアクティブな視覚・音響・3D コンテンツを構築します。
 
+## 設計思想
+
+Loom は原則としてステートレスなデータフローを基本とし、時間的な追従・遅延・累積が必要な場合のみ、明示的な state ノード(explicit temporal state)に状態を隔離します。これにより graph JSON は宣言的・再現可能なまま保たれ、状態を持つ挙動も graph の中で可視化されます。
+
+## Node categories
+
+| Category | 説明 | 例 |
+|---|---|---|
+| `source` | 入力なしで値を生成するカテゴリ | `clock`, `constant` |
+| `input` | 外界から値やイベントを受け取るカテゴリ | `pointerPosition`, `pointerClick`, `keyDown` |
+| `transform` | ステートレスな純粋変換を行うカテゴリ | `sine`, `add`, `map`, `clamp` |
+| `state` | 前フレーム値と `dt` を保持する特例カテゴリ。明示的な temporal state。詳細は SPEC.md の「State nodes」章参照 | `smoothLerp`, `lowpass`, `delay1`, `integrate` |
+| `sink` | 副作用を外部に反映するカテゴリ | `setStyle`, `setText`, `log` |
+
 ## ステータス
 
 **第一段階：プロトタイプ実装完了、仕様確定**

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -300,3 +300,56 @@ lerp = lerp(a: 100, b: 700, t: sine)
 
 render point(x: lerp, y: 250, color: "#ff6688", trail: 0.1)
 ```
+
+## State nodes (explicit temporal state)
+
+### smoothLerp — 目標値への滑らかな追従
+
+state ノード。graph JSON には現れない runtime state(prevOut)を持ち、`engine.load()` で同じ id ならその state を引き継ぐ。
+
+```js
+const graph = {
+  nodes: [
+    { id: "target", type: "constant", params: { value: 100 } },
+    { id: "follow", type: "smoothLerp", params: { rate: 5, initial: 0 } }
+  ],
+  edges: [
+    { from: "target.out", to: "follow.value" }
+  ]
+};
+```
+
+### lowpass — 時定数 tau による平滑化
+
+state ノード。graph JSON には現れない runtime state(prevOut)を持ち、ノイズの多い入力(マウス座標など)を滑らかにする用途。
+
+```js
+const graph = {
+  nodes: [
+    { id: "raw", type: "pointerPosition", params: { axis: "x" } },
+    { id: "smooth", type: "lowpass", params: { tau: 0.1, initial: 0 } }
+  ],
+  edges: [
+    { from: "raw.out", to: "smooth.value" }
+  ]
+};
+```
+
+### integrate — 時間積分(チャージゲージ等)
+
+state ノード。graph JSON には現れない runtime state(prevOut)を持ち、`min` / `max` でクランプ可能。
+
+```js
+const graph = {
+  nodes: [
+    { id: "key", type: "keyDown", params: { key: " " } },
+    { id: "rate", type: "constant", params: { value: 1 } },
+    { id: "charge", type: "integrate", params: { min: 0, max: 1, initial: 0 } }
+  ],
+  edges: [
+    { from: "rate.out", to: "charge.value" }
+  ]
+};
+```
+
+※ `delay1` は `out = prevOut` を返し、現在の入力を次フレームに渡す state ノードです。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1888,3 +1888,55 @@ JavaScript 版 Loom と同じ JSON グラフ形式を、Unity C# ランタイム
 - ビジュアルエディタ
 - WebSocket 本体実装
 - Unity Package Manager 公開
+
+## State nodes (explicit temporal state)
+
+### 動機
+
+Loom の通常ノードはステートレスな純粋関数であり、`evaluate(inputs, params)` の結果は入力のみで決まる。これは graph を「時刻 t の関数 f(t)」として扱える純度の高い性質を生むが、一方で smoothing / delay / integrate / easing follow のような「前フレーム値を必要とする挙動」は表現できない。
+
+これらを graph 外の JS に逃がすと、Loom グラフから挙動が見えなくなり、Loom の「graph に挙動を閉じ込める」という思想からむしろ外れてしまう。そこで Loom は state を禁止するのでも無制限に許すのでもなく、明示的に隔離されたカテゴリとして導入する。
+
+### 設計原則
+
+1. 通常ノードは純粋関数である。
+2. 状態を持てるのは `category: "state"` のノードだけである。
+3. state は node id に紐づく。
+4. state は graph JSON には保存されない runtime state である。
+5. `engine.load()` 時、同じ id の state ノードは state を引き継ぐ。
+6. id が変わった state ノードは `params.initial` から始まる。
+7. state ノードは同期・再現性に影響するため、必要最小限に使う。
+8. AI が graph を生成する場合、state ノードの使用は時間的挙動(smooth / delay / integrate / easing follow)が必要な場合に限定する。
+
+### 用語
+
+- カテゴリ識別子(機械可読)は `state` を使う。
+- ドキュメント・説明文では "explicit temporal state" と呼び、「時間方向のふるまいを扱うノード」であることを強調する。
+- 「任意のメモリ」「変数」「保存領域」としての拡大解釈は意図的に避ける。
+
+### エンジン契約
+
+- `dt` は秒単位で、フレーム間のタイムスタンプ差から算出される。
+- `dt` の上限は 0.1 秒にクランプされる(タブ非アクティブ時の暴走を防ぐため)。
+- state ノードの evaluate は `evaluate(inputs, params, { prevOut, dt })` の形で呼ばれる。
+- 評価後の出力は engine 側で id ごとに保持され、次フレームの `prevOut` として渡される。
+- `engine.load(newGraph)` では、同じ id の state ノードは prevOut を保持し、異なる id は `params.initial` から開始する。
+- NaN / Infinity が出た場合は `prevOut` を更新せず、必要に応じて `initial` にリセットする。
+
+### 同期(SceneSync 等)に関する注意
+
+Loom の標準的な同期モデルは「全クライアントが同じ graph JSON を受け取り、それぞれ独自に評価する」というものである。state ノードはこのモデル上、各クライアントで独立に進行する。
+
+- 同じ `params.initial` と同じ入力履歴(クロック、pointerClick イベントなど)が両端で揃っていれば、state ノードの値は収束する。
+- ジョイン時のキャッチアップ(途中参加クライアントが過去の入力を再生する仕組み)は保証されない。
+- したがって SceneSync 越しで state ノードを使う場合は、「収束しても OK な性質(easing follow、低域通過など)」に限定するのが安全である。
+- 累積誤差が問題になる挙動(`integrate` で大きなカウントを保持し続ける等)は、必要なら別途 broadcast 機構で値を共有する設計を将来検討する。
+
+### 標準 state ノード
+
+| Node | 用途 | 主なパラメータ | 式 |
+|---|---|---|---|
+| `smoothLerp` | 目標値への指数的収束(easing follow) | `rate` (1/sec), `initial` | `out = prevOut + (value - prevOut) * (1 - exp(-rate * dt))` |
+| `lowpass` | ノイズ除去・平滑化 | `tau` (sec), `initial` | `out = prevOut + (value - prevOut) * (dt / (tau + dt))` |
+| `delay1` | 1 フレーム前の入力を出力 | `initial` | `out = prevOut`、内部状態として現在の入力を次フレームへ |
+| `integrate` | 入力の時間積分 | `min`, `max`, `initial` | `out = clamp(prevOut + value * dt, min, max)` |


### PR DESCRIPTION
### Motivation

- Make the position of `state` nodes explicit: treat them as an isolated, time-directed runtime domain rather than an ad-hoc exception to Loom's stateless design. 
- Preserve declarative, reproducible graph JSON while enabling smoothing/delay/integration behavior to remain visible inside graphs. 
- Provide a single-source, docs-only articulation so implementers, UI and AI tooling can rely on consistent terminology and engine contracts without changing runtime code.

### Description

- Add a `設計思想` section to `README.md` that states "stateless-by-default" and introduces `explicit temporal state` for necessary time-based behaviors. 
- Add a `Node categories` table to `README.md` and include a `state` row with examples (`smoothLerp`, `lowpass`, `delay1`, `integrate`) and a pointer to the SPEC chapter. 
- Append a new `State nodes (explicit temporal state)` chapter to `docs/SPEC.md` describing motivation, eight design principles, terminology, engine contract (`dt`, `prevOut`, `engine.load()` behavior), SceneSync cautions, and a table of standard state-node formulas. 
- Extend `docs/DSL.md` with minimal, copy-paste examples for `smoothLerp`, `lowpass`, and `integrate` and a short note about `delay1`, clarifying that state is runtime-only and not stored in graph JSON. 
- This is a docs-only change with no modifications to `src/`, `editor-pro/`, `test/`, or `examples/`.

### Testing

- Performed automated file inspections including `sed` views of `README.md`, `docs/SPEC.md`, and `docs/DSL.md` and `rg` searches to confirm inserted headings and the `state` category. 
- Committed the documentation changes with `git commit` and prepared a PR message via the repository `make_pr` helper. 
- No build or runtime tests were required for this docs-only update (no unit tests were run against code because there are no code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81fdf4ec08320b7a0c0266f006e53)