### PR TITLE
feat: add EditorModel conversion layer between GraphJSON and editor UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Loom は原則としてステートレスなデータフローを基本とし、
 
 加えて、Source AST API（`parseDSLToAST` / `compileToGraph` / `formatDSL`）を公開しており、AI 補助編集・DSL formatter・ビジュアルエディタの基盤として利用できます。詳細は [SPEC.md の AST 章](docs/SPEC.md#astabstract-syntax-tree) を参照してください。
 
+加えて、Editor Model API（`graphToEditorModel` / `editorModelToGraph` / `applyEditorOperation`）を公開し、Source AST と GraphJSON の上にノードエディタ向けの正規化層を追加しました。三層分離の詳細は [SPEC.md の Editor Model 章](docs/SPEC.md#editor-model) を参照してください。
+
+```text
+DSL → Source AST → GraphJSON → EditorModel → (将来) Rete 描画
+                              ↑
+      (将来) Rete 操作 → EditorModel → GraphJSON → Preview 実行
+```
+
 ## Node categories
 
 | Category | 説明 | 例 |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2014,3 +2014,43 @@ interface Span { start: { line: number; column: number; offset: number }; end: {
 - editor-pro の lint / autocomplete を Source AST ベースに移行
 - DSL シンタックス拡張時の Source AST 拡張(InlineEdgeDecl, PipelineDecl 等)
 - 書式ヒントフィールドの追加(`CallExpression.multiline`, `Statement.blankLinesBefore`, `PipeExpression.lineBreakBefore`)
+
+
+## Editor Model
+
+Loom は次の 3 つの truth を分離して扱う。
+
+- **Source AST** は DSL の表層構文(配列ベース、順序・コメント保持)。
+- **GraphJSON** は Loom 実行用の正規形。
+- **Editor Model** はノードエディタ用の視覚モデル(id をキーとする Map 構造、CRDT 互換)。
+
+これらを橋渡しする関数として `parseDSLToAST` / `compileToGraph` / `graphToEditorModel` / `editorModelToGraph` / `applyEditorOperation` を提供する。Source AST と Editor Model は構造が異なる(配列ベース vs Map ベース)ため、相互変換は GraphJSON を中継して行うのが基本。
+
+### 型
+
+- `EditorNode`: `{ id, type, category, params, position }`
+- `EditorEdge`: `{ id, fromNodeId, fromPort, toNodeId, toPort }`
+- `EditorModel`: `{ nodesById, edgesById, order }`
+- `EditorOperation`: `addNode` / `removeNode` / `updateParam` / `moveNode` / `addEdge` / `removeEdge`
+
+### API
+
+- `graphToEditorModel(graph)`: GraphJSON を `nodesById` / `edgesById` / `order` に変換。`meta.position` がないノードには `layoutFallback` を適用する。
+- `editorModelToGraph(em, originalGraph = null)`: `order` で node 配列を再構築し、position を `meta.position` に保存。edge は edge id 昇順で決定論的に出力し、`originalGraph.render` を継承できる。
+- `applyEditorOperation(em, op)`: EditorModel をイミュータブル更新する。`removeNode` は関連 edge も削除し、`removeNode` / `removeEdge` は存在しない id で no-op。
+- `layoutFallback(nodes)`: category 別の決定論的グリッド配置を行う。
+
+### `layoutFallback` 仕様
+
+- `input`: x=0
+- `transform`: x=300
+- `state`: x=600
+- `sink`: x=900
+- その他: x=1200
+- 同カテゴリ内は入力順に y=0,120,240... を割り当てる。
+- 既存 `position` を持つノードは再配置しない。
+
+### v1 制約
+
+- v1 では DSL への書き戻し(EditorModel → Source AST → DSL)はサポートしない。
+- 将来の Yjs 統合では `nodesById` / `edgesById` を CRDT マップとしてそのまま扱う方針。

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -1,0 +1,206 @@
+import { NODE_TYPES } from './loom.js';
+
+/**
+ * @typedef {Object} EditorNode
+ * @property {string} id
+ * @property {string} type        - NODE_TYPES のキー
+ * @property {string} category    - "input" | "transform" | "sink" | "state"
+ * @property {Object} params
+ * @property {{ x: number, y: number }} position
+ */
+
+/**
+ * @typedef {Object} EditorEdge
+ * @property {string} id           - `${fromNodeId}.${fromPort}->${toNodeId}.${toPort}`
+ * @property {string} fromNodeId
+ * @property {string} fromPort
+ * @property {string} toNodeId
+ * @property {string} toPort
+ */
+
+/**
+ * @typedef {Object} EditorModel
+ * @property {Record<string, EditorNode>} nodesById
+ * @property {Record<string, EditorEdge>} edgesById
+ * @property {string[]} order      - ノード描画順、決定的レイアウトのため
+ */
+
+/**
+ * @typedef {
+ *   | { type: 'addNode',     node: EditorNode }
+ *   | { type: 'removeNode',  id: string }
+ *   | { type: 'updateParam', id: string, key: string, value: any }
+ *   | { type: 'moveNode',    id: string, position: { x: number, y: number } }
+ *   | { type: 'addEdge',     edge: EditorEdge }
+ *   | { type: 'removeEdge',  edgeId: string }
+ * } EditorOperation
+ */
+
+function edgeId(fromNodeId, fromPort, toNodeId, toPort) {
+  return `${fromNodeId}.${fromPort}->${toNodeId}.${toPort}`;
+}
+
+export function layoutFallback(nodes) {
+  const categoryX = {
+    input: 0,
+    transform: 300,
+    state: 600,
+    sink: 900
+  };
+  const counts = {};
+
+  return nodes.map((node) => {
+    if (node.position && Number.isFinite(node.position.x) && Number.isFinite(node.position.y)) {
+      return { ...node, position: { ...node.position } };
+    }
+
+    const category = node.category;
+    const x = Object.prototype.hasOwnProperty.call(categoryX, category) ? categoryX[category] : 1200;
+    const idx = counts[category] || 0;
+    counts[category] = idx + 1;
+
+    return {
+      ...node,
+      position: { x, y: idx * 120 }
+    };
+  });
+}
+
+export function graphToEditorModel(graph) {
+  const rawNodes = (graph.nodes || []).map((node) => {
+    const def = NODE_TYPES[node.type];
+    let category = def?.category || 'transform';
+    if (category === 'source') {
+      category = 'input';
+    }
+    if (!def) {
+      console.warn(`Unknown node type '${node.type}', fallback category 'transform'`);
+    }
+
+    const metaPosition = node.meta?.position;
+    const position = metaPosition && Number.isFinite(metaPosition.x) && Number.isFinite(metaPosition.y)
+      ? { x: metaPosition.x, y: metaPosition.y }
+      : null;
+
+    return {
+      id: node.id,
+      type: node.type,
+      category,
+      params: { ...(node.params || {}) },
+      position
+    };
+  });
+
+  const positioned = layoutFallback(rawNodes);
+  const nodesById = {};
+  for (const node of positioned) {
+    nodesById[node.id] = node;
+  }
+
+  const edgesById = {};
+  for (const edge of graph.edges || []) {
+    const [fromNodeId, fromPort] = edge.from.split('.');
+    const [toNodeId, toPort] = edge.to.split('.');
+    const id = edgeId(fromNodeId, fromPort, toNodeId, toPort);
+    edgesById[id] = { id, fromNodeId, fromPort, toNodeId, toPort };
+  }
+
+  return {
+    nodesById,
+    edgesById,
+    order: (graph.nodes || []).map((n) => n.id)
+  };
+}
+
+export function editorModelToGraph(em, originalGraph = null) {
+  const nodes = em.order.map((id) => {
+    const node = em.nodesById[id];
+    return {
+      id: node.id,
+      type: node.type,
+      params: { ...(node.params || {}) },
+      meta: {
+        position: { ...node.position }
+      }
+    };
+  });
+
+  const edgeIds = Object.keys(em.edgesById).sort();
+  const edges = edgeIds.map((id) => {
+    const edge = em.edgesById[id];
+    return {
+      from: `${edge.fromNodeId}.${edge.fromPort}`,
+      to: `${edge.toNodeId}.${edge.toPort}`
+    };
+  });
+
+  const graph = { nodes, edges };
+  if (originalGraph && originalGraph.render) {
+    graph.render = originalGraph.render;
+  }
+  return graph;
+}
+
+export function applyEditorOperation(em, op) {
+  const next = {
+    nodesById: { ...em.nodesById },
+    edgesById: { ...em.edgesById },
+    order: [...em.order]
+  };
+
+  if (op.type === 'addNode') {
+    if (next.nodesById[op.node.id]) throw new Error(`Node '${op.node.id}' already exists`);
+    next.nodesById[op.node.id] = {
+      ...op.node,
+      params: { ...(op.node.params || {}) },
+      position: { ...op.node.position }
+    };
+    next.order.push(op.node.id);
+    return next;
+  }
+
+  if (op.type === 'removeNode') {
+    if (!next.nodesById[op.id]) return next;
+    delete next.nodesById[op.id];
+    next.order = next.order.filter((id) => id !== op.id);
+    for (const id of Object.keys(next.edgesById)) {
+      const edge = next.edgesById[id];
+      if (edge.fromNodeId === op.id || edge.toNodeId === op.id) {
+        delete next.edgesById[id];
+      }
+    }
+    return next;
+  }
+
+  if (op.type === 'updateParam') {
+    const node = next.nodesById[op.id];
+    if (!node) throw new Error(`Node '${op.id}' does not exist`);
+    next.nodesById[op.id] = { ...node, params: { ...(node.params || {}), [op.key]: op.value } };
+    return next;
+  }
+
+  if (op.type === 'moveNode') {
+    const node = next.nodesById[op.id];
+    if (!node) throw new Error(`Node '${op.id}' does not exist`);
+    next.nodesById[op.id] = { ...node, position: { ...op.position } };
+    return next;
+  }
+
+  if (op.type === 'addEdge') {
+    const edge = op.edge;
+    if (next.edgesById[edge.id]) throw new Error(`Edge '${edge.id}' already exists`);
+    if (!next.nodesById[edge.fromNodeId] || !next.nodesById[edge.toNodeId]) {
+      throw new Error('Edge endpoint does not exist');
+    }
+    next.edgesById[edge.id] = { ...edge };
+    return next;
+  }
+
+  if (op.type === 'removeEdge') {
+    if (!next.edgesById[op.edgeId]) return next;
+    delete next.edgesById[op.edgeId];
+    return next;
+  }
+
+  throw new Error(`Unknown operation type: ${op.type}`);
+}

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -188,11 +188,13 @@ export function applyEditorOperation(em, op) {
 
   if (op.type === 'addEdge') {
     const edge = op.edge;
-    if (next.edgesById[edge.id]) throw new Error(`Edge '${edge.id}' already exists`);
+    const normalizedId = edgeId(edge.fromNodeId, edge.fromPort, edge.toNodeId, edge.toPort);
+    const normalizedEdge = { ...edge, id: normalizedId };
+    if (next.edgesById[normalizedId]) throw new Error(`Edge '${normalizedId}' already exists`);
     if (!next.nodesById[edge.fromNodeId] || !next.nodesById[edge.toNodeId]) {
       throw new Error('Edge endpoint does not exist');
     }
-    next.edgesById[edge.id] = { ...edge };
+    next.edgesById[normalizedId] = normalizedEdge;
     return next;
   }
 

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -128,6 +128,25 @@
       assertThrows(() => applyEditorOperation(em, { type: 'addEdge', edge: { id: 'a.out->none.in', fromNodeId: 'a', fromPort: 'out', toNodeId: 'none', toPort: 'in' } }));
     });
 
+
+    test('12b. addEdge は不正 id を normalized id で保存', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const edge = { id: 'wrong', fromNodeId: 't', fromPort: 't', toNodeId: 'wave', toPort: 't' };
+      const next = applyEditorOperation(em, { type: 'addEdge', edge });
+      assert(next.edgesById['t.t->wave.t']);
+      assert(!next.edgesById.wrong);
+    });
+
+    test('12c. editorModelToGraph は normalized edge から from/to を生成', () => {
+      const em = graphToEditorModel({ nodes: [{ id: 't', type: 'clock' }, { id: 'wave', type: 'sine' }], edges: [] });
+      const next = applyEditorOperation(em, {
+        type: 'addEdge',
+        edge: { id: 'wrong', fromNodeId: 't', fromPort: 't', toNodeId: 'wave', toPort: 't' }
+      });
+      const g = editorModelToGraph(next);
+      assertEqual(g.edges, [{ from: 't.t', to: 'wave.t' }]);
+    });
+
     test('13. layoutFallback column + deterministic', () => {
       const nodes = [
         { id: 'a', category: 'input', position: null },

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Loom Editor Model テスト</title>
+</head>
+<body>
+  <h1>Loom Editor Model テスト</h1>
+  <div id="results"></div>
+  <script type="module">
+    import { graphToEditorModel, editorModelToGraph, applyEditorOperation, layoutFallback } from "../src/loom-editor-model.js";
+
+    const results = [];
+    function test(name, fn) { results.push({ name, fn }); }
+    function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+    function assertEqual(a, b, msg) {
+      const av = JSON.stringify(a);
+      const bv = JSON.stringify(b);
+      if (av !== bv) throw new Error(msg || `expected ${bv}, got ${av}`);
+    }
+    function assertThrows(fn) {
+      let threw = false;
+      try { fn(); } catch (_) { threw = true; }
+      if (!threw) throw new Error('expected throw');
+    }
+
+    function sampleGraph() {
+      return {
+        nodes: [
+          { id: 't', type: 'clock' },
+          { id: 'wave', type: 'sine', params: { freq: 0.3 } },
+          { id: 'out', type: 'setVar', params: { key: 'v' } }
+        ],
+        edges: [
+          { from: 't.t', to: 'wave.t' },
+          { from: 'wave.out', to: 'out.value' }
+        ],
+        render: { type: 'point', x: 'wave.out', y: 'wave.out' }
+      };
+    }
+
+    test('1. roundtrip nodes/edges 等価', () => {
+      const g = sampleGraph();
+      const em = graphToEditorModel(g);
+      const out = editorModelToGraph(em, g);
+      assertEqual(out.nodes.map(n => n.id), g.nodes.map(n => n.id));
+      assertEqual(out.nodes.map(n => n.type), g.nodes.map(n => n.type));
+      assertEqual(out.edges, g.edges);
+    });
+
+    test('2. position 無しに layoutFallback', () => {
+      const em = graphToEditorModel(sampleGraph());
+      assertEqual(em.nodesById.t.position, { x: 0, y: 0 });
+      assertEqual(em.nodesById.wave.position, { x: 300, y: 0 });
+    });
+
+    test('3. meta.position が保持される', () => {
+      const g = sampleGraph();
+      g.nodes[1].meta = { position: { x: 11, y: 22 } };
+      const em = graphToEditorModel(g);
+      assertEqual(em.nodesById.wave.position, { x: 11, y: 22 });
+    });
+
+    test('4. edge id format deterministic', () => {
+      const em = graphToEditorModel(sampleGraph());
+      assert(em.edgesById['t.t->wave.t']);
+      assert(em.edgesById['wave.out->out.value']);
+    });
+
+    test('5. editorModelToGraph は order を反映', () => {
+      const em = graphToEditorModel(sampleGraph());
+      em.order = ['out', 'wave', 't'];
+      const g = editorModelToGraph(em);
+      assertEqual(g.nodes.map(n => n.id), ['out', 'wave', 't']);
+    });
+
+    test('6. editorModelToGraph は render 継承', () => {
+      const g = sampleGraph();
+      const em = graphToEditorModel(g);
+      const out = editorModelToGraph(em, g);
+      assertEqual(out.render, g.render);
+    });
+
+    test('7. addNode は order 末尾に追加', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'addNode', node: { id: 'n1', type: 'add', category: 'transform', params: {}, position: { x: 1, y: 2 } } });
+      assert(next.nodesById.n1);
+      assertEqual(next.order[next.order.length - 1], 'n1');
+    });
+
+    test('8. removeNode で関連 edge も削除', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'removeNode', id: 'wave' });
+      assert(!next.nodesById.wave);
+      assertEqual(Object.keys(next.edgesById).length, 0);
+    });
+
+    test('9. updateParam は対象のみ更新', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'updateParam', id: 'wave', key: 'freq', value: 0.9 });
+      assertEqual(next.nodesById.wave.params.freq, 0.9);
+      assertEqual(next.nodesById.out.params.key, 'v');
+    });
+
+    test('10. moveNode は position のみ更新', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'moveNode', id: 'wave', position: { x: 99, y: 88 } });
+      assertEqual(next.nodesById.wave.position, { x: 99, y: 88 });
+      assertEqual(next.nodesById.wave.params, em.nodesById.wave.params);
+    });
+
+    test('11. addEdge/removeEdge と冪等', () => {
+      let em = graphToEditorModel(sampleGraph());
+      em = applyEditorOperation(em, { type: 'addNode', node: { id: 'b', type: 'add', category: 'transform', params: {}, position: { x: 5, y: 5 } } });
+      const edge = { id: 't.t->b.a', fromNodeId: 't', fromPort: 't', toNodeId: 'b', toPort: 'a' };
+      let next = applyEditorOperation(em, { type: 'addEdge', edge });
+      assert(next.edgesById[edge.id]);
+      next = applyEditorOperation(next, { type: 'removeEdge', edgeId: edge.id });
+      assert(!next.edgesById[edge.id]);
+      const idempotent = applyEditorOperation(next, { type: 'removeEdge', edgeId: edge.id });
+      assertEqual(idempotent, next);
+    });
+
+    test('12. 不正 id は throw', () => {
+      const em = graphToEditorModel(sampleGraph());
+      assertThrows(() => applyEditorOperation(em, { type: 'updateParam', id: 'none', key: 'a', value: 1 }));
+      assertThrows(() => applyEditorOperation(em, { type: 'moveNode', id: 'none', position: { x: 0, y: 0 } }));
+      assertThrows(() => applyEditorOperation(em, { type: 'addEdge', edge: { id: 'a.out->none.in', fromNodeId: 'a', fromPort: 'out', toNodeId: 'none', toPort: 'in' } }));
+    });
+
+    test('13. layoutFallback column + deterministic', () => {
+      const nodes = [
+        { id: 'a', category: 'input', position: null },
+        { id: 'b', category: 'input', position: null },
+        { id: 'c', category: 'state', position: null },
+        { id: 'd', category: 'other', position: null }
+      ];
+      const one = layoutFallback(nodes);
+      const two = layoutFallback(nodes);
+      assertEqual(one, two);
+      assertEqual(one[0].position, { x: 0, y: 0 });
+      assertEqual(one[1].position, { x: 0, y: 120 });
+      assertEqual(one[2].position, { x: 600, y: 0 });
+      assertEqual(one[3].position, { x: 1200, y: 0 });
+    });
+
+    test('14. applyEditorOperation immutable', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const before = JSON.stringify(em);
+      const next = applyEditorOperation(em, { type: 'moveNode', id: 'wave', position: { x: 1, y: 1 } });
+      assert(JSON.stringify(em) === before, 'input unchanged');
+      assert(next !== em, 'new object');
+    });
+
+    async function run() {
+      let pass = 0; let fail = 0; const failures = [];
+      for (const t of results) {
+        try { await t.fn(); pass++; }
+        catch (e) { fail++; failures.push({ name: t.name, error: e.message }); }
+      }
+      window.__loomTestResults = { pass, fail, failures };
+      document.getElementById('results').textContent = `${pass} passed, ${fail} failed`;
+    }
+    run();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Introduce an Editor Model as a normalized, map-keyed visual layer between `GraphJSON` and a future Rete.js-based editor so the project can support deterministic editor state and future CRDT/Yjs integration. 
- Keep existing Source AST and GraphJSON APIs unchanged and avoid implementing DSL writeback in v1.

### Description

- Add `src/loom-editor-model.js` exporting `graphToEditorModel`, `editorModelToGraph`, `applyEditorOperation`, and `layoutFallback` with JSDoc types for `EditorNode`/`EditorEdge`/`EditorModel`/`EditorOperation`.
- Implement deterministic edge id generation as ``${from}.${fromPort}->${to}.${toPort}``, `meta.position` priority, and `layoutFallback` (category column x positions and 120px y spacing); unknown node types fallback to `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84e5252fc8320a19b9223e63ce53a)