### PR TITLE
feat(editor-studio): add DSL and node editor MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ out/
 ### Node.js / npm
 node_modules/
 package-lock.json
+*/dist/
 
 ### CI / Testing
 playwright-report/

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ npm run dev
 - `Generate DSL ← Node`: ノードエディタから正規形 DSL を生成
 - ノード操作：
   - ドラッグで移動
-  - パラメータ編集
   - エッジの接続・削除
 - Canvas preview：`render bar` / `render point` に対応
 - GraphJSON 表示 pane
@@ -223,7 +222,7 @@ npm run dev
 **設計方針：**
 - 手動同期: DSL ↔ Node は明示ボタン式（リアルタイム自動同期ではない）
 - Node → DSL は正規形（元のコメント・書式は保持しない）
-- EditorModel が single source of truth、Rete.js は view として扱う
+- EditorModel が single source of truth、カスタム SVG ノードエディタは view として扱う
 
 詳細は `editor-studio/src/` の実装と `test/loom-editor-studio.test.html` のテストを参照してください。
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Graph DSL → JSON graph → Web Loom / Unity Loom で評価
 |---|---|---|
 | シンプル版 (`editor/`) | [editor/](https://afjk.github.io/loom/editor/) | 依存ゼロ・軽量・textarea ベース |
 | **Pro 版** (`editor-pro/`) | [editor-pro/dist/](https://afjk.github.io/loom/editor-pro/dist/) | **補完・構文ハイライト・lint 付き、オーバーレイ UI** |
+| **Studio MVP** (`editor-studio/`) | Local dev: `npm run dev` | **DSL + ノードエディタ並行編集 MVP** |
 
 **シンプル版** はライブラリ依存ゼロで手軽に使えるテキストエリアベースのエディタです。
 
@@ -197,6 +198,35 @@ x = timer |> sine(freq: 0.3) |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 70
 
 詳細な仕様は **[docs/DSL.md](docs/DSL.md)** をご覧ください。
 
+### Editor Studio MVP
+
+`editor-studio` は、DSL とノードエディタを左右に並べた協調編集スタジオの MVP です。
+
+```bash
+cd editor-studio
+npm install
+npm run dev
+```
+
+**機能：**
+- DSL エディタ（CodeMirror）とノードエディタを左右2ペインで表示
+- `Apply DSL → Node`: DSL をパースしてノードエディタに反映
+- `Generate DSL ← Node`: ノードエディタから正規形 DSL を生成
+- ノード操作：
+  - ドラッグで移動
+  - パラメータ編集
+  - エッジの接続・削除
+- Canvas preview：`render bar` / `render point` に対応
+- GraphJSON 表示 pane
+- Errors pane
+
+**設計方針：**
+- 手動同期: DSL ↔ Node は明示ボタン式（リアルタイム自動同期ではない）
+- Node → DSL は正規形（元のコメント・書式は保持しない）
+- EditorModel が single source of truth、Rete.js は view として扱う
+
+詳細は `editor-studio/src/` の実装と `test/loom-editor-studio.test.html` のテストを参照してください。
+
 ## デモの確認方法
 
 GitHub Pages で公開されているデモを、ブラウザから直接確認できます。
@@ -221,6 +251,7 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 * integrate チャージゲージ：https://afjk.github.io/loom/examples/18-charge-gauge.html
 * **ライブエディタ（シンプル版）**：https://afjk.github.io/loom/editor/
 * **ライブエディタ（Pro 版）**：https://afjk.github.io/loom/editor-pro/dist/
+* **Studio MVP**：ローカルでのみ利用可能（`cd editor-studio && npm install && npm run dev`）
 * テスト結果：https://afjk.github.io/loom/test/loom.test.html
 
 ローカルで確認する場合は、ESM を使うため、ローカルファイル直接 (`file://`) ではなく HTTP サーバから配信する必要があります。

--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loom Editor Studio MVP</title>
+  <link rel="stylesheet" href="src/style.css">
+</head>
+<body>
+  <div id="app">
+    <div class="studio-container">
+      <!-- Left pane: DSL Editor -->
+      <div class="pane dsl-pane">
+        <div class="pane-header">
+          <h2>DSL Editor</h2>
+          <button id="applyDslBtn" class="btn btn-primary">Apply DSL → Node</button>
+        </div>
+        <div id="dsl-editor-host" class="dsl-editor-host"></div>
+      </div>
+
+      <!-- Right pane: Node Editor -->
+      <div class="pane node-pane">
+        <div class="pane-header">
+          <h2>Node Editor</h2>
+          <button id="generateDslBtn" class="btn btn-primary">Generate DSL ← Node</button>
+        </div>
+        <div id="node-editor" class="node-editor-canvas"></div>
+      </div>
+    </div>
+
+    <!-- Bottom pane: Preview, GraphJSON, Errors -->
+    <div class="bottom-pane">
+      <div class="tabs">
+        <button class="tab-btn active" data-tab="preview">Preview</button>
+        <button class="tab-btn" data-tab="graph">GraphJSON</button>
+        <button class="tab-btn" data-tab="errors">Errors</button>
+      </div>
+
+      <div class="tab-content">
+        <div id="preview-tab" class="tab-pane active">
+          <div class="controls">
+            <button id="runPreviewBtn" class="btn btn-success">Run Preview</button>
+            <button id="resetSampleBtn" class="btn">Reset Sample</button>
+          </div>
+          <canvas id="preview-canvas" width="800" height="300"></canvas>
+        </div>
+
+        <div id="graph-tab" class="tab-pane">
+          <pre id="graph-json" class="graph-json">
+          </pre>
+        </div>
+
+        <div id="errors-tab" class="tab-pane">
+          <div id="errors-list" class="errors-list"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/editor-studio/package.json
+++ b/editor-studio/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "editor-studio",
+  "version": "0.1.0",
+  "description": "Loom DSL + Node Editor Studio",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@codemirror/commands": "^6.2.5",
+    "@codemirror/lang-javascript": "^6.2.2",
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/language": "^6.9.1",
+    "@codemirror/search": "^6.5.4",
+    "@codemirror/state": "^6.2.1",
+    "@codemirror/view": "^6.17.0",
+    "@codemirror/autocomplete": "^6.10.0",
+    "@codemirror/lint": "^6.4.1",
+    "@codemirror/theme-one-dark": "^6.1.2",
+    "vite": "^5.0.0"
+  },
+  "devDependencies": {}
+}

--- a/editor-studio/src/canonical-dsl.js
+++ b/editor-studio/src/canonical-dsl.js
@@ -56,19 +56,19 @@ export function graphToCanonicalDSL(graph) {
     const renderArgs = [];
 
     if (graph.render.width !== undefined) {
-      renderArgs.push(formatParam('width', graph.render.width));
+      renderArgs.push(formatRenderParam('width', graph.render.width));
     }
     if (graph.render.height !== undefined) {
-      renderArgs.push(formatParam('height', graph.render.height));
+      renderArgs.push(formatRenderParam('height', graph.render.height));
     }
     if (graph.render.color !== undefined) {
-      renderArgs.push(formatParam('color', graph.render.color));
+      renderArgs.push(formatRenderParam('color', graph.render.color));
     }
     if (graph.render.x !== undefined) {
-      renderArgs.push(formatParam('x', graph.render.x));
+      renderArgs.push(formatRenderParam('x', graph.render.x));
     }
     if (graph.render.y !== undefined) {
-      renderArgs.push(formatParam('y', graph.render.y));
+      renderArgs.push(formatRenderParam('y', graph.render.y));
     }
 
     lines.push('');
@@ -96,4 +96,12 @@ function formatValue(val) {
 
 function formatParam(name, value) {
   return `${name}: ${formatValue(value)}`;
+}
+
+// For render params: nodeId.portName references become bare identifiers (e.g. "width.out" → width)
+function formatRenderParam(name, value) {
+  if (typeof value === 'string' && /^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    return `${name}: ${value.split('.')[0]}`;
+  }
+  return formatParam(name, value);
 }

--- a/editor-studio/src/canonical-dsl.js
+++ b/editor-studio/src/canonical-dsl.js
@@ -17,36 +17,27 @@ export function graphToCanonicalDSL(graph) {
     }
 
     const params = { ...node.params };
-    const args = [];
     const inputNames = (nodeType.inputs || []).map(inp => inp.name || inp);
+    const paramNames = (nodeType.params || []).map(p => p.name || p);
 
+    // All args are emitted as named to avoid positional-arg restrictions in the compiler
+    // (non-commutative nodes allow at most 1 positional; commutative disallows mixing).
+    const allNamedArgs = [];
     for (const inputName of inputNames) {
       if (inputEdges[inputName]) {
-        args.push(inputEdges[inputName]);
+        allNamedArgs.push(formatParam(inputName, inputEdges[inputName]));
       } else if (params[inputName] !== undefined) {
-        args.push(params[inputName]);
+        allNamedArgs.push(formatParam(inputName, params[inputName]));
         delete params[inputName];
       }
     }
-
-    const namedArgs = [];
-    const paramNames = (nodeType.params || []).map(p => p.name || p);
     for (const paramName of Object.keys(params)) {
       if (paramNames.includes(paramName)) {
-        const value = params[paramName];
-        namedArgs.push(formatParam(paramName, value));
+        allNamedArgs.push(formatParam(paramName, params[paramName]));
       }
     }
 
-    let callStr = `${node.type}(`;
-    const allArgs = [];
-    for (const arg of args) {
-      allArgs.push(formatValue(arg));
-    }
-    for (const namedArg of namedArgs) {
-      allArgs.push(namedArg);
-    }
-    callStr += allArgs.join(', ') + ')';
+    const callStr = `${node.type}(${allNamedArgs.join(', ')})`;
 
     lines.push(`${node.id} = ${callStr}`);
   }

--- a/editor-studio/src/canonical-dsl.js
+++ b/editor-studio/src/canonical-dsl.js
@@ -1,0 +1,99 @@
+import { NODE_TYPES } from '../../src/loom.js';
+
+export function graphToCanonicalDSL(graph) {
+  const lines = [];
+
+  for (const node of graph.nodes || []) {
+    const nodeType = NODE_TYPES[node.type];
+    if (!nodeType) continue;
+
+    const inputEdges = {};
+    for (const edge of graph.edges || []) {
+      if (edge.to.startsWith(node.id + '.')) {
+        const [, toPort] = edge.to.split('.');
+        const [fromNodeId] = edge.from.split('.');
+        inputEdges[toPort] = fromNodeId;
+      }
+    }
+
+    const params = { ...node.params };
+    const args = [];
+    const inputNames = (nodeType.inputs || []).map(inp => inp.name || inp);
+
+    for (const inputName of inputNames) {
+      if (inputEdges[inputName]) {
+        args.push(inputEdges[inputName]);
+      } else if (params[inputName] !== undefined) {
+        args.push(params[inputName]);
+        delete params[inputName];
+      }
+    }
+
+    const namedArgs = [];
+    const paramNames = (nodeType.params || []).map(p => p.name || p);
+    for (const paramName of Object.keys(params)) {
+      if (paramNames.includes(paramName)) {
+        const value = params[paramName];
+        namedArgs.push(formatParam(paramName, value));
+      }
+    }
+
+    let callStr = `${node.type}(`;
+    const allArgs = [];
+    for (const arg of args) {
+      allArgs.push(formatValue(arg));
+    }
+    for (const namedArg of namedArgs) {
+      allArgs.push(namedArg);
+    }
+    callStr += allArgs.join(', ') + ')';
+
+    lines.push(`${node.id} = ${callStr}`);
+  }
+
+  if (graph.render) {
+    const renderType = graph.render.type || 'bar';
+    const renderArgs = [];
+
+    if (graph.render.width !== undefined) {
+      renderArgs.push(formatParam('width', graph.render.width));
+    }
+    if (graph.render.height !== undefined) {
+      renderArgs.push(formatParam('height', graph.render.height));
+    }
+    if (graph.render.color !== undefined) {
+      renderArgs.push(formatParam('color', graph.render.color));
+    }
+    if (graph.render.x !== undefined) {
+      renderArgs.push(formatParam('x', graph.render.x));
+    }
+    if (graph.render.y !== undefined) {
+      renderArgs.push(formatParam('y', graph.render.y));
+    }
+
+    lines.push('');
+    lines.push(`render ${renderType}(${renderArgs.join(', ')})`);
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function formatValue(val) {
+  if (val === null || val === undefined) {
+    return 'null';
+  }
+  if (typeof val === 'string') {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(val)) {
+      return val;
+    }
+    return `"${val.replace(/"/g, '\\"')}"`;
+  }
+  if (typeof val === 'number' || typeof val === 'boolean') {
+    return String(val);
+  }
+  return JSON.stringify(val);
+}
+
+function formatParam(name, value) {
+  return `${name}: ${formatValue(value)}`;
+}

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1,0 +1,253 @@
+import { EditorState } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+import { defaultKeymap } from '@codemirror/commands';
+import { json } from '@codemirror/lang-json';
+
+import { Loom } from '../../src/loom.js';
+import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
+import { graphToEditorModel, editorModelToGraph, applyEditorOperation } from '../../src/loom-editor-model.js';
+import { graphToCanonicalDSL } from './canonical-dsl.js';
+import { createStore } from './studio-store.js';
+import { NodeEditorView } from './rete-view.js';
+
+const SAMPLE_DSL = `t = clock()
+wave = sine(t, freq: 0.35)
+smooth = smoothLerp(wave, rate: 5, initial: 0)
+width = map(smooth, inMin: -1, inMax: 1, outMin: 80, outMax: 680, clamp: true)
+
+render bar(width: width, color: "#80ed99", height: 48)
+`;
+
+const store = createStore();
+let dslEditor = null;
+let nodeEditor = null;
+let engine = null;
+let animationFrameId = null;
+
+const elements = {
+  dslEditorHost: document.getElementById('dsl-editor-host'),
+  nodeEditorHost: document.getElementById('node-editor'),
+  previewCanvas: document.getElementById('preview-canvas'),
+  graphJson: document.getElementById('graph-json'),
+  errorsList: document.getElementById('errors-list'),
+  applyDslBtn: document.getElementById('applyDslBtn'),
+  generateDslBtn: document.getElementById('generateDslBtn'),
+  runPreviewBtn: document.getElementById('runPreviewBtn'),
+  resetSampleBtn: document.getElementById('resetSampleBtn'),
+  tabBtns: document.querySelectorAll('.tab-btn'),
+  tabPanes: document.querySelectorAll('.tab-pane')
+};
+
+function initDslEditor() {
+  const initialState = EditorState.create({
+    doc: SAMPLE_DSL,
+    extensions: [
+      keymap.of(defaultKeymap),
+      EditorView.lineNumbers(),
+      EditorView.theme({
+        '&': { height: '100%' },
+        '.cm-scroller': { overflow: 'auto' }
+      })
+    ]
+  });
+
+  dslEditor = new EditorView({
+    state: initialState,
+    parent: elements.dslEditorHost
+  });
+}
+
+function getDslText() {
+  return dslEditor ? dslEditor.state.doc.toString() : '';
+}
+
+function setDslText(text) {
+  if (dslEditor) {
+    const changes = dslEditor.state.doc.length > 0
+      ? { from: 0, to: dslEditor.state.doc.length, insert: text }
+      : { from: 0, insert: text };
+    dslEditor.dispatch({ changes });
+  }
+}
+
+function applyDsl() {
+  const sourceText = getDslText();
+  const { ast, errors: parseErrors } = parseDSLToAST(sourceText);
+
+  if (parseErrors.length) {
+    store.setState({ errors: parseErrors });
+    renderErrors();
+    return;
+  }
+
+  const { graph, errors: compileErrors } = compileToGraph(ast);
+  if (compileErrors.length) {
+    store.setState({ errors: compileErrors });
+    renderErrors();
+    return;
+  }
+
+  const editorModel = graphToEditorModel(graph);
+
+  store.setState({
+    sourceText,
+    sourceAst: ast,
+    graph,
+    editorModel,
+    errors: []
+  });
+
+  nodeEditor?.render(editorModel);
+  renderGraphJSON(graph);
+  renderErrors();
+  runPreview(graph);
+}
+
+function generateDsl() {
+  const state = store.getState();
+  if (!state.editorModel) return;
+
+  const graph = editorModelToGraph(state.editorModel, state.graph);
+  const dsl = graphToCanonicalDSL(graph);
+
+  setDslText(dsl);
+  store.setState({
+    sourceText: dsl,
+    graph,
+    errors: []
+  });
+
+  renderGraphJSON(graph);
+  renderErrors();
+  runPreview(graph);
+}
+
+function renderGraphJSON(graph) {
+  const json = JSON.stringify(graph, null, 2);
+  elements.graphJson.textContent = json;
+}
+
+function renderErrors() {
+  const state = store.getState();
+  const html = state.errors.map(err => {
+    const line = err.line ? `:${err.line}` : '';
+    const col = err.column ? `:${err.column}` : '';
+    return `<div class="error-item"><strong>${err.code || 'ERROR'}${line}${col}</strong>: ${err.message}</div>`;
+  }).join('');
+  elements.errorsList.innerHTML = html || '<div class="error-item">No errors</div>';
+}
+
+function runPreview(graph) {
+  const state = store.getState();
+  if (!graph) graph = state.graph;
+  if (!graph) return;
+
+  try {
+    engine = new Loom(graph);
+    animationFrameId = requestAnimationFrame(() => {
+      tick(engine, graph);
+    });
+  } catch (err) {
+    store.setState({ errors: [{ message: `Preview error: ${err.message}`, code: 'RUNTIME_ERROR' }] });
+    renderErrors();
+  }
+}
+
+function tick(engine, graph) {
+  const canvas = elements.previewCanvas;
+  const ctx = canvas.getContext('2d');
+
+  if (engine) {
+    const currentRender = graph?.render;
+    const trail = currentRender?.trail !== undefined ? currentRender.trail : 0.1;
+
+    if (trail > 0) {
+      ctx.fillStyle = `rgba(0, 0, 0, ${trail})`;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    if (currentRender?.type === 'point') {
+      const x = resolveValue(engine, currentRender.x);
+      const y = resolveValue(engine, currentRender.y);
+      const color = currentRender.color || '#00ff00';
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      if (x !== null && y !== null) {
+        ctx.arc(x, y, 4, 0, Math.PI * 2);
+      } else {
+        ctx.arc(canvas.width / 2, canvas.height / 2, 4, 0, Math.PI * 2);
+      }
+      ctx.fill();
+    } else if (currentRender?.type === 'bar') {
+      const width = resolveValue(engine, currentRender.width);
+      const color = currentRender.color || '#00ccff';
+      const height = currentRender.height !== undefined ? currentRender.height : 40;
+      const y = currentRender.y !== undefined ? resolveValue(engine, currentRender.y) : (canvas.height - height) / 2;
+      if (width !== null && y !== null) {
+        ctx.fillStyle = color;
+        ctx.fillRect(0, y, width, height);
+      }
+    } else {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+  }
+
+  animationFrameId = requestAnimationFrame(() => tick(engine, graph));
+}
+
+function resolveValue(engine, ref) {
+  if (typeof ref === 'number') return ref;
+  if (ref === null || ref === undefined) return null;
+  const numVal = parseFloat(ref);
+  if (!isNaN(numVal) && String(ref).trim() === String(numVal)) return numVal;
+  return engine.getValue(ref);
+}
+
+function resetSample() {
+  setDslText(SAMPLE_DSL);
+  applyDsl();
+}
+
+function setupEventListeners() {
+  elements.applyDslBtn.addEventListener('click', applyDsl);
+  elements.generateDslBtn.addEventListener('click', generateDsl);
+  elements.runPreviewBtn.addEventListener('click', () => {
+    const state = store.getState();
+    if (animationFrameId) cancelAnimationFrame(animationFrameId);
+    runPreview(state.graph);
+  });
+  elements.resetSampleBtn.addEventListener('click', resetSample);
+
+  elements.tabBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tabName = btn.getAttribute('data-tab');
+      elements.tabBtns.forEach(b => b.classList.remove('active'));
+      elements.tabPanes.forEach(p => p.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(`${tabName}-tab`)?.classList.add('active');
+    });
+  });
+}
+
+function init() {
+  initDslEditor();
+  nodeEditor = new NodeEditorView(elements.nodeEditorHost, (operation) => {
+    const state = store.getState();
+    if (!state.editorModel) return;
+
+    const newModel = applyEditorOperation(state.editorModel, operation);
+    store.setState({ editorModel: newModel });
+    nodeEditor?.render(newModel);
+
+    const graph = editorModelToGraph(newModel, state.graph);
+    store.setState({ graph });
+    renderGraphJSON(graph);
+    runPreview(graph);
+  });
+
+  setupEventListeners();
+  applyDsl();
+}
+
+init();

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -8,7 +8,7 @@ import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
 import { graphToEditorModel, editorModelToGraph, applyEditorOperation } from '../../src/loom-editor-model.js';
 import { graphToCanonicalDSL } from './canonical-dsl.js';
 import { createStore } from './studio-store.js';
-import { NodeEditorView } from './rete-view.js';
+import { NodeEditorView } from './node-editor-view.js';
 
 const SAMPLE_DSL = `t = clock()
 wave = sine(t, freq: 0.35)
@@ -138,6 +138,11 @@ function renderErrors() {
 }
 
 function runPreview(graph) {
+  if (animationFrameId) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+
   const state = store.getState();
   if (!graph) graph = state.graph;
   if (!graph) return;

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -221,7 +221,7 @@ export class NodeEditorView {
         }
 
         portY = 45;
-        for (const outputName of ['output'] || []) {
+        for (const outputName of (nodeType.outputs || []).map(o => o.name || o)) {
           const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
           circle.setAttribute('cx', node.position.x + nodeWidth);
           circle.setAttribute('cy', node.position.y + portY);
@@ -246,7 +246,7 @@ export class NodeEditorView {
                   edge: {
                     id: '',
                     fromNodeId: nodeId,
-                    fromPort: 'output',
+                    fromPort: outputName,
                     toNodeId: this.connectFromNodeId,
                     toPort: this.connectFromPort
                   }
@@ -257,7 +257,7 @@ export class NodeEditorView {
             } else {
               this.isConnecting = true;
               this.connectFromNodeId = nodeId;
-              this.connectFromPort = 'output';
+              this.connectFromPort = outputName;
               const tempLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
               tempLine.setAttribute('x1', node.position.x + nodeWidth);
               tempLine.setAttribute('y1', node.position.y + portY);

--- a/editor-studio/src/rete-view.js
+++ b/editor-studio/src/rete-view.js
@@ -1,0 +1,292 @@
+import { NODE_TYPES } from '../../src/loom.js';
+import { applyEditorOperation } from '../../src/loom-editor-model.js';
+
+export class NodeEditorView {
+  constructor(container, onOperation) {
+    this.container = container;
+    this.onOperation = onOperation;
+    this.selectedNodeId = null;
+    this.draggedNode = null;
+    this.dragStartX = 0;
+    this.dragStartY = 0;
+    this.isConnecting = false;
+    this.connectFromNodeId = null;
+    this.connectFromPort = null;
+    this.editorModel = null;
+    this.scale = 1;
+    this.offsetX = 0;
+    this.offsetY = 0;
+
+    this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    this.svg.setAttribute('width', '100%');
+    this.svg.setAttribute('height', '100%');
+    this.svg.style.cursor = 'grab';
+    this.container.innerHTML = '';
+    this.container.appendChild(this.svg);
+
+    this.edgesGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.nodesGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.tempLineGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+    this.svg.appendChild(this.edgesGroup);
+    this.svg.appendChild(this.nodesGroup);
+    this.svg.appendChild(this.tempLineGroup);
+
+    this.setupEventListeners();
+  }
+
+  setupEventListeners() {
+    this.svg.addEventListener('mousedown', (e) => {
+      if (e.target === this.svg) {
+        this.dragStartX = e.clientX;
+        this.dragStartY = e.clientY;
+        this.svg.style.cursor = 'grabbing';
+      }
+    });
+
+    this.svg.addEventListener('mousemove', (e) => {
+      if (e.buttons === 1 && this.dragStartX !== 0) {
+        this.offsetX += e.clientX - this.dragStartX;
+        this.offsetY += e.clientY - this.dragStartY;
+        this.dragStartX = e.clientX;
+        this.dragStartY = e.clientY;
+        this.render();
+      }
+
+      if (this.isConnecting) {
+        const tempLine = this.tempLineGroup.querySelector('line');
+        if (tempLine) {
+          tempLine.setAttribute('x2', e.clientX - this.offsetX);
+          tempLine.setAttribute('y2', e.clientY - this.offsetY);
+        }
+      }
+    });
+
+    this.svg.addEventListener('mouseup', () => {
+      this.dragStartX = 0;
+      this.dragStartY = 0;
+      this.svg.style.cursor = 'grab';
+      this.isConnecting = false;
+    });
+  }
+
+  render(editorModel) {
+    if (editorModel) {
+      this.editorModel = editorModel;
+    }
+    if (!this.editorModel) return;
+
+    this.edgesGroup.innerHTML = '';
+    this.nodesGroup.innerHTML = '';
+
+    const nodeWidth = 200;
+    const nodeHeight = 100;
+    const portRadius = 6;
+    const portSpacing = 25;
+
+    for (const edge of Object.values(this.editorModel.edgesById)) {
+      const fromNode = this.editorModel.nodesById[edge.fromNodeId];
+      const toNode = this.editorModel.nodesById[edge.toNodeId];
+      if (!fromNode || !toNode) continue;
+
+      const x1 = fromNode.position.x + nodeWidth;
+      const y1 = fromNode.position.y + 50;
+      const x2 = toNode.position.x;
+      const y2 = toNode.position.y + 50;
+
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      line.setAttribute('x1', x1);
+      line.setAttribute('y1', y1);
+      line.setAttribute('x2', x2);
+      line.setAttribute('y2', y2);
+      line.setAttribute('stroke', '#999');
+      line.setAttribute('stroke-width', '2');
+      line.setAttribute('data-edge-id', edge.id);
+      line.style.cursor = 'pointer';
+
+      line.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.onOperation({ type: 'removeEdge', edgeId: edge.id });
+      });
+
+      this.edgesGroup.appendChild(line);
+    }
+
+    for (const nodeId of this.editorModel.order) {
+      const node = this.editorModel.nodesById[nodeId];
+      if (!node) continue;
+
+      const isSelected = nodeId === this.selectedNodeId;
+      const nodeGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+      const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('x', node.position.x);
+      rect.setAttribute('y', node.position.y);
+      rect.setAttribute('width', nodeWidth);
+      rect.setAttribute('height', nodeHeight);
+      rect.setAttribute('fill', isSelected ? '#4a90e2' : '#333');
+      rect.setAttribute('stroke', isSelected ? '#fff' : '#999');
+      rect.setAttribute('stroke-width', '2');
+      rect.setAttribute('rx', '4');
+      rect.style.cursor = 'move';
+
+      rect.addEventListener('mousedown', (e) => {
+        e.stopPropagation();
+        this.selectedNodeId = nodeId;
+        this.draggedNode = node;
+        this.dragStartX = e.clientX;
+        this.dragStartY = e.clientY;
+        this.render();
+      });
+
+      rect.addEventListener('mousemove', (e) => {
+        if (this.draggedNode === node && e.buttons === 1) {
+          const dx = e.clientX - this.dragStartX;
+          const dy = e.clientY - this.dragStartY;
+          this.onOperation({
+            type: 'moveNode',
+            id: nodeId,
+            position: { x: node.position.x + dx, y: node.position.y + dy }
+          });
+          this.dragStartX = e.clientX;
+          this.dragStartY = e.clientY;
+        }
+      });
+
+      nodeGroup.appendChild(rect);
+
+      const titleText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      titleText.setAttribute('x', node.position.x + 10);
+      titleText.setAttribute('y', node.position.y + 25);
+      titleText.setAttribute('fill', '#fff');
+      titleText.setAttribute('font-size', '14');
+      titleText.setAttribute('font-weight', 'bold');
+      titleText.textContent = node.type;
+      nodeGroup.appendChild(titleText);
+
+      const nodeType = NODE_TYPES[node.type];
+      if (nodeType) {
+        let portY = 45;
+
+        for (const inputName of nodeType.inputs || []) {
+          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          circle.setAttribute('cx', node.position.x);
+          circle.setAttribute('cy', node.position.y + portY);
+          circle.setAttribute('r', portRadius);
+          circle.setAttribute('fill', '#666');
+          circle.style.cursor = 'pointer';
+
+          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          label.setAttribute('x', node.position.x + 15);
+          label.setAttribute('y', node.position.y + portY + 4);
+          label.setAttribute('fill', '#aaa');
+          label.setAttribute('font-size', '12');
+          label.textContent = inputName;
+
+          circle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (this.isConnecting) {
+              if (this.connectFromNodeId !== nodeId) {
+                this.onOperation({
+                  type: 'addEdge',
+                  edge: {
+                    id: '',
+                    fromNodeId: this.connectFromNodeId,
+                    fromPort: this.connectFromPort,
+                    toNodeId: nodeId,
+                    toPort: inputName
+                  }
+                });
+              }
+              this.isConnecting = false;
+              this.tempLineGroup.innerHTML = '';
+            } else {
+              this.isConnecting = true;
+              this.connectFromNodeId = nodeId;
+              this.connectFromPort = inputName;
+              const tempLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+              tempLine.setAttribute('x1', node.position.x);
+              tempLine.setAttribute('y1', node.position.y + portY);
+              tempLine.setAttribute('x2', node.position.x);
+              tempLine.setAttribute('y2', node.position.y + portY);
+              tempLine.setAttribute('stroke', '#4a90e2');
+              tempLine.setAttribute('stroke-width', '2');
+              this.tempLineGroup.appendChild(tempLine);
+            }
+          });
+
+          nodeGroup.appendChild(circle);
+          nodeGroup.appendChild(label);
+          portY += portSpacing;
+        }
+
+        portY = 45;
+        for (const outputName of ['output'] || []) {
+          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          circle.setAttribute('cx', node.position.x + nodeWidth);
+          circle.setAttribute('cy', node.position.y + portY);
+          circle.setAttribute('r', portRadius);
+          circle.setAttribute('fill', '#4a90e2');
+          circle.style.cursor = 'pointer';
+
+          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          label.setAttribute('x', node.position.x + nodeWidth - 50);
+          label.setAttribute('y', node.position.y + portY + 4);
+          label.setAttribute('fill', '#aaa');
+          label.setAttribute('font-size', '12');
+          label.setAttribute('text-anchor', 'end');
+          label.textContent = outputName;
+
+          circle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (this.isConnecting) {
+              if (this.connectFromNodeId !== nodeId) {
+                this.onOperation({
+                  type: 'addEdge',
+                  edge: {
+                    id: '',
+                    fromNodeId: nodeId,
+                    fromPort: 'output',
+                    toNodeId: this.connectFromNodeId,
+                    toPort: this.connectFromPort
+                  }
+                });
+              }
+              this.isConnecting = false;
+              this.tempLineGroup.innerHTML = '';
+            } else {
+              this.isConnecting = true;
+              this.connectFromNodeId = nodeId;
+              this.connectFromPort = 'output';
+              const tempLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+              tempLine.setAttribute('x1', node.position.x + nodeWidth);
+              tempLine.setAttribute('y1', node.position.y + portY);
+              tempLine.setAttribute('x2', node.position.x + nodeWidth);
+              tempLine.setAttribute('y2', node.position.y + portY);
+              tempLine.setAttribute('stroke', '#4a90e2');
+              tempLine.setAttribute('stroke-width', '2');
+              this.tempLineGroup.appendChild(tempLine);
+            }
+          });
+
+          nodeGroup.appendChild(circle);
+          nodeGroup.appendChild(label);
+        }
+
+        let paramY = 45;
+        for (const [paramName, paramValue] of Object.entries(node.params || {})) {
+          const paramLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          paramLabel.setAttribute('x', node.position.x + 10);
+          paramLabel.setAttribute('y', node.position.y + paramY);
+          paramLabel.setAttribute('fill', '#aaa');
+          paramLabel.setAttribute('font-size', '11');
+          paramLabel.textContent = `${paramName}: ${JSON.stringify(paramValue).substring(0, 15)}`;
+          nodeGroup.appendChild(paramLabel);
+          paramY += 15;
+        }
+      }
+
+      this.nodesGroup.appendChild(nodeGroup);
+    }
+  }
+}

--- a/editor-studio/src/studio-store.js
+++ b/editor-studio/src/studio-store.js
@@ -1,0 +1,36 @@
+export function createStore() {
+  const state = {
+    sourceText: '',
+    sourceAst: null,
+    graph: null,
+    editorModel: null,
+    errors: [],
+    engine: null,
+    isRendering: false
+  };
+
+  const listeners = [];
+
+  return {
+    getState() {
+      return state;
+    },
+
+    setState(updates) {
+      Object.assign(state, updates);
+      this.notify();
+    },
+
+    subscribe(listener) {
+      listeners.push(listener);
+      return () => {
+        const idx = listeners.indexOf(listener);
+        if (idx !== -1) listeners.splice(idx, 1);
+      };
+    },
+
+    notify() {
+      listeners.forEach(l => l(state));
+    }
+  };
+}

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1,0 +1,275 @@
+:root {
+  --bg-dark: #1a1a1a;
+  --bg-lighter: #2a2a2a;
+  --border-color: #444;
+  --text-color: #e0e0e0;
+  --text-dim: #999;
+  --primary-color: #4a90e2;
+  --success-color: #4caf50;
+  --error-color: #f44336;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background: var(--bg-dark);
+  color: var(--text-color);
+}
+
+#app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.studio-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  flex: 1;
+  min-height: 0;
+  background: var(--border-color);
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-lighter);
+  min-height: 0;
+}
+
+.pane-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-dark);
+}
+
+.pane-header h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.dsl-editor-host {
+  flex: 1;
+  overflow: hidden;
+}
+
+.dsl-editor-host .cm-editor {
+  height: 100%;
+  background: var(--bg-lighter) !important;
+}
+
+.node-editor-canvas {
+  flex: 1;
+  background: var(--bg-lighter);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
+.bottom-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 300px;
+  background: var(--bg-lighter);
+  border-top: 1px solid var(--border-color);
+  min-height: 0;
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-dark);
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 10px 16px;
+  background: var(--bg-dark);
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.tab-btn:hover {
+  color: var(--text-color);
+}
+
+.tab-btn.active {
+  color: var(--primary-color);
+  border-bottom-color: var(--primary-color);
+}
+
+.tab-content {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+}
+
+.tab-pane {
+  width: 100%;
+  overflow: auto;
+  display: none;
+  flex-direction: column;
+}
+
+.tab-pane.active {
+  display: flex;
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-dark);
+  flex-shrink: 0;
+}
+
+#preview-canvas {
+  flex: 1;
+  background: #000;
+  display: block;
+}
+
+.graph-json {
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 12px;
+  overflow: auto;
+  flex: 1;
+  background: var(--bg-lighter);
+  color: #7fbf7f;
+}
+
+.errors-list {
+  padding: 12px;
+  overflow: auto;
+  flex: 1;
+}
+
+.error-item {
+  padding: 8px;
+  margin-bottom: 4px;
+  background: rgba(244, 67, 54, 0.1);
+  border-left: 3px solid var(--error-color);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.error-item strong {
+  color: var(--error-color);
+}
+
+.btn {
+  padding: 6px 12px;
+  background: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--border-color);
+  border-color: var(--text-dim);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn-primary {
+  color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.btn-primary:hover {
+  background: rgba(74, 144, 226, 0.1);
+}
+
+.btn-success {
+  color: var(--success-color);
+  border-color: var(--success-color);
+}
+
+.btn-success:hover {
+  background: rgba(76, 175, 80, 0.1);
+}
+
+/* CodeMirror theme adjustments */
+.cm-editor {
+  --cm-bg: var(--bg-lighter);
+  --cm-text: var(--text-color);
+}
+
+.cm-gutters {
+  background: var(--bg-dark) !important;
+  border-right: 1px solid var(--border-color) !important;
+}
+
+.cm-activeLineGutter {
+  background: var(--border-color) !important;
+}
+
+.cm-cursor {
+  border-left-color: var(--text-color) !important;
+}
+
+.cm-selectionBackground {
+  background: rgba(74, 144, 226, 0.3) !important;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .studio-container {
+    grid-template-columns: 1fr;
+  }
+
+  .pane {
+    min-height: 300px;
+  }
+}
+
+@media (max-width: 768px) {
+  .studio-container {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .pane {
+    min-height: 250px;
+  }
+
+  .bottom-pane {
+    flex: 0 0 200px;
+  }
+
+  .controls {
+    flex-wrap: wrap;
+  }
+
+  .btn {
+    flex: 1;
+    min-width: 100px;
+  }
+}

--- a/editor-studio/vite.config.js
+++ b/editor-studio/vite.config.js
@@ -1,0 +1,7 @@
+export default {
+  root: '.',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+};

--- a/test/loom-editor-studio.test.html
+++ b/test/loom-editor-studio.test.html
@@ -89,10 +89,43 @@
       assert(!dsl.includes('render'), 'should not include render when absent');
     });
 
+    test('6. render width reference is not string-literal (node reference as identifier)', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      // 'width.out' must become the identifier `width`, not the string "width.out"
+      assert(!dsl.includes('"width'), 'render width ref must not be a quoted string');
+      assert(dsl.includes('width: width'), 'render width should reference node id as bare identifier');
+    });
+
+    test('7. graphToCanonicalDSL → parseDSLToAST → compileToGraph preserves edges', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      const { ast } = parseDSLToAST(dsl);
+      const { graph: newGraph } = compileToGraph(ast);
+      assertEqual(newGraph.edges.length, graph.edges.length, 'should preserve edge count');
+      // Each original destination port must be reachable in the round-tripped graph
+      for (const origEdge of graph.edges) {
+        const found = newGraph.edges.some(e => e.to === origEdge.to);
+        assert(found, `edge to ${origEdge.to} should be preserved after round-trip`);
+      }
+    });
+
+    test('8. graphToCanonicalDSL → compileToGraph preserves render.width reference', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      const { ast } = parseDSLToAST(dsl);
+      const { graph: newGraph } = compileToGraph(ast);
+      assert(newGraph.render, 'round-tripped graph should have render');
+      assertEqual(newGraph.render.type, graph.render.type, 'render type should be preserved');
+      // compileToGraph resolves identifiers to nodeId.portName references
+      assertEqual(newGraph.render.width, graph.render.width, 'render width ref should round-trip to width.out');
+    });
+
     // Run tests
     let passed = 0;
     let failed = 0;
     const resultsList = [];
+    const failedItems = [];
 
     for (const { name, fn } of results) {
       try {
@@ -102,6 +135,7 @@
       } catch (err) {
         failed++;
         resultsList.push(`<li style="color: red;">✗ ${name}: ${err.message}</li>`);
+        failedItems.push({ name, message: err.message });
       }
     }
 
@@ -110,6 +144,12 @@
       <ul>${resultsList.join('')}</ul>
     `;
     document.getElementById('results').innerHTML = html;
+
+    window.__loomTestResults = {
+      pass: passed,
+      fail: failed,
+      failures: failedItems
+    };
   </script>
 </body>
 </html>

--- a/test/loom-editor-studio.test.html
+++ b/test/loom-editor-studio.test.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Loom Editor Studio テスト</title>
+</head>
+<body>
+  <h1>Loom Editor Studio テスト</h1>
+  <div id="results"></div>
+  <script type="module">
+    import { graphToCanonicalDSL } from "../editor-studio/src/canonical-dsl.js";
+    import { parseDSLToAST, compileToGraph } from "../src/loom-dsl.js";
+    import { graphToEditorModel, editorModelToGraph } from "../src/loom-editor-model.js";
+
+    const results = [];
+    function test(name, fn) { results.push({ name, fn }); }
+    function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+    function assertEqual(a, b, msg) {
+      const av = JSON.stringify(a);
+      const bv = JSON.stringify(b);
+      if (av !== bv) throw new Error(msg || `expected ${bv}, got ${av}`);
+    }
+
+    function sampleGraph() {
+      return {
+        nodes: [
+          { id: 't', type: 'clock' },
+          { id: 'wave', type: 'sine', params: { freq: 0.35 } },
+          { id: 'smooth', type: 'smoothLerp', params: { rate: 5, initial: 0 } },
+          { id: 'width', type: 'map', params: { inMin: -1, inMax: 1, outMin: 80, outMax: 680, clamp: true } }
+        ],
+        edges: [
+          { from: 't.t', to: 'wave.t' },
+          { from: 'wave.out', to: 'smooth.value' },
+          { from: 'smooth.out', to: 'width.value' }
+        ],
+        render: { type: 'bar', width: 'width.out', color: '#80ed99', height: 48 }
+      };
+    }
+
+    test('1. graphToCanonicalDSL produces valid DSL', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      assert(dsl.includes('t = clock()'), 'should include clock');
+      assert(dsl.includes('wave = sine('), 'should include sine');
+      assert(dsl.includes('smooth = smoothLerp('), 'should include smoothLerp');
+      assert(dsl.includes('width = map('), 'should include map');
+      assert(dsl.includes('render bar('), 'should include render bar');
+      assert(dsl.endsWith('\n'), 'should end with newline');
+    });
+
+    test('2. graphToCanonicalDSL round-trip parses correctly', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      const { ast, errors } = parseDSLToAST(dsl);
+      assert(errors.length === 0, `should have no parse errors: ${errors.map(e => e.message).join(', ')}`);
+      assert(ast, 'should produce valid AST');
+    });
+
+    test('3. graphToCanonicalDSL → DSL → Graph preserves node count', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      const { ast } = parseDSLToAST(dsl);
+      const { graph: newGraph } = compileToGraph(ast);
+      assertEqual(newGraph.nodes.length, graph.nodes.length, 'should preserve node count');
+    });
+
+    test('4. graphToCanonicalDSL respects render config', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      assert(dsl.includes('width:'), 'should include width param');
+      assert(dsl.includes('color:'), 'should include color param');
+      assert(dsl.includes('height:'), 'should include height param');
+    });
+
+    test('5. graphToCanonicalDSL handles basic graph without render', () => {
+      const graph = {
+        nodes: [
+          { id: 't', type: 'clock' },
+          { id: 'wave', type: 'sine', params: { freq: 0.3 } }
+        ],
+        edges: [
+          { from: 't.t', to: 'wave.t' }
+        ]
+      };
+      const dsl = graphToCanonicalDSL(graph);
+      assert(dsl.includes('t = clock()'), 'should include clock');
+      assert(dsl.includes('wave = sine('), 'should include sine');
+      assert(!dsl.includes('render'), 'should not include render when absent');
+    });
+
+    // Run tests
+    let passed = 0;
+    let failed = 0;
+    const resultsList = [];
+
+    for (const { name, fn } of results) {
+      try {
+        fn();
+        passed++;
+        resultsList.push(`<li style="color: green;">✓ ${name}</li>`);
+      } catch (err) {
+        failed++;
+        resultsList.push(`<li style="color: red;">✗ ${name}: ${err.message}</li>`);
+      }
+    }
+
+    const html = `
+      <h2>${passed} passed, ${failed} failed</h2>
+      <ul>${resultsList.join('')}</ul>
+    `;
+    document.getElementById('results').innerHTML = html;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- Create editor-studio/ with Vite + CodeMirror + custom SVG node editor
- Implement canonical DSL generation from GraphJSON (graphToCanonicalDSL)
- Support manual sync: Apply DSL → Node, Generate DSL ← Node
- Canvas preview for render bar/point
- GraphJSON and errors display panes
- Tests for canonical DSL round-trip conversion (node count, edges, render references)
- Update README with Editor Studio section

Design principles:
- Manual sync (not real-time) to avoid UI jank during incomplete DSL input
- EditorModel as single source of truth, custom SVG node editor as view layer
- No comment preservation in Node → DSL (canonical form)
- Scoped layout fallback and node operations via applyEditorOperation

https://claude.ai/code/session_012Pndhk3TcA8Xoq6b9gC5Yy