### PR TITLE
Fix render parameter handling and node editor port references

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ npm run dev
 - `Generate DSL ← Node`: ノードエディタから正規形 DSL を生成
 - ノード操作：
   - ドラッグで移動
-  - パラメータ編集
   - エッジの接続・削除
 - Canvas preview：`render bar` / `render point` に対応
 - GraphJSON 表示 pane
@@ -223,7 +222,7 @@ npm run dev
 **設計方針：**
 - 手動同期: DSL ↔ Node は明示ボタン式（リアルタイム自動同期ではない）
 - Node → DSL は正規形（元のコメント・書式は保持しない）
-- EditorModel が single source of truth、Rete.js は view として扱う
+- EditorModel が single source of truth、カスタム SVG ノードエディタは view として扱う
 
 詳細は `editor-studio/src/` の実装と `test/loom-editor-studio.test.html` のテストを参照してください。
 

--- a/editor-studio/src/canonical-dsl.js
+++ b/editor-studio/src/canonical-dsl.js
@@ -56,19 +56,19 @@ export function graphToCanonicalDSL(graph) {
     const renderArgs = [];
 
     if (graph.render.width !== undefined) {
-      renderArgs.push(formatParam('width', graph.render.width));
+      renderArgs.push(formatRenderParam('width', graph.render.width));
     }
     if (graph.render.height !== undefined) {
-      renderArgs.push(formatParam('height', graph.render.height));
+      renderArgs.push(formatRenderParam('height', graph.render.height));
     }
     if (graph.render.color !== undefined) {
-      renderArgs.push(formatParam('color', graph.render.color));
+      renderArgs.push(formatRenderParam('color', graph.render.color));
     }
     if (graph.render.x !== undefined) {
-      renderArgs.push(formatParam('x', graph.render.x));
+      renderArgs.push(formatRenderParam('x', graph.render.x));
     }
     if (graph.render.y !== undefined) {
-      renderArgs.push(formatParam('y', graph.render.y));
+      renderArgs.push(formatRenderParam('y', graph.render.y));
     }
 
     lines.push('');
@@ -96,4 +96,12 @@ function formatValue(val) {
 
 function formatParam(name, value) {
   return `${name}: ${formatValue(value)}`;
+}
+
+// For render params: nodeId.portName references become bare identifiers (e.g. "width.out" → width)
+function formatRenderParam(name, value) {
+  if (typeof value === 'string' && /^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    return `${name}: ${value.split('.')[0]}`;
+  }
+  return formatParam(name, value);
 }

--- a/editor-studio/src/canonical-dsl.js
+++ b/editor-studio/src/canonical-dsl.js
@@ -17,36 +17,27 @@ export function graphToCanonicalDSL(graph) {
     }
 
     const params = { ...node.params };
-    const args = [];
     const inputNames = (nodeType.inputs || []).map(inp => inp.name || inp);
+    const paramNames = (nodeType.params || []).map(p => p.name || p);
 
+    // All args are emitted as named to avoid positional-arg restrictions in the compiler
+    // (non-commutative nodes allow at most 1 positional; commutative disallows mixing).
+    const allNamedArgs = [];
     for (const inputName of inputNames) {
       if (inputEdges[inputName]) {
-        args.push(inputEdges[inputName]);
+        allNamedArgs.push(formatParam(inputName, inputEdges[inputName]));
       } else if (params[inputName] !== undefined) {
-        args.push(params[inputName]);
+        allNamedArgs.push(formatParam(inputName, params[inputName]));
         delete params[inputName];
       }
     }
-
-    const namedArgs = [];
-    const paramNames = (nodeType.params || []).map(p => p.name || p);
     for (const paramName of Object.keys(params)) {
       if (paramNames.includes(paramName)) {
-        const value = params[paramName];
-        namedArgs.push(formatParam(paramName, value));
+        allNamedArgs.push(formatParam(paramName, params[paramName]));
       }
     }
 
-    let callStr = `${node.type}(`;
-    const allArgs = [];
-    for (const arg of args) {
-      allArgs.push(formatValue(arg));
-    }
-    for (const namedArg of namedArgs) {
-      allArgs.push(namedArg);
-    }
-    callStr += allArgs.join(', ') + ')';
+    const callStr = `${node.type}(${allNamedArgs.join(', ')})`;
 
     lines.push(`${node.id} = ${callStr}`);
   }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -8,7 +8,7 @@ import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
 import { graphToEditorModel, editorModelToGraph, applyEditorOperation } from '../../src/loom-editor-model.js';
 import { graphToCanonicalDSL } from './canonical-dsl.js';
 import { createStore } from './studio-store.js';
-import { NodeEditorView } from './rete-view.js';
+import { NodeEditorView } from './node-editor-view.js';
 
 const SAMPLE_DSL = `t = clock()
 wave = sine(t, freq: 0.35)
@@ -138,6 +138,11 @@ function renderErrors() {
 }
 
 function runPreview(graph) {
+  if (animationFrameId) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+
   const state = store.getState();
   if (!graph) graph = state.graph;
   if (!graph) return;

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -221,7 +221,7 @@ export class NodeEditorView {
         }
 
         portY = 45;
-        for (const outputName of ['output'] || []) {
+        for (const outputName of (nodeType.outputs || []).map(o => o.name || o)) {
           const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
           circle.setAttribute('cx', node.position.x + nodeWidth);
           circle.setAttribute('cy', node.position.y + portY);
@@ -246,7 +246,7 @@ export class NodeEditorView {
                   edge: {
                     id: '',
                     fromNodeId: nodeId,
-                    fromPort: 'output',
+                    fromPort: outputName,
                     toNodeId: this.connectFromNodeId,
                     toPort: this.connectFromPort
                   }
@@ -257,7 +257,7 @@ export class NodeEditorView {
             } else {
               this.isConnecting = true;
               this.connectFromNodeId = nodeId;
-              this.connectFromPort = 'output';
+              this.connectFromPort = outputName;
               const tempLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
               tempLine.setAttribute('x1', node.position.x + nodeWidth);
               tempLine.setAttribute('y1', node.position.y + portY);

--- a/test/loom-editor-studio.test.html
+++ b/test/loom-editor-studio.test.html
@@ -89,10 +89,43 @@
       assert(!dsl.includes('render'), 'should not include render when absent');
     });
 
+    test('6. render width reference is not string-literal (node reference as identifier)', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      // 'width.out' must become the identifier `width`, not the string "width.out"
+      assert(!dsl.includes('"width'), 'render width ref must not be a quoted string');
+      assert(dsl.includes('width: width'), 'render width should reference node id as bare identifier');
+    });
+
+    test('7. graphToCanonicalDSL → parseDSLToAST → compileToGraph preserves edges', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      const { ast } = parseDSLToAST(dsl);
+      const { graph: newGraph } = compileToGraph(ast);
+      assertEqual(newGraph.edges.length, graph.edges.length, 'should preserve edge count');
+      // Each original destination port must be reachable in the round-tripped graph
+      for (const origEdge of graph.edges) {
+        const found = newGraph.edges.some(e => e.to === origEdge.to);
+        assert(found, `edge to ${origEdge.to} should be preserved after round-trip`);
+      }
+    });
+
+    test('8. graphToCanonicalDSL → compileToGraph preserves render.width reference', () => {
+      const graph = sampleGraph();
+      const dsl = graphToCanonicalDSL(graph);
+      const { ast } = parseDSLToAST(dsl);
+      const { graph: newGraph } = compileToGraph(ast);
+      assert(newGraph.render, 'round-tripped graph should have render');
+      assertEqual(newGraph.render.type, graph.render.type, 'render type should be preserved');
+      // compileToGraph resolves identifiers to nodeId.portName references
+      assertEqual(newGraph.render.width, graph.render.width, 'render width ref should round-trip to width.out');
+    });
+
     // Run tests
     let passed = 0;
     let failed = 0;
     const resultsList = [];
+    const failedItems = [];
 
     for (const { name, fn } of results) {
       try {
@@ -102,6 +135,7 @@
       } catch (err) {
         failed++;
         resultsList.push(`<li style="color: red;">✗ ${name}: ${err.message}</li>`);
+        failedItems.push({ name, message: err.message });
       }
     }
 
@@ -110,6 +144,12 @@
       <ul>${resultsList.join('')}</ul>
     `;
     document.getElementById('results').innerHTML = html;
+
+    window.__loomTestResults = {
+      pass: passed,
+      fail: failed,
+      failures: failedItems
+    };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR fixes critical issues with render parameter serialization and node editor port handling, ensuring proper round-trip conversion between graph and DSL formats.

## Key Changes

- **Render parameter serialization**: Added `formatRenderParam()` function to convert node reference strings (e.g., `"width.out"`) to bare identifiers (e.g., `width`) in DSL output, preventing incorrect string literals in render declarations
- **Node editor port handling**: Fixed hardcoded `'output'` port references to dynamically use actual port names from node type definitions, enabling proper multi-port node support
- **File rename**: Renamed `rete-view.js` to `node-editor-view.js` to better reflect the custom SVG implementation
- **Animation frame cleanup**: Added proper cancellation of previous animation frames in `runPreview()` to prevent memory leaks
- **Test coverage**: Added three new comprehensive tests:
  - Test 6: Validates render width references are bare identifiers, not quoted strings
  - Test 7: Verifies edge preservation through DSL round-trip conversion
  - Test 8: Confirms render parameter references survive round-trip compilation
- **Test infrastructure**: Added `window.__loomTestResults` global for programmatic test result access and failure tracking
- **Documentation**: Updated README to reflect custom SVG editor instead of Rete.js

## Implementation Details

The `formatRenderParam()` function uses regex pattern matching to identify node reference strings (`nodeId.portName` format) and extracts just the node ID for the DSL output. This ensures that when a graph is serialized to DSL and parsed back, the render parameters maintain their semantic meaning as node references rather than being treated as literal strings.

The node editor port fix iterates over actual node type outputs instead of assuming a single `'output'` port, enabling proper support for nodes with multiple or differently-named output ports.

https://claude.ai/code/session_012Pndhk3TcA8Xoq6b9gC5Yy