### PR TITLE
Migrate node editor from custom SVG to Rete.js v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ x = timer |> sine(freq: 0.3) |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 70
 
 詳細な仕様は **[docs/DSL.md](docs/DSL.md)** をご覧ください。
 
-### Editor Studio MVP
+### Editor Studio
 
-`editor-studio` は、DSL とノードエディタを左右に並べた協調編集スタジオの MVP です。
+`editor-studio` は DSL と Rete.js v2 ノードエディタを左右に並べた協調編集スタジオです。
 
 ```bash
 cd editor-studio
@@ -209,12 +209,13 @@ npm run dev
 ```
 
 **機能：**
-- DSL エディタ（CodeMirror）とノードエディタを左右2ペインで表示
+- DSL エディタ（CodeMirror）と **Rete.js v2 ノードエディタ** を左右2ペインで表示
 - `Apply DSL → Node`: DSL をパースしてノードエディタに反映
 - `Generate DSL ← Node`: ノードエディタから正規形 DSL を生成
 - ノード操作：
   - ドラッグで移動
   - エッジの接続・削除
+  - params の表示・編集
 - Canvas preview：`render bar` / `render point` に対応
 - GraphJSON 表示 pane
 - Errors pane
@@ -222,7 +223,8 @@ npm run dev
 **設計方針：**
 - 手動同期: DSL ↔ Node は明示ボタン式（リアルタイム自動同期ではない）
 - Node → DSL は正規形（元のコメント・書式は保持しない）
-- EditorModel が single source of truth、カスタム SVG ノードエディタは view として扱う
+- EditorModel が single source of truth、Rete.js ノードエディタは view として扱う
+- The node editor uses **Rete.js v2** as the visual editing layer
 
 詳細は `editor-studio/src/` の実装と `test/loom-editor-studio.test.html` のテストを参照してください。
 

--- a/editor-studio/package.json
+++ b/editor-studio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "editor-studio",
   "version": "0.1.0",
-  "description": "Loom DSL + Node Editor Studio",
+  "description": "Loom DSL + Rete.js node editor studio",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
@@ -19,6 +19,14 @@
     "@codemirror/autocomplete": "^6.10.0",
     "@codemirror/lint": "^6.4.1",
     "@codemirror/theme-one-dark": "^6.1.2",
+    "rete": "latest",
+    "rete-area-plugin": "latest",
+    "rete-connection-plugin": "latest",
+    "rete-react-plugin": "latest",
+    "rete-render-utils": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "styled-components": "latest",
     "vite": "^5.0.0"
   },
   "devDependencies": {}

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -70,7 +70,7 @@ function setDslText(text) {
   }
 }
 
-function applyDsl() {
+async function applyDsl() {
   const sourceText = getDslText();
   const { ast, errors: parseErrors } = parseDSLToAST(sourceText);
 
@@ -97,7 +97,7 @@ function applyDsl() {
     errors: []
   });
 
-  nodeEditor?.render(editorModel);
+  await nodeEditor?.renderModel(editorModel);
   renderGraphJSON(graph);
   renderErrors();
   runPreview(graph);
@@ -235,20 +235,42 @@ function setupEventListeners() {
   });
 }
 
-function init() {
-  initDslEditor();
-  nodeEditor = new NodeEditorView(elements.nodeEditorHost, (operation) => {
-    const state = store.getState();
-    if (!state.editorModel) return;
+async function handleOperation(operation) {
+  const state = store.getState();
+  if (!state.editorModel) return;
 
+  try {
     const newModel = applyEditorOperation(state.editorModel, operation);
     store.setState({ editorModel: newModel });
-    nodeEditor?.render(newModel);
+
+    // moveNode: Rete already reflects the position visually; skip full re-render
+    if (operation.type !== 'moveNode') {
+      await nodeEditor?.renderModel(newModel);
+    }
 
     const graph = editorModelToGraph(newModel, state.graph);
     store.setState({ graph });
     renderGraphJSON(graph);
     runPreview(graph);
+  } catch (e) {
+    // Revert Rete state to current model if operation fails
+    const currentModel = store.getState().editorModel;
+    if (currentModel && operation.type !== 'moveNode') {
+      await nodeEditor?.renderModel(currentModel);
+    }
+    store.setState({ errors: [{ message: `Operation error: ${e.message}`, code: 'EDITOR_ERROR' }] });
+    renderErrors();
+  }
+}
+
+function init() {
+  initDslEditor();
+  nodeEditor = new NodeEditorView(elements.nodeEditorHost, {
+    onOperation: handleOperation,
+    onError: (error) => {
+      store.setState({ errors: [{ message: `Editor error: ${error.message}`, code: 'EDITOR_ERROR' }] });
+      renderErrors();
+    }
   });
 
   setupEventListeners();

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -1,292 +1,168 @@
+import { NodeEditor, ClassicPreset } from 'rete';
+import { AreaPlugin } from 'rete-area-plugin';
+import { ConnectionPlugin, Presets as ConnectionPresets } from 'rete-connection-plugin';
+import { ReactPlugin, Presets } from 'rete-react-plugin';
 import { NODE_TYPES } from '../../src/loom.js';
-import { applyEditorOperation } from '../../src/loom-editor-model.js';
+import {
+  connectionToAddEdgeOp,
+  translateToMoveNodeOp,
+  controlValueToUpdateParamOp
+} from './rete-operation-helpers.js';
+
+const socket = new ClassicPreset.Socket('value');
+
+function getPortName(port) {
+  return typeof port === 'string' ? port : port.name;
+}
+
+function createReteNode(editorNode, onControl) {
+  const nodeTypeDef = NODE_TYPES[editorNode.type];
+  const node = new ClassicPreset.Node(editorNode.type);
+  node.id = editorNode.id;
+
+  if (nodeTypeDef) {
+    for (const input of nodeTypeDef.inputs || []) {
+      const name = getPortName(input);
+      node.addInput(name, new ClassicPreset.Input(socket, name));
+    }
+    for (const output of nodeTypeDef.outputs || []) {
+      const name = getPortName(output);
+      node.addOutput(name, new ClassicPreset.Output(socket, name));
+    }
+  }
+
+  const paramDefs = nodeTypeDef?.params || [];
+  for (const [key, value] of Object.entries(editorNode.params || {})) {
+    const paramDef = paramDefs.find(p => p.name === key);
+    const controlType = (paramDef?.type === 'number' || typeof value === 'number') ? 'number' : 'text';
+    const ctrl = new ClassicPreset.InputControl(controlType, {
+      initial: value,
+      change(v) {
+        onControl(controlValueToUpdateParamOp(editorNode.id, key, v, controlType));
+      }
+    });
+    node.addControl(key, ctrl);
+  }
+
+  return node;
+}
 
 export class NodeEditorView {
-  constructor(container, onOperation) {
+  constructor(container, { onOperation, onError } = {}) {
     this.container = container;
-    this.onOperation = onOperation;
-    this.selectedNodeId = null;
-    this.draggedNode = null;
-    this.dragStartX = 0;
-    this.dragStartY = 0;
-    this.isConnecting = false;
-    this.connectFromNodeId = null;
-    this.connectFromPort = null;
-    this.editorModel = null;
-    this.scale = 1;
-    this.offsetX = 0;
-    this.offsetY = 0;
+    this.onOperation = onOperation || (() => {});
+    this.onError = onError || ((e) => console.error('NodeEditorView:', e));
+    this.isRendering = false;
+    this.connectionMap = new Map();
+    this._renderLock = null;
 
-    this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    this.svg.setAttribute('width', '100%');
-    this.svg.setAttribute('height', '100%');
-    this.svg.style.cursor = 'grab';
+    this.editor = new NodeEditor();
+    this.area = new AreaPlugin(this.container);
+    this.connectionPlugin = new ConnectionPlugin();
+    this.renderPlugin = new ReactPlugin();
+
+    this.renderPlugin.addPreset(Presets.classic.setup());
+    this.connectionPlugin.addPreset(ConnectionPresets.classic.setup());
+
+    this.editor.use(this.area);
+    this.area.use(this.connectionPlugin);
+    this.area.use(this.renderPlugin);
+
+    this._setupPipes();
+  }
+
+  _setupPipes() {
+    this.editor.addPipe((context) => {
+      if (!this.isRendering) {
+        if (context.type === 'connectioncreated') {
+          this._onConnectionCreated(context.data);
+        } else if (context.type === 'connectionremoved') {
+          this._onConnectionRemoved(context.data);
+        }
+      }
+      return context;
+    });
+
+    this.area.addPipe((context) => {
+      if (!this.isRendering && context.type === 'nodetranslated') {
+        this._onNodeTranslated(context.data);
+      }
+      return context;
+    });
+  }
+
+  _onConnectionCreated(connection) {
+    try {
+      const edgeId = `${connection.source}.${connection.sourceOutput}->${connection.target}.${connection.targetInput}`;
+      this.connectionMap.set(connection.id, edgeId);
+      this.onOperation(connectionToAddEdgeOp(connection));
+    } catch (e) {
+      this.onError(e);
+    }
+  }
+
+  _onConnectionRemoved(connection) {
+    const edgeId = this.connectionMap.get(connection.id);
+    if (edgeId) {
+      this.connectionMap.delete(connection.id);
+      this.onOperation({ type: 'removeEdge', edgeId });
+    }
+  }
+
+  _onNodeTranslated(data) {
+    this.onOperation(translateToMoveNodeOp(data));
+  }
+
+  async renderModel(editorModel) {
+    if (this._renderLock) {
+      await this._renderLock;
+    }
+
+    let resolve;
+    this._renderLock = new Promise(r => { resolve = r; });
+    this.isRendering = true;
+    this.connectionMap.clear();
+
+    try {
+      await this.editor.clear();
+
+      for (const nodeId of editorModel.order) {
+        const node = editorModel.nodesById[nodeId];
+        if (!node) continue;
+        const reteNode = createReteNode(node, (op) => {
+          if (!this.isRendering) {
+            this.onOperation(op);
+          }
+        });
+        await this.editor.addNode(reteNode);
+        const pos = node.position ?? { x: 0, y: 0 };
+        await this.area.translate(reteNode.id, { x: pos.x, y: pos.y });
+      }
+
+      for (const edge of Object.values(editorModel.edgesById)) {
+        const sourceNode = this.editor.getNode(edge.fromNodeId);
+        const targetNode = this.editor.getNode(edge.toNodeId);
+        if (!sourceNode || !targetNode) continue;
+        try {
+          const conn = new ClassicPreset.Connection(
+            sourceNode, edge.fromPort,
+            targetNode, edge.toPort
+          );
+          await this.editor.addConnection(conn);
+          this.connectionMap.set(conn.id, edge.id);
+        } catch (e) {
+          console.warn('renderModel: skipping connection', edge.id, e.message);
+        }
+      }
+    } finally {
+      this.isRendering = false;
+      resolve();
+      this._renderLock = null;
+    }
+  }
+
+  destroy() {
+    this.area.destroy();
     this.container.innerHTML = '';
-    this.container.appendChild(this.svg);
-
-    this.edgesGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-    this.nodesGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-    this.tempLineGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-
-    this.svg.appendChild(this.edgesGroup);
-    this.svg.appendChild(this.nodesGroup);
-    this.svg.appendChild(this.tempLineGroup);
-
-    this.setupEventListeners();
-  }
-
-  setupEventListeners() {
-    this.svg.addEventListener('mousedown', (e) => {
-      if (e.target === this.svg) {
-        this.dragStartX = e.clientX;
-        this.dragStartY = e.clientY;
-        this.svg.style.cursor = 'grabbing';
-      }
-    });
-
-    this.svg.addEventListener('mousemove', (e) => {
-      if (e.buttons === 1 && this.dragStartX !== 0) {
-        this.offsetX += e.clientX - this.dragStartX;
-        this.offsetY += e.clientY - this.dragStartY;
-        this.dragStartX = e.clientX;
-        this.dragStartY = e.clientY;
-        this.render();
-      }
-
-      if (this.isConnecting) {
-        const tempLine = this.tempLineGroup.querySelector('line');
-        if (tempLine) {
-          tempLine.setAttribute('x2', e.clientX - this.offsetX);
-          tempLine.setAttribute('y2', e.clientY - this.offsetY);
-        }
-      }
-    });
-
-    this.svg.addEventListener('mouseup', () => {
-      this.dragStartX = 0;
-      this.dragStartY = 0;
-      this.svg.style.cursor = 'grab';
-      this.isConnecting = false;
-    });
-  }
-
-  render(editorModel) {
-    if (editorModel) {
-      this.editorModel = editorModel;
-    }
-    if (!this.editorModel) return;
-
-    this.edgesGroup.innerHTML = '';
-    this.nodesGroup.innerHTML = '';
-
-    const nodeWidth = 200;
-    const nodeHeight = 100;
-    const portRadius = 6;
-    const portSpacing = 25;
-
-    for (const edge of Object.values(this.editorModel.edgesById)) {
-      const fromNode = this.editorModel.nodesById[edge.fromNodeId];
-      const toNode = this.editorModel.nodesById[edge.toNodeId];
-      if (!fromNode || !toNode) continue;
-
-      const x1 = fromNode.position.x + nodeWidth;
-      const y1 = fromNode.position.y + 50;
-      const x2 = toNode.position.x;
-      const y2 = toNode.position.y + 50;
-
-      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-      line.setAttribute('x1', x1);
-      line.setAttribute('y1', y1);
-      line.setAttribute('x2', x2);
-      line.setAttribute('y2', y2);
-      line.setAttribute('stroke', '#999');
-      line.setAttribute('stroke-width', '2');
-      line.setAttribute('data-edge-id', edge.id);
-      line.style.cursor = 'pointer';
-
-      line.addEventListener('click', (e) => {
-        e.stopPropagation();
-        this.onOperation({ type: 'removeEdge', edgeId: edge.id });
-      });
-
-      this.edgesGroup.appendChild(line);
-    }
-
-    for (const nodeId of this.editorModel.order) {
-      const node = this.editorModel.nodesById[nodeId];
-      if (!node) continue;
-
-      const isSelected = nodeId === this.selectedNodeId;
-      const nodeGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-
-      const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-      rect.setAttribute('x', node.position.x);
-      rect.setAttribute('y', node.position.y);
-      rect.setAttribute('width', nodeWidth);
-      rect.setAttribute('height', nodeHeight);
-      rect.setAttribute('fill', isSelected ? '#4a90e2' : '#333');
-      rect.setAttribute('stroke', isSelected ? '#fff' : '#999');
-      rect.setAttribute('stroke-width', '2');
-      rect.setAttribute('rx', '4');
-      rect.style.cursor = 'move';
-
-      rect.addEventListener('mousedown', (e) => {
-        e.stopPropagation();
-        this.selectedNodeId = nodeId;
-        this.draggedNode = node;
-        this.dragStartX = e.clientX;
-        this.dragStartY = e.clientY;
-        this.render();
-      });
-
-      rect.addEventListener('mousemove', (e) => {
-        if (this.draggedNode === node && e.buttons === 1) {
-          const dx = e.clientX - this.dragStartX;
-          const dy = e.clientY - this.dragStartY;
-          this.onOperation({
-            type: 'moveNode',
-            id: nodeId,
-            position: { x: node.position.x + dx, y: node.position.y + dy }
-          });
-          this.dragStartX = e.clientX;
-          this.dragStartY = e.clientY;
-        }
-      });
-
-      nodeGroup.appendChild(rect);
-
-      const titleText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-      titleText.setAttribute('x', node.position.x + 10);
-      titleText.setAttribute('y', node.position.y + 25);
-      titleText.setAttribute('fill', '#fff');
-      titleText.setAttribute('font-size', '14');
-      titleText.setAttribute('font-weight', 'bold');
-      titleText.textContent = node.type;
-      nodeGroup.appendChild(titleText);
-
-      const nodeType = NODE_TYPES[node.type];
-      if (nodeType) {
-        let portY = 45;
-
-        for (const inputName of nodeType.inputs || []) {
-          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-          circle.setAttribute('cx', node.position.x);
-          circle.setAttribute('cy', node.position.y + portY);
-          circle.setAttribute('r', portRadius);
-          circle.setAttribute('fill', '#666');
-          circle.style.cursor = 'pointer';
-
-          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          label.setAttribute('x', node.position.x + 15);
-          label.setAttribute('y', node.position.y + portY + 4);
-          label.setAttribute('fill', '#aaa');
-          label.setAttribute('font-size', '12');
-          label.textContent = inputName;
-
-          circle.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (this.isConnecting) {
-              if (this.connectFromNodeId !== nodeId) {
-                this.onOperation({
-                  type: 'addEdge',
-                  edge: {
-                    id: '',
-                    fromNodeId: this.connectFromNodeId,
-                    fromPort: this.connectFromPort,
-                    toNodeId: nodeId,
-                    toPort: inputName
-                  }
-                });
-              }
-              this.isConnecting = false;
-              this.tempLineGroup.innerHTML = '';
-            } else {
-              this.isConnecting = true;
-              this.connectFromNodeId = nodeId;
-              this.connectFromPort = inputName;
-              const tempLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-              tempLine.setAttribute('x1', node.position.x);
-              tempLine.setAttribute('y1', node.position.y + portY);
-              tempLine.setAttribute('x2', node.position.x);
-              tempLine.setAttribute('y2', node.position.y + portY);
-              tempLine.setAttribute('stroke', '#4a90e2');
-              tempLine.setAttribute('stroke-width', '2');
-              this.tempLineGroup.appendChild(tempLine);
-            }
-          });
-
-          nodeGroup.appendChild(circle);
-          nodeGroup.appendChild(label);
-          portY += portSpacing;
-        }
-
-        portY = 45;
-        for (const outputName of (nodeType.outputs || []).map(o => o.name || o)) {
-          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-          circle.setAttribute('cx', node.position.x + nodeWidth);
-          circle.setAttribute('cy', node.position.y + portY);
-          circle.setAttribute('r', portRadius);
-          circle.setAttribute('fill', '#4a90e2');
-          circle.style.cursor = 'pointer';
-
-          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          label.setAttribute('x', node.position.x + nodeWidth - 50);
-          label.setAttribute('y', node.position.y + portY + 4);
-          label.setAttribute('fill', '#aaa');
-          label.setAttribute('font-size', '12');
-          label.setAttribute('text-anchor', 'end');
-          label.textContent = outputName;
-
-          circle.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (this.isConnecting) {
-              if (this.connectFromNodeId !== nodeId) {
-                this.onOperation({
-                  type: 'addEdge',
-                  edge: {
-                    id: '',
-                    fromNodeId: nodeId,
-                    fromPort: outputName,
-                    toNodeId: this.connectFromNodeId,
-                    toPort: this.connectFromPort
-                  }
-                });
-              }
-              this.isConnecting = false;
-              this.tempLineGroup.innerHTML = '';
-            } else {
-              this.isConnecting = true;
-              this.connectFromNodeId = nodeId;
-              this.connectFromPort = outputName;
-              const tempLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-              tempLine.setAttribute('x1', node.position.x + nodeWidth);
-              tempLine.setAttribute('y1', node.position.y + portY);
-              tempLine.setAttribute('x2', node.position.x + nodeWidth);
-              tempLine.setAttribute('y2', node.position.y + portY);
-              tempLine.setAttribute('stroke', '#4a90e2');
-              tempLine.setAttribute('stroke-width', '2');
-              this.tempLineGroup.appendChild(tempLine);
-            }
-          });
-
-          nodeGroup.appendChild(circle);
-          nodeGroup.appendChild(label);
-        }
-
-        let paramY = 45;
-        for (const [paramName, paramValue] of Object.entries(node.params || {})) {
-          const paramLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          paramLabel.setAttribute('x', node.position.x + 10);
-          paramLabel.setAttribute('y', node.position.y + paramY);
-          paramLabel.setAttribute('fill', '#aaa');
-          paramLabel.setAttribute('font-size', '11');
-          paramLabel.textContent = `${paramName}: ${JSON.stringify(paramValue).substring(0, 15)}`;
-          nodeGroup.appendChild(paramLabel);
-          paramY += 15;
-        }
-      }
-
-      this.nodesGroup.appendChild(nodeGroup);
-    }
   }
 }

--- a/editor-studio/src/rete-operation-helpers.js
+++ b/editor-studio/src/rete-operation-helpers.js
@@ -1,0 +1,36 @@
+/**
+ * Pure helpers that convert Rete.js v2 event payloads into EditorModel operations.
+ * Kept separate from node-editor-view.js so they can be imported and tested without
+ * loading Rete.js packages (which use bare specifiers and require a bundler).
+ */
+
+export function connectionToAddEdgeOp(connection) {
+  return {
+    type: 'addEdge',
+    edge: {
+      id: '',
+      fromNodeId: connection.source,
+      fromPort: connection.sourceOutput,
+      toNodeId: connection.target,
+      toPort: connection.targetInput,
+    }
+  };
+}
+
+export function translateToMoveNodeOp(data) {
+  return {
+    type: 'moveNode',
+    id: data.id,
+    position: { x: data.position.x, y: data.position.y }
+  };
+}
+
+export function controlValueToUpdateParamOp(nodeId, key, rawValue, controlType) {
+  const parsed = controlType === 'number' ? parseFloat(rawValue) : rawValue;
+  return {
+    type: 'updateParam',
+    id: nodeId,
+    key,
+    value: Number.isNaN(parsed) ? rawValue : parsed
+  };
+}

--- a/editor-studio/src/rete-operation-helpers.js
+++ b/editor-studio/src/rete-operation-helpers.js
@@ -26,11 +26,11 @@ export function translateToMoveNodeOp(data) {
 }
 
 export function controlValueToUpdateParamOp(nodeId, key, rawValue, controlType) {
-  const parsed = controlType === 'number' ? parseFloat(rawValue) : rawValue;
+  const parsed = controlType === 'number' ? Number(rawValue) : rawValue;
   return {
     type: 'updateParam',
     id: nodeId,
     key,
-    value: Number.isNaN(parsed) ? rawValue : parsed
+    value: controlType === 'number' && Number.isFinite(parsed) ? parsed : rawValue
   };
 }

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -74,6 +74,47 @@ html, body {
   background: var(--bg-lighter);
   border: 1px solid var(--border-color);
   overflow: hidden;
+  position: relative;
+}
+
+/* Rete.js v2 dark theme overrides */
+.node-editor-canvas .rete-area {
+  width: 100%;
+  height: 100%;
+}
+
+/* Node title bar */
+.node-editor-canvas .title {
+  background: #2a2a2a !important;
+  color: var(--text-color) !important;
+  border-bottom: 1px solid var(--border-color) !important;
+}
+
+/* Node body */
+.node-editor-canvas .node {
+  background: #222 !important;
+  border-color: var(--border-color) !important;
+  color: var(--text-color) !important;
+}
+
+.node-editor-canvas .node.selected-node {
+  border-color: var(--primary-color) !important;
+}
+
+/* Port sockets */
+.node-editor-canvas .socket {
+  background: var(--primary-color) !important;
+  border-color: #1a5cb0 !important;
+}
+
+/* Input controls */
+.node-editor-canvas input[type="number"],
+.node-editor-canvas input[type="text"] {
+  background: #111 !important;
+  color: var(--text-color) !important;
+  border: 1px solid var(--border-color) !important;
+  border-radius: 3px !important;
+  padding: 2px 4px !important;
 }
 
 .bottom-pane {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "http-server": "^14.1.1",
-    "playwright": "^1.40.0"
+    "playwright": "^1.56.0"
   }
 }

--- a/test/loom-editor-studio.test.html
+++ b/test/loom-editor-studio.test.html
@@ -10,7 +10,12 @@
   <script type="module">
     import { graphToCanonicalDSL } from "../editor-studio/src/canonical-dsl.js";
     import { parseDSLToAST, compileToGraph } from "../src/loom-dsl.js";
-    import { graphToEditorModel, editorModelToGraph } from "../src/loom-editor-model.js";
+    import { graphToEditorModel, editorModelToGraph, applyEditorOperation } from "../src/loom-editor-model.js";
+    import {
+      connectionToAddEdgeOp,
+      translateToMoveNodeOp,
+      controlValueToUpdateParamOp
+    } from "../editor-studio/src/rete-operation-helpers.js";
 
     const results = [];
     function test(name, fn) { results.push({ name, fn }); }
@@ -108,6 +113,79 @@
         const found = newGraph.edges.some(e => e.to === origEdge.to);
         assert(found, `edge to ${origEdge.to} should be preserved after round-trip`);
       }
+    });
+
+    // --- rete-operation-helpers pure function tests ---
+
+    test('9. connectionToAddEdgeOp returns correct addEdge operation shape', () => {
+      const reteConnection = {
+        id: 'rete-conn-1',
+        source: 'nodeA',
+        sourceOutput: 'out',
+        target: 'nodeB',
+        targetInput: 'value'
+      };
+      const op = connectionToAddEdgeOp(reteConnection);
+      assertEqual(op.type, 'addEdge', 'type should be addEdge');
+      assertEqual(op.edge.fromNodeId, 'nodeA', 'fromNodeId');
+      assertEqual(op.edge.fromPort, 'out', 'fromPort');
+      assertEqual(op.edge.toNodeId, 'nodeB', 'toNodeId');
+      assertEqual(op.edge.toPort, 'value', 'toPort');
+      assertEqual(op.edge.id, '', 'id should be empty string');
+    });
+
+    test('10. translateToMoveNodeOp returns correct moveNode operation shape', () => {
+      const reteData = {
+        id: 'nodeA',
+        position: { x: 120, y: 80 },
+        previous: { x: 100, y: 60 }
+      };
+      const op = translateToMoveNodeOp(reteData);
+      assertEqual(op.type, 'moveNode', 'type should be moveNode');
+      assertEqual(op.id, 'nodeA', 'id');
+      assertEqual(op.position.x, 120, 'x');
+      assertEqual(op.position.y, 80, 'y');
+    });
+
+    test('11. controlValueToUpdateParamOp returns correct updateParam shape (number)', () => {
+      const op = controlValueToUpdateParamOp('nodeA', 'freq', '0.5', 'number');
+      assertEqual(op.type, 'updateParam', 'type should be updateParam');
+      assertEqual(op.id, 'nodeA', 'id');
+      assertEqual(op.key, 'freq', 'key');
+      assertEqual(op.value, 0.5, 'value should be parsed as number');
+    });
+
+    test('12. controlValueToUpdateParamOp returns correct updateParam shape (text)', () => {
+      const op = controlValueToUpdateParamOp('nodeA', 'target', '#el', 'text');
+      assertEqual(op.type, 'updateParam', 'type should be updateParam');
+      assertEqual(op.id, 'nodeA', 'id');
+      assertEqual(op.key, 'target', 'key');
+      assertEqual(op.value, '#el', 'value should remain string');
+    });
+
+    test('13. controlValueToUpdateParamOp: NaN input kept as raw string', () => {
+      const op = controlValueToUpdateParamOp('nodeA', 'freq', 'abc', 'number');
+      assertEqual(op.value, 'abc', 'NaN parse should fall back to raw string');
+    });
+
+    test('14. connectionToAddEdgeOp result is accepted by applyEditorOperation addEdge', () => {
+      // Build a model with two unconnected nodes
+      const { ast } = parseDSLToAST('clk = clock()\nw = sine()');
+      const { graph } = compileToGraph(ast);
+      const em = graphToEditorModel(graph);
+
+      // Simulate a Rete connectioncreated payload
+      const reteConnection = {
+        id: 'rete-conn-x',
+        source: 'clk',
+        sourceOutput: 't',
+        target: 'w',
+        targetInput: 't'
+      };
+      const op = connectionToAddEdgeOp(reteConnection);
+      const newModel = applyEditorOperation(em, op);
+      const edgeId = 'clk.t->w.t';
+      assert(newModel.edgesById[edgeId], 'edge should exist in model after applyEditorOperation');
     });
 
     test('8. graphToCanonicalDSL → compileToGraph preserves render.width reference', () => {


### PR DESCRIPTION
## Summary
Replaces the custom SVG-based node editor implementation with Rete.js v2, a mature graph editing library. This modernizes the editor UI, improves maintainability, and enables future extensibility.

## Key Changes

### Core Editor Rewrite
- **Replaced custom SVG rendering** (`NodeEditorView`) with Rete.js v2 architecture using:
  - `NodeEditor` for graph state management
  - `AreaPlugin` for canvas/viewport handling
  - `ConnectionPlugin` for edge management
  - `ReactPlugin` for node/control rendering
- **Removed ~290 lines of manual DOM manipulation** (SVG element creation, event listeners, drag/pan logic)
- **Reduced to ~170 lines** with cleaner separation of concerns

### Operation Helpers
- Extracted pure conversion functions into new `rete-operation-helpers.js`:
  - `connectionToAddEdgeOp()` - converts Rete connection events to addEdge operations
  - `translateToMoveNodeOp()` - converts node position changes to moveNode operations
  - `controlValueToUpdateParamOp()` - converts parameter control changes to updateParam operations; uses `Number()` + `Number.isFinite()` for strict parsing (avoids `parseFloat("1abc") === 1`)
- These helpers are testable without loading Rete.js packages (which require a bundler)

### Integration Updates
- Updated `main.js` to use async `renderModel()` instead of sync `render()`
- Implemented operation error handling with automatic Rete state reversion on failure
- Optimized re-rendering: skip full re-render for moveNode operations (Rete handles visual updates)
- Added `onError` callback support for editor error reporting

### UI/Styling
- Added Rete.js v2 dark theme CSS overrides to match existing design system
- Styled nodes, sockets, and input controls to integrate with the dark theme
- Maintained visual consistency with the rest of the application

### Testing
- Added 6 new test cases validating operation helper functions
- Tests verify correct operation shape generation and integration with `applyEditorOperation`

## Implementation Details
- Uses a `connectionMap` to track Rete connection IDs ↔ edge IDs for proper removal handling
- Implements render locking to prevent race conditions during async model updates
- Pipes intercept Rete events only when not rendering to avoid feedback loops
- Node creation dynamically builds inputs/outputs/controls from `NODE_TYPES` definitions

## Testing
- `npm test` passed (173 passed, 0 failed).
- `cd editor-studio && npm install && npm run build` passed.

https://claude.ai/code/session_018cEYkHySaKAvBVNA3h2iRF