### PR TITLE
[codex] Add reusable Loom CLI toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,30 @@ Graph DSL → JSON graph → Web Loom / Unity Loom で評価
 
 詳細な API・ノード仕様は [docs/SPEC.md](docs/SPEC.md) をご覧ください。
 
+## CLI
+
+Loom CLI は Loom DSL の最初のターミナルインターフェースです。CLI 自体に処理を閉じ込めず、`src/toolchain/` の compile / format / inspect / run を Web Studio / Scene Sync / AI toolchain からも再利用できる前提で追加しています。
+
+現在の CLI は、Loom DSL を GraphJSON に変換し、整形し、要約を取り、単純な pure/source/transform/state グラフを 1 回実行する用途に向いています。
+
+```bash
+npm run loom -- compile examples/cli-basic.loom
+npm run loom -- format examples/cli-basic.loom
+npm run loom -- inspect examples/cli-basic.loom
+npm run loom -- run examples/cli-basic.loom --get x.out --time 1
+```
+
+```bash
+node bin/loom.mjs compile examples/cli-basic.loom
+node bin/loom.mjs run examples/cli-basic.loom --get x.out --time 1
+```
+
+現時点の制約:
+
+- CLI run は pure/source/transform/state ノード中心の実行にフォーカスしています。
+- DOM / Three.js / Unity / SceneSync アダプタは CLI からは実行しません。
+- file I/O ノードと import syntax は今後の作業です。
+
 ## ライブエディタと DSL
 
 ### エディタ一覧

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -26,10 +26,7 @@ function printToolErrors(errors) {
   }
 }
 
-function parseBoolean(value, defaultValue) {
-  if (value === undefined) {
-    return defaultValue;
-  }
+function parseBoolean(value) {
   if (value === 'true') {
     return true;
   }
@@ -146,21 +143,22 @@ async function handleCompile(args) {
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
     if (arg === '-o' || arg === '--out') {
-      outputPath = rest[index + 1];
+      const next = rest[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`${arg} requires a file path`);
+      }
+      outputPath = next;
       index += 1;
     } else if (arg === '--pretty') {
-      pretty = parseBoolean(rest[index + 1], true);
+      const next = rest[index + 1];
+      if (next === undefined || next.startsWith('-')) {
+        throw new Error('--pretty requires true or false');
+      }
+      pretty = parseBoolean(next);
       index += 1;
     } else {
-      throw new Error(`unknown option for compile: ${arg}`);
+      throw new Error(`Unknown option: ${arg}`);
     }
-  }
-
-  if (outputPath === null && rest.includes('-o')) {
-    throw new Error('-o requires a file path');
-  }
-  if (outputPath === null && rest.includes('--out')) {
-    throw new Error('--out requires a file path');
   }
 
   const source = await readSourceFile(file);
@@ -199,7 +197,7 @@ async function handleFormat(args) {
     } else if (arg === '--check') {
       shouldCheck = true;
     } else {
-      throw new Error(`unknown option for format: ${arg}`);
+      throw new Error(`Unknown option: ${arg}`);
     }
   }
 
@@ -250,7 +248,7 @@ async function handleInspect(args) {
     } else if (arg === '--json') {
       showJson = true;
     } else {
-      throw new Error(`unknown option for inspect: ${arg}`);
+      throw new Error(`Unknown option: ${arg}`);
     }
   }
 
@@ -314,7 +312,7 @@ async function handleRun(args) {
     } else if (arg === '--json') {
       json = true;
     } else {
-      throw new Error(`unknown option for run: ${arg}`);
+      throw new Error(`Unknown option: ${arg}`);
     }
   }
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  compileLoomSource,
+  formatLoomSource,
+  inspectLoomSource,
+  formatInspectionSummary,
+  runLoomSource,
+  formatLoomError
+} from '../src/toolchain/index.js';
+
+function print(message = '') {
+  process.stdout.write(`${message}\n`);
+}
+
+function printError(message = '') {
+  process.stderr.write(`${message}\n`);
+}
+
+function printToolErrors(errors) {
+  for (const error of errors) {
+    printError(formatLoomError(error));
+  }
+}
+
+function parseBoolean(value, defaultValue) {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  throw new Error(`expected true or false, got: ${value}`);
+}
+
+function parseNumber(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${optionName} expects a finite number`);
+  }
+  return parsed;
+}
+
+function parseCommonCommandArgs(args) {
+  let file = null;
+  const rest = [];
+
+  for (const arg of args) {
+    if (file === null && !arg.startsWith('-')) {
+      file = arg;
+    } else {
+      rest.push(arg);
+    }
+  }
+
+  return { file, rest };
+}
+
+function stringifyJson(value, pretty = true) {
+  return JSON.stringify(value, null, pretty ? 2 : 0);
+}
+
+function getGeneralHelp() {
+  return `Loom CLI
+
+Usage:
+  loom <command> <file> [options]
+
+Commands:
+  compile <file>   Compile Loom DSL to GraphJSON
+  format <file>    Format Loom DSL
+  inspect <file>   Inspect Loom DSL and print a summary
+  run <file>       Evaluate a Loom graph once
+  help             Show help
+
+Examples:
+  loom compile examples/cli-basic.loom
+  loom format examples/cli-basic.loom --check
+  loom inspect examples/cli-basic.loom --json
+  loom run examples/cli-basic.loom --get x.out --time 0.25`;
+}
+
+function getCompileHelp() {
+  return `Usage:
+  loom compile <file> [--out <file>] [--pretty false]
+
+Options:
+  -o, --out <file>   Write GraphJSON to a file
+  --pretty false     Print compact JSON`;
+}
+
+function getFormatHelp() {
+  return `Usage:
+  loom format <file> [--write] [--check]
+
+Options:
+  --write   Overwrite the input file
+  --check   Exit 1 if formatting would change the file`;
+}
+
+function getInspectHelp() {
+  return `Usage:
+  loom inspect <file> [--ast] [--graph] [--json]
+
+Options:
+  --ast    Print Source AST JSON
+  --graph  Print GraphJSON
+  --json   Print the full inspection result as JSON`;
+}
+
+function getRunHelp() {
+  return `Usage:
+  loom run <file> --get <ref> [--time <number>] [--dt <number>] [--json]
+
+Options:
+  --get <ref>       Output reference to read. Repeatable.
+  --time <number>   Evaluation time in seconds. Default: 0
+  --dt <number>     Delta time in seconds. Default: 0
+  --json            Print result values as JSON`;
+}
+
+async function readSourceFile(file) {
+  return readFile(path.resolve(process.cwd(), file), 'utf8');
+}
+
+async function handleCompile(args) {
+  if (args.includes('--help')) {
+    print(getCompileHelp());
+    return 0;
+  }
+
+  const { file, rest } = parseCommonCommandArgs(args);
+  if (!file) {
+    throw new Error('compile requires <file>');
+  }
+
+  let outputPath = null;
+  let pretty = true;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (arg === '-o' || arg === '--out') {
+      outputPath = rest[index + 1];
+      index += 1;
+    } else if (arg === '--pretty') {
+      pretty = parseBoolean(rest[index + 1], true);
+      index += 1;
+    } else {
+      throw new Error(`unknown option for compile: ${arg}`);
+    }
+  }
+
+  if (outputPath === null && rest.includes('-o')) {
+    throw new Error('-o requires a file path');
+  }
+  if (outputPath === null && rest.includes('--out')) {
+    throw new Error('--out requires a file path');
+  }
+
+  const source = await readSourceFile(file);
+  const result = compileLoomSource(source, { filename: file, target: 'cli' });
+  if (!result.ok) {
+    printToolErrors(result.errors);
+    return 1;
+  }
+
+  const json = stringifyJson(result.graph, pretty);
+  if (outputPath) {
+    await writeFile(path.resolve(process.cwd(), outputPath), `${json}\n`, 'utf8');
+  } else {
+    print(json);
+  }
+  return 0;
+}
+
+async function handleFormat(args) {
+  if (args.includes('--help')) {
+    print(getFormatHelp());
+    return 0;
+  }
+
+  const { file, rest } = parseCommonCommandArgs(args);
+  if (!file) {
+    throw new Error('format requires <file>');
+  }
+
+  let shouldWrite = false;
+  let shouldCheck = false;
+
+  for (const arg of rest) {
+    if (arg === '--write') {
+      shouldWrite = true;
+    } else if (arg === '--check') {
+      shouldCheck = true;
+    } else {
+      throw new Error(`unknown option for format: ${arg}`);
+    }
+  }
+
+  const source = await readSourceFile(file);
+  const result = formatLoomSource(source, { filename: file });
+  if (!result.ok) {
+    printToolErrors(result.errors);
+    return 1;
+  }
+
+  if (shouldCheck) {
+    if (result.formatted !== source) {
+      printError(`file is not formatted: ${file}`);
+      return 1;
+    }
+    return 0;
+  }
+
+  if (shouldWrite) {
+    await writeFile(path.resolve(process.cwd(), file), result.formatted, 'utf8');
+    return 0;
+  }
+
+  print(result.formatted.trimEnd());
+  return 0;
+}
+
+async function handleInspect(args) {
+  if (args.includes('--help')) {
+    print(getInspectHelp());
+    return 0;
+  }
+
+  const { file, rest } = parseCommonCommandArgs(args);
+  if (!file) {
+    throw new Error('inspect requires <file>');
+  }
+
+  let showAst = false;
+  let showGraph = false;
+  let showJson = false;
+
+  for (const arg of rest) {
+    if (arg === '--ast') {
+      showAst = true;
+    } else if (arg === '--graph') {
+      showGraph = true;
+    } else if (arg === '--json') {
+      showJson = true;
+    } else {
+      throw new Error(`unknown option for inspect: ${arg}`);
+    }
+  }
+
+  const source = await readSourceFile(file);
+  const result = inspectLoomSource(source, { filename: file, target: 'cli' });
+  if (!result.ok) {
+    printToolErrors(result.errors);
+    return 1;
+  }
+
+  if (showJson) {
+    print(stringifyJson(result));
+    return 0;
+  }
+
+  if (showAst) {
+    print(stringifyJson(result.ast));
+    return 0;
+  }
+
+  if (showGraph) {
+    print(stringifyJson(result.graph));
+    return 0;
+  }
+
+  print(formatInspectionSummary(result.summary));
+  return 0;
+}
+
+async function handleRun(args) {
+  if (args.includes('--help')) {
+    print(getRunHelp());
+    return 0;
+  }
+
+  const { file, rest } = parseCommonCommandArgs(args);
+  if (!file) {
+    throw new Error('run requires <file>');
+  }
+
+  const get = [];
+  let time = 0;
+  let dt = 0;
+  let json = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (arg === '--get') {
+      const ref = rest[index + 1];
+      if (!ref) {
+        throw new Error('--get requires a ref');
+      }
+      get.push(ref);
+      index += 1;
+    } else if (arg === '--time') {
+      time = parseNumber(rest[index + 1], '--time');
+      index += 1;
+    } else if (arg === '--dt') {
+      dt = parseNumber(rest[index + 1], '--dt');
+      index += 1;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`unknown option for run: ${arg}`);
+    }
+  }
+
+  const source = await readSourceFile(file);
+  const result = runLoomSource(source, {
+    filename: file,
+    target: 'cli',
+    get: get.length === 1 ? get[0] : get.length > 1 ? get : undefined,
+    time,
+    dt
+  });
+  if (!result.ok) {
+    printToolErrors(result.errors);
+    return 1;
+  }
+
+  if (!json && get.length === 1) {
+    print(String(result.values[get[0]]));
+    return 0;
+  }
+
+  print(stringifyJson(result.values));
+  return 0;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (!command || command === '--help' || command === 'help') {
+    print(getGeneralHelp());
+    return;
+  }
+
+  let exitCode = 0;
+  try {
+    if (command === 'compile') {
+      exitCode = await handleCompile(args.slice(1));
+    } else if (command === 'format') {
+      exitCode = await handleFormat(args.slice(1));
+    } else if (command === 'inspect') {
+      exitCode = await handleInspect(args.slice(1));
+    } else if (command === 'run') {
+      exitCode = await handleRun(args.slice(1));
+    } else {
+      throw new Error(`unknown command: ${command}`);
+    }
+  } catch (error) {
+    printError(error.message || String(error));
+    exitCode = 1;
+  }
+
+  process.exitCode = exitCode;
+}
+
+main();

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -1,0 +1,58 @@
+# Loom CLI Roadmap
+
+## Phase 1: CLI MVP
+
+- compile
+- format
+- inspect
+- run pure graphs
+
+## Phase 2: Import syntax
+
+- import math
+- import scene
+- import fs
+- target compatibility validation
+
+## Phase 3: CLI libraries
+
+- fs.readText
+- fs.writeText
+- console.log
+- json.parse
+- text.upper / lower / replace
+
+## Phase 4: REPL
+
+- interactive prompt
+- incremental graph patching
+- inspect current graph
+- watch values
+
+## Phase 5: SceneSync integration
+
+- compile DSL and send graph
+- target scene scope
+- target object scope
+- clear graph
+- patch graph
+
+## Phase 6: Web Studio integration
+
+- reuse toolchain modules
+- shared diagnostics
+- target/import compatibility panel
+- inspect panel
+
+## Phase 7: AI/MCP integration
+
+- expose compile/format/inspect as tools
+- use inspect summaries to reduce context size
+- validate AI-generated DSL before sending to SceneSync
+
+## Toolchain reuse
+
+- `bin/loom.mjs` is only one UI for the toolchain.
+- Web Studio should call `src/toolchain/compile.js`, `format.js`, and `inspect.js` directly.
+- Scene Sync integrations should compile DSL to GraphJSON with the same toolchain before sending `scene-graph-set` or `scene-graph-patch`.
+- MCP/GPTs tools should also call the same toolchain modules instead of re-implementing parsing or compile logic.

--- a/docs/RUNTIME_TARGETS.md
+++ b/docs/RUNTIME_TARGETS.md
@@ -1,0 +1,21 @@
+# Runtime Targets
+
+Loom DSL programs will eventually target multiple runtimes instead of assuming a browser-only environment.
+
+The new toolchain layer is shared by CLI, Web Studio, Scene Sync, and future AI/MCP integrations. Import syntax is not implemented in this PR, but future imports will declare required libraries and runtime capabilities against the compatibility table below.
+
+Some libraries are universal and should work across every host. Others are intentionally runtime-specific because they depend on DOM APIs, file I/O, rendering adapters, or protocol bridges.
+
+| import | CLI | Web Studio | Scene Sync | Unity | Description |
+|---|---:|---:|---:|---:|---|
+| math | yes | yes | yes | yes | Pure math |
+| state | yes | yes | yes | yes | Explicit state nodes |
+| text | yes | yes | yes | yes | String processing |
+| json | yes | yes | yes | yes | JSON utilities |
+| fs | yes | no | no | no/partial | File I/O |
+| dom | no | yes | no | no | DOM operations |
+| canvas | no | yes | no | no | Canvas preview |
+| scene | no | partial | yes | yes | Scene object control |
+| three | no | yes | partial | no | Three.js adapter |
+| unity | no | no | no | yes | Unity adapter |
+| scenesync | partial | yes | yes | partial | SceneSync protocol |

--- a/examples/cli-basic.loom
+++ b/examples/cli-basic.loom
@@ -1,0 +1,13 @@
+t = clock()
+wave = sine(
+  t,
+  freq: 0.5,
+  amplitude: 2
+)
+x = wave
+  |> map(
+    inMin: -2,
+    inMax: 2,
+    outMin: 0,
+    outMax: 100
+  )

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "loom": "./bin/loom.mjs"
+  },
   "scripts": {
-    "test": "node ci/run-tests.mjs"
+    "test": "node ci/run-tests.mjs",
+    "loom": "node bin/loom.mjs",
+    "test:cli": "node test/loom-cli.test.mjs"
   },
   "devDependencies": {
     "http-server": "^14.1.1",

--- a/src/loom.js
+++ b/src/loom.js
@@ -1067,25 +1067,26 @@ export class Loom {
     NODE_TYPES[name] = definition;
   }
 
-  evaluateAt(time, frameTimestamp = time * 1000) {
-    // 保留中グラフがあれば切り替え
-    if (this._pendingGraph !== null) {
-      // 旧グラフのノードの onStop を呼ぶ
-      if (this._currentGraph) {
-        for (const node of this._currentGraph.nodes) {
-          const nodeType = NODE_TYPES[node.type];
-          if (nodeType.onStop) {
-            nodeType.onStop(node, this);
-          }
+  _activatePendingGraph(runLifecycle = true) {
+    if (this._pendingGraph === null) {
+      return;
+    }
+
+    if (runLifecycle && this._currentGraph) {
+      for (const node of this._currentGraph.nodes) {
+        const nodeType = NODE_TYPES[node.type];
+        if (nodeType.onStop) {
+          nodeType.onStop(node, this);
         }
       }
+    }
 
-      this._reconcileStateForGraph(this._pendingGraph);
-      this._currentGraph = this._pendingGraph;
-      this._sortedNodeIds = this._pendingNodeIds;
-      this._pendingGraph = null;
+    this._reconcileStateForGraph(this._pendingGraph);
+    this._currentGraph = this._pendingGraph;
+    this._sortedNodeIds = this._pendingNodeIds;
+    this._pendingGraph = null;
 
-      // 新グラフのノードの onStart を呼ぶ
+    if (runLifecycle && this._currentGraph) {
       for (const node of this._currentGraph.nodes) {
         const nodeType = NODE_TYPES[node.type];
         if (nodeType.onStart) {
@@ -1093,6 +1094,10 @@ export class Loom {
         }
       }
     }
+  }
+
+  evaluateAt(time, frameTimestamp = time * 1000) {
+    this._activatePendingGraph(true);
 
     // グラフが設定されていなければ何もしない
     if (!this._currentGraph) return;
@@ -1208,6 +1213,16 @@ export class Loom {
         }
       }
     }
+  }
+
+  evaluateOnce({ time = 0, dt = 0 } = {}) {
+    const safeTime = Number.isFinite(time) ? time : 0;
+    const safeDt = Number.isFinite(dt) ? Math.max(0, dt) : 0;
+    const frameTimestamp = safeTime * 1000;
+
+    this._activatePendingGraph(false);
+    this._lastTimestamp = frameTimestamp - (safeDt * 1000);
+    this.evaluateAt(safeTime, frameTimestamp);
   }
 
   getValue(ref) {

--- a/src/toolchain/compile.js
+++ b/src/toolchain/compile.js
@@ -2,30 +2,43 @@ import { parseDSLToAST, compileToGraph } from '../loom-dsl.js';
 import { normalizeLoomError } from './errors.js';
 
 export function compileLoomSource(source, options = {}) {
-  const { ast, errors: parseErrors } = parseDSLToAST(source);
-  if (parseErrors.length > 0) {
+  let ast = null;
+
+  try {
+    const parsed = parseDSLToAST(source);
+    ast = parsed.ast;
+
+    if (parsed.errors.length > 0) {
+      return {
+        ok: false,
+        ast,
+        graph: null,
+        errors: parsed.errors.map(normalizeLoomError)
+      };
+    }
+
+    const compiled = compileToGraph(ast);
+    if (compiled.errors.length > 0) {
+      return {
+        ok: false,
+        ast,
+        graph: null,
+        errors: compiled.errors.map(normalizeLoomError)
+      };
+    }
+
+    return {
+      ok: true,
+      ast,
+      graph: compiled.graph,
+      errors: []
+    };
+  } catch (error) {
     return {
       ok: false,
       ast,
       graph: null,
-      errors: parseErrors.map(normalizeLoomError)
+      errors: [normalizeLoomError(error)]
     };
   }
-
-  const { graph, errors: compileErrors } = compileToGraph(ast);
-  if (compileErrors.length > 0) {
-    return {
-      ok: false,
-      ast,
-      graph: null,
-      errors: compileErrors.map(normalizeLoomError)
-    };
-  }
-
-  return {
-    ok: true,
-    ast,
-    graph,
-    errors: []
-  };
 }

--- a/src/toolchain/compile.js
+++ b/src/toolchain/compile.js
@@ -1,0 +1,31 @@
+import { parseDSLToAST, compileToGraph } from '../loom-dsl.js';
+import { normalizeLoomError } from './errors.js';
+
+export function compileLoomSource(source, options = {}) {
+  const { ast, errors: parseErrors } = parseDSLToAST(source);
+  if (parseErrors.length > 0) {
+    return {
+      ok: false,
+      ast,
+      graph: null,
+      errors: parseErrors.map(normalizeLoomError)
+    };
+  }
+
+  const { graph, errors: compileErrors } = compileToGraph(ast);
+  if (compileErrors.length > 0) {
+    return {
+      ok: false,
+      ast,
+      graph: null,
+      errors: compileErrors.map(normalizeLoomError)
+    };
+  }
+
+  return {
+    ok: true,
+    ast,
+    graph,
+    errors: []
+  };
+}

--- a/src/toolchain/errors.js
+++ b/src/toolchain/errors.js
@@ -1,0 +1,53 @@
+function getSpanLocation(error) {
+  if (typeof error?.line === 'number' || typeof error?.column === 'number') {
+    return {
+      line: typeof error.line === 'number' ? error.line : null,
+      column: typeof error.column === 'number' ? error.column : null
+    };
+  }
+
+  const start = error?.span?.start;
+  if (start && (typeof start.line === 'number' || typeof start.column === 'number')) {
+    return {
+      line: typeof start.line === 'number' ? start.line : null,
+      column: typeof start.column === 'number' ? start.column : null
+    };
+  }
+
+  return { line: null, column: null };
+}
+
+function inferErrorSource(error) {
+  const type = error?.type;
+  const name = error?.name;
+
+  if (type === 'ParseError' || name === 'LoomDSLError') {
+    return 'parse';
+  }
+  if (type === 'CompileError') {
+    return 'compile';
+  }
+  if (name === 'LoomError' || error?.source === 'runtime') {
+    return 'runtime';
+  }
+  return 'unknown';
+}
+
+export function normalizeLoomError(error) {
+  const location = getSpanLocation(error);
+  return {
+    code: error?.code || 'UNKNOWN_ERROR',
+    message: error?.message || 'Unknown Loom error',
+    line: location.line,
+    column: location.column,
+    source: inferErrorSource(error)
+  };
+}
+
+export function formatLoomError(error) {
+  const normalized = normalizeLoomError(error);
+  if (typeof normalized.line === 'number' && typeof normalized.column === 'number') {
+    return `${normalized.code} at ${normalized.line}:${normalized.column} - ${normalized.message}`;
+  }
+  return `${normalized.code} - ${normalized.message}`;
+}

--- a/src/toolchain/format.js
+++ b/src/toolchain/format.js
@@ -2,20 +2,29 @@ import { parseDSLToAST, formatDSL } from '../loom-dsl.js';
 import { normalizeLoomError } from './errors.js';
 
 export function formatLoomSource(source, options = {}) {
-  const { ast, errors } = parseDSLToAST(source);
-  if (errors.length > 0 || !ast) {
+  try {
+    const { ast, errors } = parseDSLToAST(source);
+    if (errors.length > 0 || !ast) {
+      return {
+        ok: false,
+        formatted: null,
+        ast: ast || null,
+        errors: errors.map(normalizeLoomError)
+      };
+    }
+
+    return {
+      ok: true,
+      formatted: formatDSL(ast, options.formatOptions || {}),
+      ast,
+      errors: []
+    };
+  } catch (error) {
     return {
       ok: false,
       formatted: null,
       ast: null,
-      errors: errors.map(normalizeLoomError)
+      errors: [normalizeLoomError(error)]
     };
   }
-
-  return {
-    ok: true,
-    formatted: formatDSL(ast, options.formatOptions || {}),
-    ast,
-    errors: []
-  };
 }

--- a/src/toolchain/format.js
+++ b/src/toolchain/format.js
@@ -1,0 +1,21 @@
+import { parseDSLToAST, formatDSL } from '../loom-dsl.js';
+import { normalizeLoomError } from './errors.js';
+
+export function formatLoomSource(source, options = {}) {
+  const { ast, errors } = parseDSLToAST(source);
+  if (errors.length > 0 || !ast) {
+    return {
+      ok: false,
+      formatted: null,
+      ast: null,
+      errors: errors.map(normalizeLoomError)
+    };
+  }
+
+  return {
+    ok: true,
+    formatted: formatDSL(ast, options.formatOptions || {}),
+    ast,
+    errors: []
+  };
+}

--- a/src/toolchain/index.js
+++ b/src/toolchain/index.js
@@ -1,0 +1,6 @@
+export * from './compile.js';
+export * from './format.js';
+export * from './inspect.js';
+export * from './run.js';
+export * from './errors.js';
+export * from './runtime-targets.js';

--- a/src/toolchain/inspect.js
+++ b/src/toolchain/inspect.js
@@ -1,0 +1,54 @@
+import { compileLoomSource } from './compile.js';
+
+function summarizeGraph(graph) {
+  return {
+    nodeCount: graph.nodes.length,
+    edgeCount: graph.edges.length,
+    renderType: graph.render?.type || 'none',
+    nodes: graph.nodes.map((node) => ({ id: node.id, type: node.type })),
+    imports: [],
+    requiredCapabilities: [],
+    compatibleTargets: []
+  };
+}
+
+export function inspectLoomGraph(graph, options = {}) {
+  return {
+    ok: true,
+    ast: options.ast || null,
+    graph,
+    summary: summarizeGraph(graph),
+    errors: []
+  };
+}
+
+export function inspectLoomSource(source, options = {}) {
+  const compiled = compileLoomSource(source, options);
+  if (!compiled.ok || !compiled.graph) {
+    return {
+      ok: false,
+      ast: compiled.ast,
+      graph: null,
+      summary: null,
+      errors: compiled.errors
+    };
+  }
+
+  return inspectLoomGraph(compiled.graph, { ast: compiled.ast });
+}
+
+export function formatInspectionSummary(summary) {
+  const lines = [
+    `Nodes: ${summary.nodeCount}`,
+    `Edges: ${summary.edgeCount}`,
+    `Render: ${summary.renderType}`,
+    '',
+    'Node list:'
+  ];
+
+  for (const node of summary.nodes) {
+    lines.push(`- ${node.id}: ${node.type}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/toolchain/run.js
+++ b/src/toolchain/run.js
@@ -1,0 +1,95 @@
+import { Loom, LoomError, NODE_TYPES } from '../loom.js';
+import { compileLoomSource } from './compile.js';
+import { normalizeLoomError } from './errors.js';
+
+const CLI_SAFE_CATEGORIES = new Set(['source', 'transform', 'state']);
+
+function getRefsToRead(graph, get) {
+  if (Array.isArray(get)) {
+    return get;
+  }
+  if (typeof get === 'string' && get.length > 0) {
+    return [get];
+  }
+  return null;
+}
+
+function getDefaultOutputPort(node) {
+  const nodeType = NODE_TYPES[node.type];
+  if (!nodeType || !Array.isArray(nodeType.outputs) || nodeType.outputs.length === 0) {
+    return null;
+  }
+  if (nodeType.outputs.length === 1) {
+    return nodeType.outputs[0].name;
+  }
+  const outPort = nodeType.outputs.find((output) => output.name === 'out');
+  return outPort ? outPort.name : nodeType.outputs[0].name;
+}
+
+function validateCliRunnableGraph(graph) {
+  for (const node of graph.nodes) {
+    const nodeType = NODE_TYPES[node.type];
+    if (!nodeType) {
+      throw new LoomError('UNKNOWN_NODE_TYPE', `Unknown node type: ${node.type}`, { nodeId: node.id, type: node.type });
+    }
+    if (!CLI_SAFE_CATEGORIES.has(nodeType.category)) {
+      throw new LoomError(
+        'UNSUPPORTED_RUNTIME_NODE',
+        `Node '${node.id}' of type '${node.type}' is not supported by CLI run`,
+        { nodeId: node.id, type: node.type, category: nodeType.category }
+      );
+    }
+  }
+}
+
+function collectRequestedValues(engine, graph, get) {
+  const requestedRefs = getRefsToRead(graph, get);
+  if (requestedRefs === null) {
+    throw new LoomError('GET_REQUIRED', 'run requires --get in this version');
+  }
+
+  const values = {};
+  for (const ref of requestedRefs) {
+    values[ref] = engine.getValue(ref);
+  }
+  return values;
+}
+
+export function runLoomGraph(graph, options = {}) {
+  try {
+    validateCliRunnableGraph(graph);
+    const engine = new Loom(graph);
+    engine.evaluateOnce({
+      time: Number.isFinite(options.time) ? options.time : 0,
+      dt: Number.isFinite(options.dt) ? options.dt : 0
+    });
+
+    return {
+      ok: true,
+      values: collectRequestedValues(engine, graph, options.get),
+      graph,
+      errors: []
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      values: {},
+      graph,
+      errors: [normalizeLoomError(error)]
+    };
+  }
+}
+
+export function runLoomSource(source, options = {}) {
+  const compiled = compileLoomSource(source, options);
+  if (!compiled.ok || !compiled.graph) {
+    return {
+      ok: false,
+      values: {},
+      graph: compiled.graph,
+      errors: compiled.errors
+    };
+  }
+
+  return runLoomGraph(compiled.graph, options);
+}

--- a/src/toolchain/runtime-targets.js
+++ b/src/toolchain/runtime-targets.js
@@ -1,0 +1,98 @@
+export const RUNTIME_TARGETS = ['cli', 'web', 'scenesync', 'unity', 'any'];
+
+export const LIBRARY_COMPATIBILITY = {
+  math: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'pure',
+    description: 'Pure math and numeric transform nodes'
+  },
+  state: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'state',
+    description: 'Explicit time-based state nodes'
+  },
+  text: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'pure',
+    description: 'String processing utilities'
+  },
+  json: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'pure',
+    description: 'JSON parse/stringify utilities'
+  },
+  fs: {
+    targets: ['cli'],
+    kind: 'effect',
+    description: 'File system access'
+  },
+  console: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'effect',
+    description: 'Logging to the host environment'
+  },
+  dom: {
+    targets: ['web'],
+    kind: 'effect',
+    description: 'DOM input and DOM sink nodes'
+  },
+  canvas: {
+    targets: ['web'],
+    kind: 'renderer',
+    description: 'Canvas preview renderer'
+  },
+  scene: {
+    targets: ['scenesync', 'unity', 'web'],
+    kind: 'effect',
+    description: 'Scene object control through a host adapter'
+  },
+  three: {
+    targets: ['web'],
+    kind: 'adapter',
+    description: 'Three.js Object3D adapter'
+  },
+  unity: {
+    targets: ['unity'],
+    kind: 'adapter',
+    description: 'Unity-specific runtime adapter'
+  },
+  scenesync: {
+    targets: ['web', 'scenesync', 'unity'],
+    kind: 'protocol',
+    description: 'SceneSync graph/message integration'
+  }
+};
+
+export function isKnownRuntimeTarget(target) {
+  return RUNTIME_TARGETS.includes(target);
+}
+
+export function isKnownLibrary(name) {
+  return Object.hasOwn(LIBRARY_COMPATIBILITY, name);
+}
+
+export function isLibraryAvailableInTarget(name, target) {
+  if (!isKnownLibrary(name) || !isKnownRuntimeTarget(target)) {
+    return false;
+  }
+  if (target === 'any') {
+    return true;
+  }
+  return LIBRARY_COMPATIBILITY[name].targets.includes(target);
+}
+
+export function getLibraryCompatibility(name) {
+  return isKnownLibrary(name) ? LIBRARY_COMPATIBILITY[name] : null;
+}
+
+export function listLibrariesForTarget(target) {
+  if (!isKnownRuntimeTarget(target)) {
+    return [];
+  }
+  if (target === 'any') {
+    return Object.entries(LIBRARY_COMPATIBILITY).map(([name, info]) => ({ name, ...info }));
+  }
+  return Object.entries(LIBRARY_COMPATIBILITY)
+    .filter(([, info]) => info.targets.includes(target))
+    .map(([name, info]) => ({ name, ...info }));
+}

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -40,6 +40,42 @@ test('compile -o writes file', async () => {
   assert.ok(Array.isArray(graph.nodes));
 });
 
+test('compile -o without path exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '-o']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /requires a file path/);
+});
+
+test('compile --out without path exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '--out']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /requires a file path/);
+});
+
+test('compile -o followed by another option exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '-o', '--pretty', 'false']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /requires a file path/);
+});
+
+test('compile --pretty without value exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '--pretty']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--pretty requires true or false/);
+});
+
+test('compile --pretty invalid value exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '--pretty', 'maybe']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /true or false|Invalid/);
+});
+
+test('compile unknown option exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '--unknown']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown option/);
+});
+
 test('format outputs DSL', () => {
   const result = runCli(['format', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);
@@ -52,6 +88,12 @@ test('format --check succeeds for formatted file', () => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test('format unknown option exits 1', () => {
+  const result = runCli(['format', 'examples/cli-basic.loom', '--unknown']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown option/);
+});
+
 test('inspect outputs summary', () => {
   const result = runCli(['inspect', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);
@@ -61,6 +103,12 @@ test('inspect outputs summary', () => {
   assert.match(result.stdout, /clock/);
   assert.match(result.stdout, /sine/);
   assert.match(result.stdout, /map/);
+});
+
+test('inspect unknown option exits 1', () => {
+  const result = runCli(['inspect', 'examples/cli-basic.loom', '--unknown']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown option/);
 });
 
 test('parse error exits 1', async () => {
@@ -86,6 +134,12 @@ test('run --json returns object', () => {
   const values = JSON.parse(result.stdout);
   assert.equal(typeof values['x.out'], 'number');
   assert.equal(Number.isFinite(values['x.out']), true);
+});
+
+test('run unknown option exits 1', () => {
+  const result = runCli(['run', 'examples/cli-basic.loom', '--unknown']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown option/);
 });
 
 test('run rejects browser-only nodes with a clear error', async () => {

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+
+function runCli(args) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: projectRoot,
+    encoding: 'utf8'
+  });
+}
+
+test('compile outputs GraphJSON', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom']);
+  assert.equal(result.status, 0, result.stderr);
+
+  const graph = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(graph.nodes));
+  assert.ok(graph.nodes.some((node) => node.type === 'clock'));
+  assert.ok(graph.nodes.some((node) => node.type === 'sine'));
+  assert.ok(graph.nodes.some((node) => node.type === 'map'));
+});
+
+test('compile -o writes file', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-'));
+  const outFile = path.join(tmpDir, 'graph.json');
+  const result = runCli(['compile', 'examples/cli-basic.loom', '-o', outFile]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(outFile), true);
+  const graph = JSON.parse(await fsp.readFile(outFile, 'utf8'));
+  assert.ok(Array.isArray(graph.nodes));
+});
+
+test('format outputs DSL', () => {
+  const result = runCli(['format', 'examples/cli-basic.loom']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /t = clock\(\)/);
+  assert.match(result.stdout, /\|>/);
+});
+
+test('format --check succeeds for formatted file', () => {
+  const result = runCli(['format', 'examples/cli-basic.loom', '--check']);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('inspect outputs summary', () => {
+  const result = runCli(['inspect', 'examples/cli-basic.loom']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Nodes:/);
+  assert.match(result.stdout, /Edges:/);
+  assert.match(result.stdout, /Node list:/);
+  assert.match(result.stdout, /clock/);
+  assert.match(result.stdout, /sine/);
+  assert.match(result.stdout, /map/);
+});
+
+test('parse error exits 1', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-invalid-'));
+  const invalidFile = path.join(tmpDir, 'invalid.loom');
+  await fsp.writeFile(invalidFile, 'x =\n', 'utf8');
+
+  const result = runCli(['compile', invalidFile]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /UNEXPECTED_TOKEN|Expected assignment|Unexpected token/);
+});
+
+test('run --get returns finite number', () => {
+  const result = runCli(['run', 'examples/cli-basic.loom', '--get', 'x.out', '--time', '0.25']);
+  assert.equal(result.status, 0, result.stderr);
+  const value = Number(result.stdout.trim());
+  assert.equal(Number.isFinite(value), true);
+});
+
+test('run --json returns object', () => {
+  const result = runCli(['run', 'examples/cli-basic.loom', '--get', 'x.out', '--time', '0.25', '--json']);
+  assert.equal(result.status, 0, result.stderr);
+  const values = JSON.parse(result.stdout);
+  assert.equal(typeof values['x.out'], 'number');
+  assert.equal(Number.isFinite(values['x.out']), true);
+});
+
+test('run rejects browser-only nodes with a clear error', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-unsupported-'));
+  const file = path.join(tmpDir, 'unsupported.loom');
+  await fsp.writeFile(file, 'x = constant(value: 1)\ny = setText(x, target: "#app")\n', 'utf8');
+
+  const result = runCli(['run', file, '--get', 'x.out']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /UNSUPPORTED_RUNTIME_NODE/);
+});
+
+test('evaluateOnce supports Node-safe one-shot evaluation', async () => {
+  const { Loom } = await import(path.join(projectRoot, 'src', 'loom.js'));
+  const graph = {
+    nodes: [
+      { id: 't', type: 'clock' },
+      { id: 'wave', type: 'sine', params: { freq: 0.5, amplitude: 2 } }
+    ],
+    edges: [
+      { from: 't.t', to: 'wave.t' }
+    ]
+  };
+
+  const engine = new Loom(graph);
+  engine.evaluateOnce({ time: 0.25, dt: 0 });
+  const value = engine.getValue('wave.out');
+
+  assert.equal(Number.isFinite(value), true);
+});


### PR DESCRIPTION
## What changed

This PR adds a reusable Loom toolchain layer and a first CLI MVP built on top of it.

- adds `src/toolchain/` modules for `compile`, `format`, `inspect`, `run`, error normalization, and runtime target compatibility metadata
- adds `bin/loom.mjs` with `compile`, `format`, `inspect`, and `run` commands
- adds a Node-safe one-shot runtime API via `engine.evaluateOnce({ time, dt })`
- adds `examples/cli-basic.loom`
- adds Node-based CLI tests and `npm run test:cli`
- documents the CLI, runtime targets, roadmap, and toolchain reuse path

## Why

The goal is to move Loom toward a shared language toolchain that can be reused from CLI, Web Studio, Scene Sync, MCP, and GPT-style integrations, instead of keeping compile/format/run logic embedded in one UI.

This establishes the common path:

`DSL -> AST -> GraphJSON -> inspect / run`

## Impact

- CLI users can now compile, format, inspect, and run simple Loom DSL files from Node.js
- Web Studio and future integrations have a dedicated shared toolchain import surface
- Node-based validation is now available without relying on browser APIs for simple graph execution

## Validation

- `npm run test:cli`
- manual checks:
  - `node bin/loom.mjs --help`
  - `node bin/loom.mjs compile examples/cli-basic.loom`
  - `node bin/loom.mjs format examples/cli-basic.loom`
  - `node bin/loom.mjs inspect examples/cli-basic.loom`
  - `node bin/loom.mjs run examples/cli-basic.loom --get x.out --time 0.25`
  - `node bin/loom.mjs run examples/cli-basic.loom --get x.out --time 0.25 --json`

Note: `npm test` was not completed in this environment because Playwright Chromium was not available locally.

## Non-goals

This PR does not implement:

- Loom import syntax
- file I/O nodes
- fs capability
- SceneSync send command
- REPL
- watch mode
- package/module loading
- property assignment syntax
- command buffer
- core/nodes package split
- Unity changes