### PR TITLE
[codex] Add Loom DSL import syntax and target validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,15 @@ Loom CLI は Loom DSL の最初のターミナルインターフェースです�
 
 現在の CLI は、Loom DSL を GraphJSON に変換し、整形し、要約を取り、単純な pure/source/transform/state グラフを 1 回実行する用途に向いています。
 
+最小の import metadata と target validation もサポートしています。
+
 ```bash
 npm run loom -- compile examples/cli-basic.loom
 npm run loom -- format examples/cli-basic.loom
 npm run loom -- inspect examples/cli-basic.loom
 npm run loom -- run examples/cli-basic.loom --get x.out --time 1
+npm run loom -- compile script.loom --target cli
+npm run loom -- inspect script.loom --target web
 ```
 
 ```bash
@@ -177,7 +181,18 @@ node bin/loom.mjs run examples/cli-basic.loom --get x.out --time 1
 
 - CLI run は pure/source/transform/state ノード中心の実行にフォーカスしています。
 - DOM / Three.js / Unity / SceneSync アダプタは CLI からは実行しません。
-- file I/O ノードと import syntax は今後の作業です。
+- file I/O ノードの実体、module loading、named/alias import は今後の作業です。
+
+例:
+
+```text
+import math
+import fs
+
+x = constant(value: 1)
+```
+
+`compile` と `inspect` の `--target` は省略時に `any` として扱われ、runtime-specific import を generic workflow 用に許可します。`run` は省略時に `cli` で検証するため、たとえば `import dom` は CLI 実行時に失敗します。
 
 ## ライブエディタと DSL
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -133,7 +133,7 @@ Options:
   --time <number>   Evaluation time in seconds. Default: 0
   --dt <number>     Delta time in seconds. Default: 0
   --json            Print result values as JSON
-  --target <target> Validate imports for a runtime target. Default: cli`;
+  --target <target> Only cli is supported by loom run in this version. Default: cli`;
 }
 
 async function readSourceFile(file) {
@@ -341,6 +341,10 @@ async function handleRun(args) {
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
+  }
+
+  if (target !== 'cli') {
+    throw new Error('loom run currently only supports --target cli');
   }
 
   const source = await readSourceFile(file);

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -9,7 +9,8 @@ import {
   inspectLoomSource,
   formatInspectionSummary,
   runLoomSource,
-  formatLoomError
+  formatLoomError,
+  isKnownRuntimeTarget
 } from '../src/toolchain/index.js';
 
 function print(message = '') {
@@ -42,6 +43,16 @@ function parseNumber(value, optionName) {
     throw new Error(`${optionName} expects a finite number`);
   }
   return parsed;
+}
+
+function parseTarget(value) {
+  if (!value || value.startsWith('-')) {
+    throw new Error('--target requires a runtime target');
+  }
+  if (!isKnownRuntimeTarget(value)) {
+    throw new Error(`Unknown runtime target: ${value}`);
+  }
+  return value;
 }
 
 function parseCommonCommandArgs(args) {
@@ -85,11 +96,12 @@ Examples:
 
 function getCompileHelp() {
   return `Usage:
-  loom compile <file> [--out <file>] [--pretty false]
+  loom compile <file> [--out <file>] [--pretty false] [--target <target>]
 
 Options:
   -o, --out <file>   Write GraphJSON to a file
-  --pretty false     Print compact JSON`;
+  --pretty false     Print compact JSON
+  --target <target>  Validate imports for a runtime target. Default: any`;
 }
 
 function getFormatHelp() {
@@ -103,23 +115,25 @@ Options:
 
 function getInspectHelp() {
   return `Usage:
-  loom inspect <file> [--ast] [--graph] [--json]
+  loom inspect <file> [--ast] [--graph] [--json] [--target <target>]
 
 Options:
   --ast    Print Source AST JSON
   --graph  Print GraphJSON
-  --json   Print the full inspection result as JSON`;
+  --json   Print the full inspection result as JSON
+  --target <target>  Validate imports for a runtime target. Default: any`;
 }
 
 function getRunHelp() {
   return `Usage:
-  loom run <file> --get <ref> [--time <number>] [--dt <number>] [--json]
+  loom run <file> --get <ref> [--time <number>] [--dt <number>] [--json] [--target <target>]
 
 Options:
   --get <ref>       Output reference to read. Repeatable.
   --time <number>   Evaluation time in seconds. Default: 0
   --dt <number>     Delta time in seconds. Default: 0
-  --json            Print result values as JSON`;
+  --json            Print result values as JSON
+  --target <target> Validate imports for a runtime target. Default: cli`;
 }
 
 async function readSourceFile(file) {
@@ -139,6 +153,7 @@ async function handleCompile(args) {
 
   let outputPath = null;
   let pretty = true;
+  let target = 'any';
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
@@ -156,13 +171,16 @@ async function handleCompile(args) {
       }
       pretty = parseBoolean(next);
       index += 1;
+    } else if (arg === '--target') {
+      target = parseTarget(rest[index + 1]);
+      index += 1;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
   }
 
   const source = await readSourceFile(file);
-  const result = compileLoomSource(source, { filename: file, target: 'cli' });
+  const result = compileLoomSource(source, { filename: file, target });
   if (!result.ok) {
     printToolErrors(result.errors);
     return 1;
@@ -239,21 +257,26 @@ async function handleInspect(args) {
   let showAst = false;
   let showGraph = false;
   let showJson = false;
+  let target = 'any';
 
-  for (const arg of rest) {
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
     if (arg === '--ast') {
       showAst = true;
     } else if (arg === '--graph') {
       showGraph = true;
     } else if (arg === '--json') {
       showJson = true;
+    } else if (arg === '--target') {
+      target = parseTarget(rest[index + 1]);
+      index += 1;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
   }
 
   const source = await readSourceFile(file);
-  const result = inspectLoomSource(source, { filename: file, target: 'cli' });
+  const result = inspectLoomSource(source, { filename: file, target });
   if (!result.ok) {
     printToolErrors(result.errors);
     return 1;
@@ -293,6 +316,7 @@ async function handleRun(args) {
   let time = 0;
   let dt = 0;
   let json = false;
+  let target = 'cli';
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
@@ -311,6 +335,9 @@ async function handleRun(args) {
       index += 1;
     } else if (arg === '--json') {
       json = true;
+    } else if (arg === '--target') {
+      target = parseTarget(rest[index + 1]);
+      index += 1;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -319,7 +346,7 @@ async function handleRun(args) {
   const source = await readSourceFile(file);
   const result = runLoomSource(source, {
     filename: file,
-    target: 'cli',
+    target,
     get: get.length === 1 ? get[0] : get.length > 1 ? get : undefined,
     time,
     dt

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -9,6 +9,8 @@
 
 ## Phase 2: Import syntax
 
+- minimal `import math` / `import fs` / `import scene`
+- runtime target validation
 - import math
 - import scene
 - import fs

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -36,6 +36,49 @@ wave = sine(t, freq: 0.3)
 t = clock()  # 時間ソース
 ```
 
+### import 文
+
+Loom DSL はトップレベルの `import` 文をサポートします。
+
+```text
+import math
+import fs
+import scene
+```
+
+現時点の `import` は metadata / target validation 用です。実際の module loading や node library の自動登録はまだ行いません。
+
+`import` は、代入文や `render` 文より前に書く必要があります。
+
+```text
+import math
+
+t = clock()
+x = sine(t, freq: 0.5)
+```
+
+以下はエラーです。
+
+```text
+t = clock()
+import math
+```
+
+library name は単純な識別子のみ対応します。
+
+```text
+import math
+```
+
+以下は未対応です。
+
+```text
+import math.extra
+import { sine } from math
+from math import sine
+import math as m
+```
+
 ### 代入文
 
 ```
@@ -229,6 +272,10 @@ smooth = smoothLerp(wave, rate: 5, initial: 0)
 | `UNKNOWN_NODE_TYPE` | 未知のノード型 |
 | `MISSING_ARGUMENT_NAME` | 引数名が必要 |
 | `UNDEFINED_IDENTIFIER` | 未定義の識別子 |
+| `IMPORT_MUST_BE_TOP_LEVEL` | `import` 文が代入文または `render` 文の後に書かれている |
+| `UNKNOWN_IMPORT` | 未知の import library |
+| `UNSUPPORTED_IMPORT` | 指定 runtime target で利用できない import library |
+| `UNKNOWN_RUNTIME_TARGET` | 未知の runtime target |
 
 ---
 

--- a/docs/RUNTIME_TARGETS.md
+++ b/docs/RUNTIME_TARGETS.md
@@ -1,8 +1,16 @@
 # Runtime Targets
 
-Loom DSL programs will eventually target multiple runtimes instead of assuming a browser-only environment.
+Loom DSL programs can now declare minimal top-level imports and will eventually target multiple runtimes instead of assuming a browser-only environment.
 
-The new toolchain layer is shared by CLI, Web Studio, Scene Sync, and future AI/MCP integrations. Import syntax is not implemented in this PR, but future imports will declare required libraries and runtime capabilities against the compatibility table below.
+The new toolchain layer is shared by CLI, Web Studio, Scene Sync, and future AI/MCP integrations. This PR only supports simple line-based imports:
+
+```text
+import math
+import fs
+import scene
+```
+
+Imports are metadata and validation only in this phase. They do not load modules yet and do not add library-specific nodes by themselves.
 
 Some libraries are universal and should work across every host. Others are intentionally runtime-specific because they depend on DOM APIs, file I/O, rendering adapters, or protocol bridges.
 
@@ -19,3 +27,20 @@ Some libraries are universal and should work across every host. Others are inten
 | three | no | yes | partial | no | Three.js adapter |
 | unity | no | no | no | yes | Unity adapter |
 | scenesync | partial | yes | yes | partial | SceneSync protocol |
+
+## Target validation
+
+- `loom compile ... --target <target>` validates imports for a runtime target.
+- `loom inspect ... --target <target>` validates imports and reports compatible targets.
+- `loom run ...` defaults to `--target cli`.
+- `compile` and `inspect` default to `target: any`, which allows runtime-specific imports for generic parse/format/inspect workflows.
+
+Example:
+
+```text
+import fs
+x = constant(value: 1)
+```
+
+- `loom compile script.loom --target cli` succeeds
+- `loom compile script.loom --target web` fails with `UNSUPPORTED_IMPORT`

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -86,6 +86,7 @@ export function parseDSLToAST(source) {
     const tokens = tokenize(source);
     let p = 0;
     const body = [];
+    const imports = [];
     let pendingComments = [];
     const peek = (o = 0) => tokens[Math.min(p + o, tokens.length - 1)];
     const take = () => tokens[p++];
@@ -111,6 +112,7 @@ export function parseDSLToAST(source) {
       const end = expect(TT.RPAREN); return { type: 'CallExpression', callee, args, span: spanFrom(nt.span.start, end.span.end) }; }
 
     let blankLines = 0;
+    let seenNonImportStatement = false;
     function flushPendingAsStandalone() {
       if (!pendingComments.length) return;
       for (const c of pendingComments) body.push({ type: 'CommentStatement', comment: c, span: c.span });
@@ -132,10 +134,43 @@ export function parseDSLToAST(source) {
       }
       blankLines = 0;
       const stTok = peek();
+      if (stTok.type === TT.IDENT && stTok.value === 'import') {
+        if (seenNonImportStatement) {
+          throw new LoomDSLError('Import statements must appear before other statements', stTok.span.start.line, stTok.span.start.column, 'IMPORT_MUST_BE_TOP_LEVEL');
+        }
+        take();
+        const libTok = peek();
+        if (libTok.type !== TT.IDENT) {
+          throw new LoomDSLError('Expected library name after import', stTok.span.end.line, stTok.span.end.column, 'UNEXPECTED_TOKEN');
+        }
+        take();
+        if (peek().type !== TT.NEWLINE && peek().type !== TT.EOF && peek().type !== TT.COMMENT) {
+          throw new LoomDSLError('Import names must be simple identifiers', peek().span.start.line, peek().span.start.column, 'UNEXPECTED_TOKEN');
+        }
+        const importDecl = {
+          type: 'ImportDeclaration',
+          name: libTok.value,
+          line: stTok.span.start.line,
+          column: stTok.span.start.column,
+          span: spanFrom(stTok.span.start, libTok.span.end)
+        };
+        if (pendingComments.length) {
+          importDecl.leadingComments = pendingComments;
+          pendingComments = [];
+        }
+        if (peek().type === TT.COMMENT) {
+          const ct = take();
+          importDecl.trailingComment = { type: 'Comment', text: ct.value, variant: 'line', span: ct.span };
+        }
+        if (peek().type === TT.NEWLINE) take();
+        imports.push(importDecl);
+        continue;
+      }
       let stmt;
       if (stTok.type === TT.IDENT && stTok.value === 'render') { take(); const call = parseCall(); stmt = { type: 'RenderStatement', call, span: spanFrom(stTok.span.start, call.span.end) }; }
       else if (stTok.type === TT.IDENT && peek(1).type === TT.ASSIGN) { const target = mkIdent(take()); take(); const value = parseExpr(); stmt = { type: 'AssignmentStatement', target, value, span: spanFrom(target.span.start, value.span.end) }; }
       else throw new LoomDSLError('Expected assignment or render statement', stTok.span.start.line, stTok.span.start.column, 'UNEXPECTED_TOKEN');
+      seenNonImportStatement = true;
       if (pendingComments.length) { stmt.leadingComments = pendingComments; pendingComments = []; }
       if (peek().type === TT.COMMENT) { const ct = take(); stmt.trailingComment = { type: 'Comment', text: ct.value, variant: 'line', span: ct.span }; }
       if (peek().type === TT.NEWLINE) take();
@@ -143,7 +178,7 @@ export function parseDSLToAST(source) {
     }
     flushPendingAsStandalone();
     const end = tokens[tokens.length - 1].span.end;
-    return { ast: { type: 'Program', body, span: spanFrom(posFrom(1, 1, 0), end) }, errors };
+    return { ast: { type: 'Program', imports, body, span: spanFrom(posFrom(1, 1, 0), end) }, errors };
   } catch (e) {
     // TODO: support error recovery to collect multiple errors
     errors.push({ type: 'ParseError', message: e.message, code: e.code || 'UNEXPECTED_TOKEN', span: { start: { line: e.line || 1, column: e.column || 1, offset: 0 }, end: { line: e.line || 1, column: e.column || 1, offset: 0 } } });
@@ -164,7 +199,10 @@ export function compileToGraph(ast) { /* bridge via existing shape */
   const errors = []; if (!ast) return { graph: { nodes: [], edges: [] }, errors };
   try {
     const textAst = astToLegacy(ast);
-    const graph = buildGraph(textAst);
+    const graph = buildGraph(textAst.statements);
+    if (textAst.imports.length > 0) {
+      graph.imports = textAst.imports;
+    }
     return { graph, errors };
   } catch (e) {
     const span = (typeof e.line === 'number' && typeof e.column === 'number')
@@ -205,7 +243,12 @@ function astToLegacy(program) {
     }
     throw new LoomDSLError('Unsupported JSON literal', line, col, 'UNEXPECTED_TOKEN');
   }
-  return program.body.filter(s => s.type !== 'CommentStatement').map(s => s.type === 'RenderStatement' ? { type: 'render', call: convExpr(s.call) } : { type: 'assign', name: s.target.name, expr: convExpr(s.value) });
+  return {
+    imports: (program.imports || []).map((entry) => entry.name),
+    statements: program.body
+      .filter(s => s.type !== 'CommentStatement')
+      .map(s => s.type === 'RenderStatement' ? { type: 'render', call: convExpr(s.call) } : { type: 'assign', name: s.target.name, expr: convExpr(s.value) })
+  };
 }
 
 function buildGraph(stmts) { /* mostly original */
@@ -274,6 +317,13 @@ export function formatDSL(ast, options = {}) {
     return `${call.callee.name}(\n${body}\n${indent(level)})`;
   }
 
+  const importLines = [];
+  for (const entry of ast.imports || []) {
+    if (entry.leadingComments) for (const c of entry.leadingComments) importLines.push(`#${c.text}`);
+    let line = `import ${entry.name}`;
+    if (entry.trailingComment) line += `  #${entry.trailingComment.text}`;
+    importLines.push(line);
+  }
   const lines = [];
   for (const s of ast.body) {
     if (s.type === 'CommentStatement') { lines.push(`#${s.comment.text}`); continue; }
@@ -283,7 +333,10 @@ export function formatDSL(ast, options = {}) {
     if (s.trailingComment) line += `  #${s.trailingComment.text}`;
     lines.push(line);
   }
-  return `${lines.join('\n')}\n`;
+  const sections = [];
+  if (importLines.length > 0) sections.push(importLines.join('\n'));
+  if (lines.length > 0) sections.push(lines.join('\n'));
+  return `${sections.join('\n\n')}\n`;
 }
 
 export function parseDSL(text) {

--- a/src/toolchain/compile.js
+++ b/src/toolchain/compile.js
@@ -1,10 +1,95 @@
 import { parseDSLToAST, compileToGraph } from '../loom-dsl.js';
 import { normalizeLoomError } from './errors.js';
+import {
+  RUNTIME_TARGETS,
+  isKnownLibrary,
+  isKnownRuntimeTarget,
+  isLibraryAvailableInTarget,
+  getLibraryCompatibility
+} from './runtime-targets.js';
+
+const DEFAULT_COMPATIBLE_TARGETS = RUNTIME_TARGETS.filter((target) => target !== 'any');
+
+function normalizeImportName(entry) {
+  return typeof entry === 'string' ? entry : entry.name;
+}
+
+export function getImportedLibraries(ast) {
+  return (ast?.imports || []).map(normalizeImportName);
+}
+
+export function getCompatibleTargetsForImports(importNames) {
+  if (!importNames || importNames.length === 0) {
+    return [...DEFAULT_COMPATIBLE_TARGETS];
+  }
+
+  let compatibleTargets = [...DEFAULT_COMPATIBLE_TARGETS];
+  for (const name of importNames) {
+    const info = getLibraryCompatibility(name);
+    if (!info) {
+      return [];
+    }
+    compatibleTargets = compatibleTargets.filter((target) => info.targets.includes(target));
+  }
+  return compatibleTargets;
+}
+
+function validateTarget(target) {
+  if (target === undefined || target === null) {
+    return [];
+  }
+  if (!isKnownRuntimeTarget(target)) {
+    return [{
+      code: 'UNKNOWN_RUNTIME_TARGET',
+      message: `Unknown runtime target: ${target}`,
+      line: null,
+      column: null,
+      source: 'compile'
+    }];
+  }
+  return [];
+}
+
+function validateImports(ast, target) {
+  const errors = [];
+  for (const entry of ast?.imports || []) {
+    if (!isKnownLibrary(entry.name)) {
+      errors.push({
+        code: 'UNKNOWN_IMPORT',
+        message: `Unknown import: ${entry.name}`,
+        line: entry.line ?? entry.span?.start?.line ?? null,
+        column: entry.column ?? entry.span?.start?.column ?? null,
+        source: 'compile'
+      });
+      continue;
+    }
+    if (target && target !== 'any' && !isLibraryAvailableInTarget(entry.name, target)) {
+      errors.push({
+        code: 'UNSUPPORTED_IMPORT',
+        message: `Import '${entry.name}' is not available in target '${target}'`,
+        line: entry.line ?? entry.span?.start?.line ?? null,
+        column: entry.column ?? entry.span?.start?.column ?? null,
+        source: 'compile'
+      });
+    }
+  }
+  return errors;
+}
 
 export function compileLoomSource(source, options = {}) {
   let ast = null;
 
   try {
+    const targetErrors = validateTarget(options.target);
+    if (targetErrors.length > 0) {
+      return {
+        ok: false,
+        ast,
+        graph: null,
+        errors: targetErrors
+      };
+    }
+
     const parsed = parseDSLToAST(source);
     ast = parsed.ast;
 
@@ -14,6 +99,16 @@ export function compileLoomSource(source, options = {}) {
         ast,
         graph: null,
         errors: parsed.errors.map(normalizeLoomError)
+      };
+    }
+
+    const importErrors = validateImports(ast, options.target ?? 'any');
+    if (importErrors.length > 0) {
+      return {
+        ok: false,
+        ast,
+        graph: null,
+        errors: importErrors
       };
     }
 

--- a/src/toolchain/errors.js
+++ b/src/toolchain/errors.js
@@ -18,6 +18,9 @@ function getSpanLocation(error) {
 }
 
 function inferErrorSource(error) {
+  if (typeof error?.source === 'string' && ['parse', 'compile', 'runtime', 'unknown'].includes(error.source)) {
+    return error.source;
+  }
   const type = error?.type;
   const name = error?.name;
 

--- a/src/toolchain/inspect.js
+++ b/src/toolchain/inspect.js
@@ -1,14 +1,18 @@
-import { compileLoomSource } from './compile.js';
+import { RUNTIME_TARGETS } from './runtime-targets.js';
+import { compileLoomSource, getCompatibleTargetsForImports } from './compile.js';
 
 function summarizeGraph(graph) {
+  const imports = Array.isArray(graph.imports) ? graph.imports : [];
   return {
     nodeCount: graph.nodes.length,
     edgeCount: graph.edges.length,
     renderType: graph.render?.type || 'none',
     nodes: graph.nodes.map((node) => ({ id: node.id, type: node.type })),
-    imports: [],
-    requiredCapabilities: [],
-    compatibleTargets: []
+    imports,
+    requiredCapabilities: [...imports],
+    compatibleTargets: imports.length > 0
+      ? getCompatibleTargetsForImports(imports)
+      : RUNTIME_TARGETS.filter((target) => target !== 'any')
   };
 }
 
@@ -38,10 +42,22 @@ export function inspectLoomSource(source, options = {}) {
 }
 
 export function formatInspectionSummary(summary) {
+  const importLines = summary.imports.length > 0
+    ? summary.imports.map((entry) => `- ${entry}`)
+    : ['Imports: none'];
+  const compatibleTargetLines = summary.compatibleTargets.length > 0
+    ? summary.compatibleTargets.map((entry) => `- ${entry}`)
+    : ['- none'];
   const lines = [
     `Nodes: ${summary.nodeCount}`,
     `Edges: ${summary.edgeCount}`,
     `Render: ${summary.renderType}`,
+    '',
+    summary.imports.length > 0 ? 'Imports:' : importLines[0],
+    ...(summary.imports.length > 0 ? importLines : []),
+    '',
+    'Compatible targets:',
+    ...compatibleTargetLines,
     '',
     'Node list:'
   ];

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -76,6 +76,52 @@ test('compile unknown option exits 1', () => {
   assert.match(result.stderr, /Unknown option/);
 });
 
+test('compile includes imports in GraphJSON', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-imports-'));
+  const file = path.join(tmpDir, 'imports.loom');
+  await fsp.writeFile(file, 'import math\nimport fs\n\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['compile', file]);
+  assert.equal(result.status, 0, result.stderr);
+  const graph = JSON.parse(result.stdout);
+  assert.deepEqual(graph.imports, ['math', 'fs']);
+});
+
+test('unknown import fails when target is specific', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-unknown-import-'));
+  const file = path.join(tmpDir, 'unknown-import.loom');
+  await fsp.writeFile(file, 'import doesNotExist\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['compile', file, '--target', 'cli']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /UNKNOWN_IMPORT/);
+});
+
+test('unsupported import fails for target', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-unsupported-import-'));
+  const file = path.join(tmpDir, 'unsupported-import.loom');
+  await fsp.writeFile(file, 'import fs\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['compile', file, '--target', 'web']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /UNSUPPORTED_IMPORT/);
+});
+
+test('compile default target any allows fs', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-any-import-'));
+  const file = path.join(tmpDir, 'any-import.loom');
+  await fsp.writeFile(file, 'import fs\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['compile', file]);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('compile invalid target exits 1', () => {
+  const result = runCli(['compile', 'examples/cli-basic.loom', '--target', 'banana']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown runtime target/);
+});
+
 test('format outputs DSL', () => {
   const result = runCli(['format', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);
@@ -94,6 +140,16 @@ test('format unknown option exits 1', () => {
   assert.match(result.stderr, /Unknown option/);
 });
 
+test('format preserves imports', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-format-imports-'));
+  const file = path.join(tmpDir, 'format-imports.loom');
+  await fsp.writeFile(file, 'import math\nimport fs\n\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['format', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^import math\nimport fs\n\nx = constant\(value: 1\)\n$/);
+});
+
 test('inspect outputs summary', () => {
   const result = runCli(['inspect', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);
@@ -109,6 +165,20 @@ test('inspect unknown option exits 1', () => {
   const result = runCli(['inspect', 'examples/cli-basic.loom', '--unknown']);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Unknown option/);
+});
+
+test('inspect shows imports and compatible targets', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-inspect-imports-'));
+  const file = path.join(tmpDir, 'inspect-imports.loom');
+  await fsp.writeFile(file, 'import math\nimport fs\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['inspect', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Imports:/);
+  assert.match(result.stdout, /math/);
+  assert.match(result.stdout, /fs/);
+  assert.match(result.stdout, /Compatible targets:/);
+  assert.match(result.stdout, /cli/);
 });
 
 test('parse error exits 1', async () => {
@@ -140,6 +210,16 @@ test('run unknown option exits 1', () => {
   const result = runCli(['run', 'examples/cli-basic.loom', '--unknown']);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Unknown option/);
+});
+
+test('run defaults to cli and rejects dom import', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-run-dom-'));
+  const file = path.join(tmpDir, 'run-dom.loom');
+  await fsp.writeFile(file, 'import dom\nx = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['run', file, '--get', 'x.out']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /UNSUPPORTED_IMPORT/);
 });
 
 test('run rejects browser-only nodes with a clear error', async () => {

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -198,6 +198,23 @@ test('run --get returns finite number', () => {
   assert.equal(Number.isFinite(value), true);
 });
 
+test('run accepts --target cli', () => {
+  const result = runCli([
+    'run',
+    'examples/cli-basic.loom',
+    '--target',
+    'cli',
+    '--get',
+    'x.out',
+    '--time',
+    '0.25'
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const value = Number(result.stdout.trim());
+  assert.equal(Number.isFinite(value), true);
+});
+
 test('run --json returns object', () => {
   const result = runCli(['run', 'examples/cli-basic.loom', '--get', 'x.out', '--time', '0.25', '--json']);
   assert.equal(result.status, 0, result.stderr);
@@ -210,6 +227,34 @@ test('run unknown option exits 1', () => {
   const result = runCli(['run', 'examples/cli-basic.loom', '--unknown']);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Unknown option/);
+});
+
+test('run rejects non-cli target', () => {
+  const result = runCli([
+    'run',
+    'examples/cli-basic.loom',
+    '--target',
+    'web',
+    '--get',
+    'x.out'
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /only supports --target cli/);
+});
+
+test('run rejects target any', () => {
+  const result = runCli([
+    'run',
+    'examples/cli-basic.loom',
+    '--target',
+    'any',
+    '--get',
+    'x.out'
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /only supports --target cli/);
 });
 
 test('run defaults to cli and rejects dom import', async () => {

--- a/test/loom-dsl.test.html
+++ b/test/loom-dsl.test.html
@@ -238,6 +238,13 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       assertEqual(s.value.type, "CallExpression");
     });
 
+    test("16b. parseDSLToAST: import metadata", () => {
+      const { ast, errors } = parseDSLToAST("import math\nimport fs\n\nx = constant(value: 1)");
+      assertEqual(errors.length, 0);
+      assertEqual(ast.imports.map(x => x.name), ["math", "fs"]);
+      assertEqual(ast.body[0].type, "AssignmentStatement");
+    });
+
     test("17. parseDSLToAST: pipe expression and comments", () => {
       const src = `# lead\na = clock() # tail\n# lone\nb = a |> sine(freq: 0.3)`;
       const { ast } = parseDSLToAST(src);
@@ -277,6 +284,13 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       assert(out.errors.length > 0, "compile error exists");
       assert(out.errors[0].span && out.errors[0].span.start.line > 0, "span exists");
     });
+    test("18d. compileToGraph includes imports metadata", () => {
+      const src = `import math\nimport fs\n\nx = constant(value: 1)`;
+      const { ast } = parseDSLToAST(src);
+      const out = compileToGraph(ast);
+      assertEqual(out.errors.length, 0);
+      assertEqual(out.graph.imports, ["math", "fs"]);
+    });
 
     test("19. parseDSLToAST parse error is non-throwing", () => {
       const out = parseDSLToAST("a = ");
@@ -304,6 +318,12 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       const out2 = formatDSL(ast, { maxInlineParams: 2 });
       assert(out1.includes("map(\n"), "multiline call");
       assertEqual(out1, out2, "deterministic");
+    });
+    test("21b. formatDSL preserves imports and blank line", () => {
+      const src = `import math\nimport fs\n\nx = constant(value: 1)`;
+      const ast = parseDSLToAST(src).ast;
+      const out = formatDSL(ast);
+      assert(out.startsWith("import math\nimport fs\n\nx = constant(value: 1)\n"), "imports kept at top");
     });
 
     const el = document.getElementById("results");


### PR DESCRIPTION
## What changed

This PR adds minimal top-level `import` syntax to Loom DSL and validates imported libraries against runtime targets.

- adds line-based DSL imports such as `import math`, `import fs`, `import scene`
- stores import metadata in Source AST and preserves it in formatting
- includes import metadata in GraphJSON as `imports`
- validates imports against `src/toolchain/runtime-targets.js`
- adds `--target <target>` to `loom compile`, `loom inspect`, and `loom run`
- extends inspect summaries with imports and compatible target output
- adds parser and CLI tests for import parsing, formatting, validation, and target handling

## Why

The goal is to prepare Loom for runtime-specific libraries without implementing the libraries themselves yet.

This lets the shared toolchain understand target requirements early so CLI, Web Studio, Scene Sync, and future MCP/GPT integrations can all rely on the same validation path.

## Behavior

- `compile` and `inspect` default to `target: any`
- `run` defaults to `target: cli`
- unknown imports fail with `UNKNOWN_IMPORT`
- target-incompatible imports fail with `UNSUPPORTED_IMPORT`
- imports are metadata and validation only in this phase; they do not load modules yet

## Validation

- `npm run test:cli`
- manual checks:
  - `node bin/loom.mjs compile examples/cli-basic.loom --target cli`
  - `node bin/loom.mjs inspect examples/cli-basic.loom --target cli`
  - `node bin/loom.mjs run examples/cli-basic.loom --target cli --get x.out --time 0.25`
  - `import fs` fails for `--target web`
  - `inspect` reports imports and compatible targets

Note: `npm test` was not completed in this environment because Playwright Chromium is not installed locally. The current failure is `browserType.launch` looking for `chromium_headless_shell-1217`.

## Non-goals

This PR does not implement:

- actual `fs.readText` / `fs.writeText`
- actual module loading
- alias imports
- named imports
- Python-style `from ... import ...`
- REPL
- SceneSync send
- Web Studio UI changes
- node registry split
- command buffer
- property assignment syntax