### PR TITLE
[codex] Add initial CLI-safe Loom libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ npm run loom -- inspect examples/cli-basic.loom
 npm run loom -- run examples/cli-basic.loom --get x.out --time 1
 npm run loom -- compile script.loom --target cli
 npm run loom -- inspect script.loom --target web
+node bin/loom.mjs run examples/cli-text.loom --get message.out
 ```
 
 ```bash
@@ -193,6 +194,12 @@ x = constant(value: 1)
 ```
 
 `compile` と `inspect` の `--target` は省略時に `any` として扱われ、runtime-specific import を generic workflow 用に許可します。`run` は省略時に `cli` で検証するため、たとえば `import dom` は CLI 実行時に失敗します。
+
+初期の CLI-safe library nodes:
+
+- `text.upper`, `text.lower`, `text.trim`, `text.replace`
+- `json.parse`, `json.stringify`
+- `console.log`, `console.warn`, `console.error`
 
 ## ライブエディタと DSL
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -21,6 +21,17 @@ function printError(message = '') {
   process.stderr.write(`${message}\n`);
 }
 
+function formatEffectValue(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 function printToolErrors(errors) {
   for (const error of errors) {
     printError(formatLoomError(error));
@@ -358,6 +369,10 @@ async function handleRun(args) {
   if (!result.ok) {
     printToolErrors(result.errors);
     return 1;
+  }
+
+  for (const effect of result.effects || []) {
+    printError(`[${effect.level}] ${formatEffectValue(effect.value)}`);
   }
 
   if (!json && get.length === 1) {

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -20,9 +20,9 @@
 
 - fs.readText
 - fs.writeText
-- console.log
-- json.parse
-- text.upper / lower / replace
+- expand beyond initial `console.*`
+- expand beyond initial `json.parse` / `json.stringify`
+- expand beyond initial `text.upper` / `lower` / `trim` / `replace`
 
 ## Phase 4: REPL
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -79,6 +79,34 @@ from math import sine
 import math as m
 ```
 
+### Qualified function calls
+
+Loom DSL は `library.nodeName` 形式の qualified function call をサポートします。
+
+```loom
+import text
+
+message = text.upper("hello")
+```
+
+- qualified function call は `library.nodeName`
+- import 名そのものは引き続き単純な識別子だけをサポートします
+- dotted import name は未対応です
+
+### Effect statements
+
+トップレベルの関数呼び出しを、代入なしで effect statement として書けます。
+
+```loom
+import console
+
+message = constant(value: "hello")
+console.log(message)
+```
+
+- effect statement は generated effect node に compile されます
+- 現時点では `console.log` などの output/effect node 用です
+
 ### 代入文
 
 ```

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -46,7 +46,9 @@ import fs
 import scene
 ```
 
-現時点の `import` は metadata / target validation 用です。実際の module loading や node library の自動登録はまだ行いません。
+現時点の `import` は主に metadata / target validation 用です。
+`text`, `json`, `console` など一部の標準ライブラリノードは実行できますが、
+`import` による動的 module loading や node registry の厳密な import-driven 切り替えはまだ行いません。
 
 `import` は、代入文や `render` 文より前に書く必要があります。
 
@@ -92,6 +94,8 @@ message = text.upper("hello")
 - qualified function call は `library.nodeName`
 - import 名そのものは引き続き単純な識別子だけをサポートします
 - dotted import name は未対応です
+
+`text.upper`, `json.parse`, `console.log` などの一部の qualified function は標準ライブラリノードとして実行できます。
 
 ### Effect statements
 

--- a/docs/RUNTIME_TARGETS.md
+++ b/docs/RUNTIME_TARGETS.md
@@ -18,9 +18,10 @@ Some libraries are universal and should work across every host. Others are inten
 |---|---:|---:|---:|---:|---|
 | math | yes | yes | yes | yes | Pure math |
 | state | yes | yes | yes | yes | Explicit state nodes |
-| text | yes | yes | yes | yes | String processing |
-| json | yes | yes | yes | yes | JSON utilities |
+| text | yes | yes | yes | yes | String processing, including `text.upper`, `text.lower`, `text.trim`, `text.replace` |
+| json | yes | yes | yes | yes | JSON utilities, including `json.parse` and `json.stringify` |
 | fs | yes | no | no | no/partial | File I/O |
+| console | yes | yes | yes | yes | Host logging, including `console.log`, `console.warn`, `console.error` |
 | dom | no | yes | no | no | DOM operations |
 | canvas | no | yes | no | no | Canvas preview |
 | scene | no | partial | yes | yes | Scene object control |

--- a/examples/cli-console.loom
+++ b/examples/cli-console.loom
@@ -1,0 +1,5 @@
+import console
+import text
+
+message = text.upper("hello loom")
+console.log(message)

--- a/examples/cli-json.loom
+++ b/examples/cli-json.loom
@@ -1,0 +1,4 @@
+import json
+
+parsed = json.parse('{"name":"loom","version":1}')
+message = json.stringify(parsed)

--- a/examples/cli-text.loom
+++ b/examples/cli-text.loom
@@ -1,0 +1,3 @@
+import text
+
+message = text.upper("hello loom")

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -92,6 +92,18 @@ export function parseDSLToAST(source) {
     const take = () => tokens[p++];
     const expect = (tt) => { const t = peek(); if (t.type !== tt) throw new LoomDSLError(`Expected ${tt}, got ${t.type}`, t.span.start.line, t.span.start.column, 'UNEXPECTED_TOKEN'); return take(); };
     const skipNL = () => { while (peek().type === TT.NEWLINE) take(); };
+    function parseQualifiedIdentifier() {
+      const first = expect(TT.IDENT);
+      const parts = [first.value];
+      let end = first.span.end;
+      while (peek().type === TT.DOT) {
+        take();
+        const next = expect(TT.IDENT);
+        parts.push(next.value);
+        end = next.span.end;
+      }
+      return { type: 'Identifier', name: parts.join('.'), span: spanFrom(first.span.start, end) };
+    }
 
     function parseExpr() { return parsePipe(); }
     function parsePipe() { let left = parseAtom(); while (true) { if (peek().type === TT.PIPE || (peek().type === TT.NEWLINE && peek(1).type === TT.PIPE)) { if (peek().type === TT.NEWLINE) take(); const pt = take(); const right = parseCall(); left = { type: 'PipeExpression', left, right, span: spanFrom(left.span.start, right.span.end) }; } else break; } return left; }
@@ -103,13 +115,13 @@ export function parseDSLToAST(source) {
       if (t.type === TT.NULL) { take(); return { type: 'NullLiteral', span: t.span }; }
       if (t.type === TT.LBRACKET) return parseArray();
       if (t.type === TT.LBRACE) return parseObject();
-      if (t.type === TT.IDENT) { if (peek(1).type === TT.LPAREN) return parseCall(); take(); return mkIdent(t); }
+      if (t.type === TT.IDENT) { if (peek(1).type === TT.LPAREN || peek(1).type === TT.DOT) return parseCall(); take(); return mkIdent(t); }
       throw new LoomDSLError(`Unexpected token: ${t.type}`, t.span.start.line, t.span.start.column, 'UNEXPECTED_TOKEN');
     }
     function parseArray() { const st = expect(TT.LBRACKET); const elements = []; while (peek().type !== TT.RBRACKET && peek().type !== TT.EOF) { elements.push(parseExpr()); if (peek().type === TT.COMMA) take(); else break; } const ed = expect(TT.RBRACKET); return { type: 'ArrayLiteral', elements, span: spanFrom(st.span.start, ed.span.end) }; }
     function parseObject() { const st = expect(TT.LBRACE); const entries = []; while (peek().type !== TT.RBRACE && peek().type !== TT.EOF) { const kt = peek(); let key; if (kt.type === TT.IDENT) { take(); key = mkIdent(kt); } else if (kt.type === TT.STRING) { take(); key = { type: 'StringLiteral', value: kt.value.value, raw: kt.value.raw, span: kt.span }; } else throw new LoomDSLError('Expected object key', kt.span.start.line, kt.span.start.column, 'UNEXPECTED_TOKEN'); expect(TT.COLON); const value = parseExpr(); entries.push({ type: 'ObjectEntry', key, value, span: spanFrom(key.span.start, value.span.end) }); if (peek().type === TT.COMMA) take(); else break; } const ed = expect(TT.RBRACE); return { type: 'ObjectLiteral', entries, span: spanFrom(st.span.start, ed.span.end) }; }
-    function parseCall() { const nt = expect(TT.IDENT); const callee = mkIdent(nt); expect(TT.LPAREN); skipNL(); const args = []; while (peek().type !== TT.RPAREN && peek().type !== TT.EOF) { skipNL(); const at = peek(); if (at.type === TT.IDENT && peek(1).type === TT.COLON) { const n = mkIdent(take()); take(); skipNL(); const v = parseExpr(); args.push({ type: 'NamedArg', name: n, value: v, span: spanFrom(n.span.start, v.span.end) }); } else { const v = parseExpr(); args.push({ type: 'PositionalArg', value: v, span: v.span }); } skipNL(); if (peek().type === TT.COMMA) take(); skipNL(); }
-      const end = expect(TT.RPAREN); return { type: 'CallExpression', callee, args, span: spanFrom(nt.span.start, end.span.end) }; }
+    function parseCall() { const callee = parseQualifiedIdentifier(); expect(TT.LPAREN); skipNL(); const args = []; while (peek().type !== TT.RPAREN && peek().type !== TT.EOF) { skipNL(); const at = peek(); if (at.type === TT.IDENT && peek(1).type === TT.COLON) { const n = mkIdent(take()); take(); skipNL(); const v = parseExpr(); args.push({ type: 'NamedArg', name: n, value: v, span: spanFrom(n.span.start, v.span.end) }); } else { const v = parseExpr(); args.push({ type: 'PositionalArg', value: v, span: v.span }); } skipNL(); if (peek().type === TT.COMMA) take(); skipNL(); }
+      const end = expect(TT.RPAREN); return { type: 'CallExpression', callee, args, span: spanFrom(callee.span.start, end.span.end) }; }
 
     let blankLines = 0;
     let seenNonImportStatement = false;
@@ -169,6 +181,7 @@ export function parseDSLToAST(source) {
       let stmt;
       if (stTok.type === TT.IDENT && stTok.value === 'render') { take(); const call = parseCall(); stmt = { type: 'RenderStatement', call, span: spanFrom(stTok.span.start, call.span.end) }; }
       else if (stTok.type === TT.IDENT && peek(1).type === TT.ASSIGN) { const target = mkIdent(take()); take(); const value = parseExpr(); stmt = { type: 'AssignmentStatement', target, value, span: spanFrom(target.span.start, value.span.end) }; }
+      else if (stTok.type === TT.IDENT && (peek(1).type === TT.LPAREN || peek(1).type === TT.DOT)) { const expression = parseCall(); stmt = { type: 'ExpressionStatement', expression, span: expression.span }; }
       else throw new LoomDSLError('Expected assignment or render statement', stTok.span.start.line, stTok.span.start.column, 'UNEXPECTED_TOKEN');
       seenNonImportStatement = true;
       if (pendingComments.length) { stmt.leadingComments = pendingComments; pendingComments = []; }
@@ -247,12 +260,16 @@ function astToLegacy(program) {
     imports: (program.imports || []).map((entry) => entry.name),
     statements: program.body
       .filter(s => s.type !== 'CommentStatement')
-      .map(s => s.type === 'RenderStatement' ? { type: 'render', call: convExpr(s.call) } : { type: 'assign', name: s.target.name, expr: convExpr(s.value) })
+      .map((s) => {
+        if (s.type === 'RenderStatement') return { type: 'render', call: convExpr(s.call) };
+        if (s.type === 'ExpressionStatement') return { type: 'effect', expr: convExpr(s.expression) };
+        return { type: 'assign', name: s.target.name, expr: convExpr(s.value) };
+      })
   };
 }
 
 function buildGraph(stmts) { /* mostly original */
-  const nodes = []; const edges = []; let renderConfig = null; let anonCounter = 0; const scope = {};
+  const nodes = []; const edges = []; let renderConfig = null; let anonCounter = 0; let effectCounter = 0; const scope = {};
   const anonId = () => `_anon_${++anonCounter}`;
   const resolveIdent = (name, line, col) => { if (!(name in scope)) throw new LoomDSLError(`Undefined identifier: ${name}`, line, col, 'UNDEFINED_IDENTIFIER'); const node = nodes.find(n => n.id === scope[name]); return `${scope[name]}.${defaultOutputPort(node.type)}`; };
   function buildNode(call, resultId, pipeFrom) { const fnName = call.name; const typeDef = NODE_TYPES[fnName]; if (!typeDef) throw new LoomDSLError(`Unknown node type: ${fnName}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); const id = resultId || anonId(); const nodeObj = { id, type: fnName }; nodes.push(nodeObj); const inputNames = typeDef.inputs.map(i => i.name); const paramNames = (typeDef.params || []).map(p => p.name); const pos = call.args.filter(a => !a.named); const named = call.args.filter(a => a.named); if (typeDef.commutative && pos.length && named.length) throw new LoomDSLError(`Node '${fnName}' is commutative: arguments must be all positional or all named`, call.line, call.col, 'MISSING_ARGUMENT_NAME'); if (!typeDef.commutative && pos.length > (pipeFrom ? 0 : 1)) throw new LoomDSLError(`Argument at position 2 for '${fnName}' requires a name`, call.line, call.col, 'MISSING_ARGUMENT_NAME'); let idx = 0;
@@ -263,7 +280,11 @@ function buildGraph(stmts) { /* mostly original */
     return id; };
   const buildExpr = (expr, resultId, pipeFrom) => expr.type === 'call' ? buildNode(expr, resultId, pipeFrom) : expr.type === 'pipe' ? (() => { const lId = buildExpr(expr.left, null, null); const ln = nodes.find(n => n.id === lId); return buildNode(expr.call, resultId, `${lId}.${defaultOutputPort(ln.type)}`); })() : expr.type === 'ident' ? scope[expr.name] || (()=>{throw new LoomDSLError(`Undefined identifier: ${expr.name}`, expr.line, expr.col, 'UNDEFINED_IDENTIFIER');})() : (()=>{throw new LoomDSLError('Cannot use literal as expression', expr.line, expr.col, 'UNEXPECTED_TOKEN');})();
   const buildRender = (call) => { const named = {}; for (const a of call.args) { if (!a.named) throw new LoomDSLError('render arguments must be named', call.line, call.col, 'MISSING_ARGUMENT_NAME'); named[a.name] = a.value; } const rv = (e) => e.type === 'ident' ? resolveIdent(e.name, e.line, e.col) : e.value; if (call.name === 'point') return { type: 'point', x: named.x ? rv(named.x) : undefined, y: named.y ? rv(named.y) : undefined, color: named.color ? named.color.value : '#00ff00', trail: named.trail ? named.trail.value : 0.1 }; if (call.name === 'bar') return { type: 'bar', width: named.width ? rv(named.width) : undefined, color: named.color ? named.color.value : '#00ccff', height: named.height ? named.height.value : 40, y: named.y ? rv(named.y) : undefined }; throw new LoomDSLError(`Unknown render function: ${call.name}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); };
-  for (const s of stmts) { if (s.type === 'render') renderConfig = buildRender(s.call); else { const id = buildExpr(s.expr, s.name, null); scope[s.name] = id; } }
+  for (const s of stmts) {
+    if (s.type === 'render') renderConfig = buildRender(s.call);
+    else if (s.type === 'effect') buildExpr(s.expr, `_effect${++effectCounter}`, null);
+    else { const id = buildExpr(s.expr, s.name, null); scope[s.name] = id; }
+  }
   const r = { nodes, edges }; if (renderConfig) r.render = renderConfig; return r;
 }
 
@@ -328,7 +349,11 @@ export function formatDSL(ast, options = {}) {
   for (const s of ast.body) {
     if (s.type === 'CommentStatement') { lines.push(`#${s.comment.text}`); continue; }
     if (s.leadingComments) for (const c of s.leadingComments) lines.push(`#${c.text}`);
-    const expr = s.type === 'AssignmentStatement' ? `${s.target.name} = ${fmtExpr(s.value, 0)}` : `render ${fmtExpr(s.call, 0)}`;
+    const expr = s.type === 'AssignmentStatement'
+      ? `${s.target.name} = ${fmtExpr(s.value, 0)}`
+      : s.type === 'ExpressionStatement'
+        ? `${fmtExpr(s.expression, 0)}`
+        : `render ${fmtExpr(s.call, 0)}`;
     let line = expr;
     if (s.trailingComment) line += `  #${s.trailingComment.text}`;
     lines.push(line);

--- a/src/loom.js
+++ b/src/loom.js
@@ -358,6 +358,10 @@ function sanitizeStateValue(value, initial) {
   return isFiniteNumber(value) ? value : initial;
 }
 
+function stringifyJsonValue(value, pretty = false) {
+  return JSON.stringify(value, null, pretty ? 2 : 0);
+}
+
 // ノード型レジストリ
 export const NODE_TYPES = {
   // Phase 0 ノード
@@ -371,8 +375,8 @@ export const NODE_TYPES = {
   constant: {
     category: 'source',
     inputs: [],
-    outputs: [{ name: 'out', type: 'number', kind: 'behavior' }],
-    params: [{ name: 'value', type: 'number', default: 0 }],
+    outputs: [{ name: 'out', type: 'any', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: 0 }],
     evaluate: (inputs, params, ctx) => ({ out: params.value })
   },
   sine: {
@@ -910,6 +914,98 @@ export const NODE_TYPES = {
     }
   },
 
+  'text.upper': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: String(inputs.value ?? '').toUpperCase() })
+  },
+  'text.lower': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: String(inputs.value ?? '').toLowerCase() })
+  },
+  'text.trim': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: String(inputs.value ?? '').trim() })
+  },
+  'text.replace': {
+    category: 'transform',
+    inputs: [
+      { name: 'value', type: 'any', default: '', kind: 'behavior' },
+      { name: 'search', type: 'any', default: '', kind: 'behavior' },
+      { name: 'replacement', type: 'any', default: '', kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [
+      { name: 'value', type: 'any', default: '' },
+      { name: 'search', type: 'any', default: '' },
+      { name: 'replacement', type: 'any', default: '' }
+    ],
+    evaluate: (inputs) => ({
+      out: String(inputs.value ?? '').replaceAll(String(inputs.search ?? ''), String(inputs.replacement ?? ''))
+    })
+  },
+  'json.parse': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'any', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }],
+    evaluate: (inputs) => {
+      try {
+        return { out: JSON.parse(String(inputs.value ?? '')) };
+      } catch (error) {
+        throw new LoomError('INVALID_JSON', `JSON parse failed: ${error.message}`);
+      }
+    }
+  },
+  'json.stringify': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [
+      { name: 'value', type: 'any', default: null },
+      { name: 'pretty', type: 'boolean', default: false }
+    ],
+    evaluate: (inputs, params) => ({ out: stringifyJsonValue(inputs.value, params.pretty === true) })
+  },
+  'console.log': {
+    category: 'sink',
+    inputs: [{ name: 'value', type: 'any', default: undefined, kind: 'behavior' }],
+    outputs: [],
+    params: [],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({ type: 'console.log', level: 'log', value: inputs.value });
+      return {};
+    }
+  },
+  'console.warn': {
+    category: 'sink',
+    inputs: [{ name: 'value', type: 'any', default: undefined, kind: 'behavior' }],
+    outputs: [],
+    params: [],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({ type: 'console.warn', level: 'warn', value: inputs.value });
+      return {};
+    }
+  },
+  'console.error': {
+    category: 'sink',
+    inputs: [{ name: 'value', type: 'any', default: undefined, kind: 'behavior' }],
+    outputs: [],
+    params: [],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({ type: 'console.error', level: 'error', value: inputs.value });
+      return {};
+    }
+  },
+
   // DOM シンクノード
   setText: {
     category: 'sink',
@@ -1054,6 +1150,7 @@ export class Loom {
     this._startTime = null;
     this._lastTimestamp = null;
     this._inputStates = {};
+    this._effects = [];
 
     // グラフの検証とソートを実行
     this._loadGraphInternal(graph);
@@ -1101,6 +1198,8 @@ export class Loom {
 
     // グラフが設定されていなければ何もしない
     if (!this._currentGraph) return;
+
+    this._effects = [];
 
     const dt = this._computeDeltaTime(frameTimestamp);
 
@@ -1227,6 +1326,14 @@ export class Loom {
 
   getValue(ref) {
     return this._values.get(ref);
+  }
+
+  getEffects() {
+    return [...this._effects];
+  }
+
+  _recordEffect(effect) {
+    this._effects.push(effect);
   }
 
   dispatchEvent(ref, payload) {

--- a/src/toolchain/run.js
+++ b/src/toolchain/run.js
@@ -4,6 +4,10 @@ import { normalizeLoomError } from './errors.js';
 
 const CLI_SAFE_CATEGORIES = new Set(['source', 'transform', 'state']);
 
+function isCliSafeSink(nodeTypeName) {
+  return nodeTypeName === 'console.log' || nodeTypeName === 'console.warn' || nodeTypeName === 'console.error';
+}
+
 function getRefsToRead(graph, get) {
   if (Array.isArray(get)) {
     return get;
@@ -32,7 +36,7 @@ function validateCliRunnableGraph(graph) {
     if (!nodeType) {
       throw new LoomError('UNKNOWN_NODE_TYPE', `Unknown node type: ${node.type}`, { nodeId: node.id, type: node.type });
     }
-    if (!CLI_SAFE_CATEGORIES.has(nodeType.category)) {
+    if (!CLI_SAFE_CATEGORIES.has(nodeType.category) && !(nodeType.category === 'sink' && isCliSafeSink(node.type))) {
       throw new LoomError(
         'UNSUPPORTED_RUNTIME_NODE',
         `Node '${node.id}' of type '${node.type}' is not supported by CLI run`,
@@ -67,6 +71,7 @@ export function runLoomGraph(graph, options = {}) {
     return {
       ok: true,
       values: collectRequestedValues(engine, graph, options.get),
+      effects: engine.getEffects(),
       graph,
       errors: []
     };
@@ -74,6 +79,7 @@ export function runLoomGraph(graph, options = {}) {
     return {
       ok: false,
       values: {},
+      effects: [],
       graph,
       errors: [normalizeLoomError(error)]
     };
@@ -86,6 +92,7 @@ export function runLoomSource(source, options = {}) {
     return {
       ok: false,
       values: {},
+      effects: [],
       graph: compiled.graph,
       errors: compiled.errors
     };

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -87,6 +87,18 @@ test('compile includes imports in GraphJSON', async () => {
   assert.deepEqual(graph.imports, ['math', 'fs']);
 });
 
+test('console.log effect statement compiles', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-console-compile-'));
+  const file = path.join(tmpDir, 'console.loom');
+  await fsp.writeFile(file, 'import console\nmessage = constant(value: "hello")\nconsole.log(message)\n', 'utf8');
+
+  const result = runCli(['compile', file]);
+  assert.equal(result.status, 0, result.stderr);
+  const graph = JSON.parse(result.stdout);
+  assert.ok(graph.nodes.some((node) => node.type === 'console.log'));
+  assert.ok(graph.nodes.some((node) => node.id === '_effect1'));
+});
+
 test('unknown import fails when target is specific', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-unknown-import-'));
   const file = path.join(tmpDir, 'unknown-import.loom');
@@ -150,6 +162,16 @@ test('format preserves imports', async () => {
   assert.match(result.stdout, /^import math\nimport fs\n\nx = constant\(value: 1\)\n$/);
 });
 
+test('format preserves qualified calls and effect statements', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-format-effects-'));
+  const file = path.join(tmpDir, 'format-effects.loom');
+  await fsp.writeFile(file, 'import console\nimport text\n\nmessage = text.upper("hello")\nconsole.log(message)\n', 'utf8');
+
+  const result = runCli(['format', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^import console\nimport text\n\nmessage = text\.upper\("hello"\)\nconsole\.log\(message\)\n$/);
+});
+
 test('inspect outputs summary', () => {
   const result = runCli(['inspect', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);
@@ -181,6 +203,16 @@ test('inspect shows imports and compatible targets', async () => {
   assert.match(result.stdout, /cli/);
 });
 
+test('inspect includes qualified function node names', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-inspect-qualified-'));
+  const file = path.join(tmpDir, 'inspect-qualified.loom');
+  await fsp.writeFile(file, 'import text\nmessage = text.upper("hello")\n', 'utf8');
+
+  const result = runCli(['inspect', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /text\.upper/);
+});
+
 test('parse error exits 1', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-invalid-'));
   const invalidFile = path.join(tmpDir, 'invalid.loom');
@@ -196,6 +228,38 @@ test('run --get returns finite number', () => {
   assert.equal(result.status, 0, result.stderr);
   const value = Number(result.stdout.trim());
   assert.equal(Number.isFinite(value), true);
+});
+
+test('text.upper run returns uppercased string', () => {
+  const result = runCli(['run', 'examples/cli-text.loom', '--get', 'message.out']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'HELLO LOOM');
+});
+
+test('text.replace run returns replaced string', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-text-replace-'));
+  const file = path.join(tmpDir, 'text-replace.loom');
+  await fsp.writeFile(file, 'import text\nmessage = text.replace("hello world", search: "world", replacement: "loom")\n', 'utf8');
+
+  const result = runCli(['run', file, '--get', 'message.out']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'hello loom');
+});
+
+test('json.stringify run returns compact JSON string', () => {
+  const result = runCli(['run', 'examples/cli-json.loom', '--get', 'message.out']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), '{"name":"loom","version":1}');
+});
+
+test('json.parse invalid JSON fails clearly', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-json-invalid-'));
+  const file = path.join(tmpDir, 'json-invalid.loom');
+  await fsp.writeFile(file, 'import json\nvalue = json.parse("{bad")\n', 'utf8');
+
+  const result = runCli(['run', file, '--get', 'value.out']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /JSON|INVALID_JSON|RUNTIME/);
 });
 
 test('run accepts --target cli', () => {
@@ -265,6 +329,13 @@ test('run defaults to cli and rejects dom import', async () => {
   const result = runCli(['run', file, '--get', 'x.out']);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /UNSUPPORTED_IMPORT/);
+});
+
+test('console.log run produces effect on stderr while keeping stdout clean', () => {
+  const result = runCli(['run', 'examples/cli-console.loom', '--get', 'message.out']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'HELLO LOOM');
+  assert.match(result.stderr, /\[log\] HELLO LOOM/);
 });
 
 test('run rejects browser-only nodes with a clear error', async () => {

--- a/test/loom-dsl.test.html
+++ b/test/loom-dsl.test.html
@@ -244,6 +244,13 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       assertEqual(ast.imports.map(x => x.name), ["math", "fs"]);
       assertEqual(ast.body[0].type, "AssignmentStatement");
     });
+    test("16c. parseDSLToAST: qualified call and effect statement", () => {
+      const { ast, errors } = parseDSLToAST("import console\nimport text\n\nmessage = text.upper(\"hello\")\nconsole.log(message)");
+      assertEqual(errors.length, 0);
+      assertEqual(ast.body[0].value.callee.name, "text.upper");
+      assertEqual(ast.body[1].type, "ExpressionStatement");
+      assertEqual(ast.body[1].expression.callee.name, "console.log");
+    });
 
     test("17. parseDSLToAST: pipe expression and comments", () => {
       const src = `# lead\na = clock() # tail\n# lone\nb = a |> sine(freq: 0.3)`;
@@ -291,6 +298,14 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       assertEqual(out.errors.length, 0);
       assertEqual(out.graph.imports, ["math", "fs"]);
     });
+    test("18e. compileToGraph lowers effect statements to effect nodes", () => {
+      const src = `import console\nmessage = constant(value: "hello")\nconsole.log(message)`;
+      const { ast } = parseDSLToAST(src);
+      const out = compileToGraph(ast);
+      assertEqual(out.errors.length, 0);
+      assert(out.graph.nodes.some(n => n.id === "_effect1" && n.type === "console.log"), "effect node generated");
+      assert(out.graph.edges.some(e => e.to === "_effect1.value"), "effect edge generated");
+    });
 
     test("19. parseDSLToAST parse error is non-throwing", () => {
       const out = parseDSLToAST("a = ");
@@ -324,6 +339,13 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       const ast = parseDSLToAST(src).ast;
       const out = formatDSL(ast);
       assert(out.startsWith("import math\nimport fs\n\nx = constant(value: 1)\n"), "imports kept at top");
+    });
+    test("21c. formatDSL preserves qualified calls and effect statements", () => {
+      const src = `import console\nimport text\n\nmessage = text.upper("hello")\nconsole.log(message)`;
+      const ast = parseDSLToAST(src).ast;
+      const out = formatDSL(ast);
+      assert(out.includes('message = text.upper("hello")'), "qualified assignment preserved");
+      assert(out.includes('console.log(message)'), "effect statement preserved");
     });
 
     const el = document.getElementById("results");


### PR DESCRIPTION
## What changed

This PR adds the first import-backed CLI-safe Loom libraries.

- adds qualified function call support such as `text.upper(...)`, `json.parse(...)`, and `console.log(...)`
- adds top-level effect statements such as `console.log(message)`
- adds initial runtime nodes for:
  - `text.upper`, `text.lower`, `text.trim`, `text.replace`
  - `json.parse`, `json.stringify`
  - `console.log`, `console.warn`, `console.error`
- extends `runLoomSource()` to return `effects`
- makes CLI `run` print console effects to `stderr` while keeping requested values on `stdout`
- adds CLI examples for text/json/console usage
- updates DSL/docs/tests for qualified calls and effect statements

## Why

The goal is to make a first set of safe libraries actually usable from Loom CLI without introducing async effects, fs access, or a full import-driven registry split.

This creates a practical base for future REPL work and later CLI libraries.

## Behavior

- `text.*` and `json.*` behave as pure transforms
- `console.*` compiles as effect nodes and produces collected effects during `run`
- CLI prints those console effects to `stderr` in `[level] value` form so `stdout` stays machine-readable
- imports still validate through the existing target compatibility layer
- import names remain simple identifiers; dotted imports are still unsupported

## Validation

- `npm run test:cli`
- manual checks:
  - `node bin/loom.mjs run examples/cli-text.loom --get message.out`
  - `node bin/loom.mjs run examples/cli-json.loom --get message.out`
  - `node bin/loom.mjs run examples/cli-console.loom --get message.out`

Expected examples:

- `cli-text` stdout: `HELLO LOOM`
- `cli-json` stdout: `{"name":"loom","version":1}`
- `cli-console` stdout: `HELLO LOOM`
- `cli-console` stderr: `[log] HELLO LOOM`

Note: `npm test` was not completed in this environment because Playwright Chromium is not installed locally. The current failure is `browserType.launch` looking for `chromium_headless_shell-1217`.

## Non-goals

This PR does not implement:

- `fs.readText`
- `fs.writeText`
- path sandboxing
- async effects
- SceneSync send
- REPL
- strict import-driven node registry split
- named imports
- alias imports
- dotted imports
- property assignment syntax
- command buffer
- Web Studio UI changes