### PR TITLE
Add Loom REPL session API and CLI MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ loom> :quit
 ```
 
 The REPL currently recompiles the accumulated source after each snippet. Invalid snippets are rejected and do not modify the current session.
+Import snippets are hoisted into the import block automatically, so you can add imports later while exploring.
 
 ## ライブエディタと DSL
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,35 @@ x = constant(value: 1)
 - `json.parse`, `json.stringify`
 - `console.log`, `console.warn`, `console.error`
 
+### REPL
+
+Start an interactive Loom session:
+
+```bash
+node bin/loom.mjs repl
+```
+
+Example:
+
+```text
+loom> import text
+imported text
+loom> message = text.upper("hello loom")
+message.out = HELLO LOOM
+loom> import console
+imported console
+loom> console.log(message)
+[log] HELLO LOOM
+loom> :source
+import text
+message = text.upper("hello loom")
+import console
+console.log(message)
+loom> :quit
+```
+
+The REPL currently recompiles the accumulated source after each snippet. Invalid snippets are rejected and do not modify the current session.
+
 ## ライブエディタと DSL
 
 ### エディタ一覧

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -3,6 +3,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import readline from 'node:readline';
 import {
   compileLoomSource,
   formatLoomSource,
@@ -10,7 +11,8 @@ import {
   formatInspectionSummary,
   runLoomSource,
   formatLoomError,
-  isKnownRuntimeTarget
+  isKnownRuntimeTarget,
+  LoomReplSession
 } from '../src/toolchain/index.js';
 
 function print(message = '') {
@@ -96,13 +98,15 @@ Commands:
   format <file>    Format Loom DSL
   inspect <file>   Inspect Loom DSL and print a summary
   run <file>       Evaluate a Loom graph once
+  repl             Start an interactive Loom REPL
   help             Show help
 
 Examples:
   loom compile examples/cli-basic.loom
   loom format examples/cli-basic.loom --check
   loom inspect examples/cli-basic.loom --json
-  loom run examples/cli-basic.loom --get x.out --time 0.25`;
+  loom run examples/cli-basic.loom --get x.out --time 0.25
+  loom repl`;
 }
 
 function getCompileHelp() {
@@ -145,6 +149,66 @@ Options:
   --dt <number>     Delta time in seconds. Default: 0
   --json            Print result values as JSON
   --target <target> Only cli is supported by loom run in this version. Default: cli`;
+}
+
+function getReplHelp() {
+  return `Usage:
+  loom repl
+
+Commands:
+  :help      Show REPL help
+  :source    Show accumulated source
+  :inspect   Show current graph summary
+  :graph     Show current GraphJSON
+  :reset     Clear current session
+  :quit      Exit the REPL
+  :q         Exit the REPL
+  :exit      Exit the REPL`;
+}
+
+function formatValue(value) {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+}
+
+function printEffects(effects) {
+  for (const effect of effects || []) {
+    printError(`[${effect.level}] ${formatEffectValue(effect.value)}`);
+  }
+}
+
+function getAssignedIdentifier(snippet) {
+  const match = snippet.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+  return match ? match[1] : null;
+}
+
+function getImportedLibrary(snippet) {
+  const match = snippet.trim().match(/^import\s+([A-Za-z_][A-Za-z0-9_]*)$/);
+  return match ? match[1] : null;
+}
+
+function printSnippetResult(snippet, result) {
+  printEffects(result.effects || []);
+
+  const imported = getImportedLibrary(snippet);
+  if (imported) {
+    print(`imported ${imported}`);
+    return;
+  }
+
+  const assigned = getAssignedIdentifier(snippet);
+  if (!assigned) {
+    return;
+  }
+
+  const refsToTry = [`${assigned}.out`, `${assigned}.t`, `${assigned}.pos`];
+  for (const ref of refsToTry) {
+    if (Object.hasOwn(result.values, ref) && result.values[ref] !== undefined) {
+      print(`${ref} = ${formatValue(result.values[ref])}`);
+      return;
+    }
+  }
 }
 
 async function readSourceFile(file) {
@@ -371,9 +435,7 @@ async function handleRun(args) {
     return 1;
   }
 
-  for (const effect of result.effects || []) {
-    printError(`[${effect.level}] ${formatEffectValue(effect.value)}`);
-  }
+  printEffects(result.effects || []);
 
   if (!json && get.length === 1) {
     print(String(result.values[get[0]]));
@@ -382,6 +444,79 @@ async function handleRun(args) {
 
   print(stringifyJson(result.values));
   return 0;
+}
+
+async function handleRepl(args) {
+  if (args.includes('--help')) {
+    print(getReplHelp());
+    return 0;
+  }
+
+  const session = new LoomReplSession({ target: 'cli', time: 0, dt: 0 });
+  print('Loom REPL');
+  print('Type :help for commands, :quit to exit.');
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: 'loom> '
+  });
+
+  return await new Promise((resolve) => {
+    rl.prompt();
+
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (trimmed === ':quit' || trimmed === ':q' || trimmed === ':exit') {
+        rl.close();
+        return;
+      }
+      if (trimmed === ':help') {
+        print(getReplHelp());
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':source') {
+        print(session.getSource() || '<empty>');
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':inspect') {
+        const inspection = session.inspect();
+        if (!inspection.ok) {
+          printToolErrors(inspection.errors);
+        } else {
+          print(formatInspectionSummary(inspection.summary));
+        }
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':graph') {
+        const graph = session.getGraph();
+        print(graph ? stringifyJson(graph) : '<no graph>');
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':reset') {
+        session.reset();
+        print('session reset');
+        rl.prompt();
+        return;
+      }
+
+      const result = session.evaluateSnippet(line);
+      if (!result.ok) {
+        printToolErrors(result.errors);
+      } else if (!result.empty) {
+        printSnippetResult(line, result);
+      }
+      rl.prompt();
+    });
+
+    rl.on('close', () => {
+      resolve(0);
+    });
+  });
 }
 
 async function main() {
@@ -403,6 +538,8 @@ async function main() {
       exitCode = await handleInspect(args.slice(1));
     } else if (command === 'run') {
       exitCode = await handleRun(args.slice(1));
+    } else if (command === 'repl') {
+      exitCode = await handleRepl(args.slice(1));
     } else {
       throw new Error(`unknown command: ${command}`);
     }

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -24,14 +24,23 @@
 - expand beyond initial `json.parse` / `json.stringify`
 - expand beyond initial `text.upper` / `lower` / `trim` / `replace`
 
-## Phase 4: REPL
+## Phase 4: REPL MVP
 
 - interactive prompt
-- incremental graph patching
-- inspect current graph
-- watch values
+- accumulated source session
+- `:source`, `:inspect`, `:graph`, `:reset`, `:quit`
+- recompile-and-run after each snippet
 
-## Phase 5: SceneSync integration
+## Phase 5: REPL follow-up
+
+- multiline input
+- watch/live ticking
+- command history persistence
+- autocomplete
+- notebook-style cells
+- incremental graph patching
+
+## Phase 6: SceneSync integration
 
 - compile DSL and send graph
 - target scene scope
@@ -39,14 +48,14 @@
 - clear graph
 - patch graph
 
-## Phase 6: Web Studio integration
+## Phase 7: Web Studio integration
 
 - reuse toolchain modules
 - shared diagnostics
 - target/import compatibility panel
 - inspect panel
 
-## Phase 7: AI/MCP integration
+## Phase 8: AI/MCP integration
 
 - expose compile/format/inspect as tools
 - use inspect summaries to reduce context size

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "node ci/run-tests.mjs",
     "loom": "node bin/loom.mjs",
-    "test:cli": "node test/loom-cli.test.mjs"
+    "test:cli": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
+    "test:repl": "node test/loom-repl-session.test.mjs"
   },
   "devDependencies": {
     "http-server": "^14.1.1",

--- a/src/toolchain/index.js
+++ b/src/toolchain/index.js
@@ -4,3 +4,4 @@ export * from './inspect.js';
 export * from './run.js';
 export * from './errors.js';
 export * from './runtime-targets.js';
+export * from './repl-session.js';

--- a/src/toolchain/repl-session.js
+++ b/src/toolchain/repl-session.js
@@ -14,6 +14,47 @@ function createEmptySummary() {
   };
 }
 
+function isImportSnippet(snippet) {
+  return /^\s*import\s+[A-Za-z_][A-Za-z0-9_]*\s*$/.test(snippet);
+}
+
+function appendSnippetToSource(currentSource, snippet) {
+  if (!currentSource) {
+    return snippet;
+  }
+
+  if (!isImportSnippet(snippet)) {
+    return `${currentSource}\n${snippet}`;
+  }
+
+  const importLine = snippet.trim();
+  const lines = currentSource.split(/\r?\n/);
+
+  if (lines.some((line) => line.trim() === importLine)) {
+    return currentSource;
+  }
+
+  let insertIndex = 0;
+
+  while (
+    insertIndex < lines.length &&
+    lines[insertIndex].trim().startsWith('import ')
+  ) {
+    insertIndex += 1;
+  }
+
+  const before = lines.slice(0, insertIndex);
+  const after = lines.slice(insertIndex);
+  const nextLines = [...before, importLine];
+
+  if (after.length > 0) {
+    const afterWithoutLeadingBlank = after[0].trim() === '' ? after.slice(1) : after;
+    nextLines.push('', ...afterWithoutLeadingBlank);
+  }
+
+  return nextLines.join('\n');
+}
+
 export class LoomReplSession {
   constructor(options = {}) {
     this.target = options.target || 'cli';
@@ -41,7 +82,7 @@ export class LoomReplSession {
       };
     }
 
-    const nextSource = this.source ? `${this.source}\n${snippet}` : snippet;
+    const nextSource = appendSnippetToSource(this.source, snippet);
     const result = runLoomSource(nextSource, {
       target: this.target,
       time: this.time,

--- a/src/toolchain/repl-session.js
+++ b/src/toolchain/repl-session.js
@@ -1,0 +1,103 @@
+import { inspectLoomSource } from './inspect.js';
+import { runLoomSource } from './run.js';
+import { RUNTIME_TARGETS } from './runtime-targets.js';
+
+function createEmptySummary() {
+  return {
+    nodeCount: 0,
+    edgeCount: 0,
+    renderType: null,
+    imports: [],
+    requiredCapabilities: [],
+    compatibleTargets: RUNTIME_TARGETS.filter((target) => target !== 'any'),
+    nodes: []
+  };
+}
+
+export class LoomReplSession {
+  constructor(options = {}) {
+    this.target = options.target || 'cli';
+    this.time = Number.isFinite(options.time) ? options.time : 0;
+    this.dt = Number.isFinite(options.dt) ? options.dt : 0;
+    this.sourceLines = [];
+    this.source = '';
+    this.graph = null;
+    this.lastResult = null;
+  }
+
+  evaluateSnippet(source) {
+    const snippet = String(source ?? '');
+    const trimmed = snippet.trim();
+
+    if (!trimmed) {
+      return {
+        ok: true,
+        empty: true,
+        source: this.source,
+        graph: this.graph,
+        values: this.lastResult?.values || {},
+        effects: [],
+        errors: []
+      };
+    }
+
+    const nextSource = this.source ? `${this.source}\n${snippet}` : snippet;
+    const result = runLoomSource(nextSource, {
+      target: this.target,
+      time: this.time,
+      dt: this.dt
+    });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        source: this.source,
+        graph: this.graph,
+        values: {},
+        effects: [],
+        errors: result.errors
+      };
+    }
+
+    this.source = nextSource;
+    this.sourceLines = this.source.split(/\r?\n/);
+    this.graph = result.graph;
+    this.lastResult = result;
+
+    return {
+      ok: true,
+      empty: false,
+      source: this.source,
+      graph: result.graph,
+      values: result.values,
+      effects: result.effects || [],
+      errors: []
+    };
+  }
+
+  getSource() {
+    return this.source;
+  }
+
+  reset() {
+    this.sourceLines = [];
+    this.source = '';
+    this.graph = null;
+    this.lastResult = null;
+  }
+
+  inspect() {
+    if (!this.source) {
+      return {
+        ok: true,
+        summary: createEmptySummary(),
+        errors: []
+      };
+    }
+    return inspectLoomSource(this.source, { target: this.target });
+  }
+
+  getGraph() {
+    return this.graph;
+  }
+}

--- a/src/toolchain/run.js
+++ b/src/toolchain/run.js
@@ -49,7 +49,17 @@ function validateCliRunnableGraph(graph) {
 function collectRequestedValues(engine, graph, get) {
   const requestedRefs = getRefsToRead(graph, get);
   if (requestedRefs === null) {
-    throw new LoomError('GET_REQUIRED', 'run requires --get in this version');
+    const values = {};
+    for (const node of graph.nodes) {
+      const nodeType = NODE_TYPES[node.type];
+      if (!nodeType || !Array.isArray(nodeType.outputs)) {
+        continue;
+      }
+      for (const output of nodeType.outputs) {
+        values[`${node.id}.${output.name}`] = engine.getValue(`${node.id}.${output.name}`);
+      }
+    }
+    return values;
   }
 
   const values = {};

--- a/test/loom-repl-cli.test.mjs
+++ b/test/loom-repl-cli.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+
+test('repl smoke flow works', () => {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'repl'],
+    {
+      cwd: projectRoot,
+      input: [
+        'import text',
+        'message = text.upper("hello")',
+        ':source',
+        ':quit'
+      ].join('\n'),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Loom REPL/);
+  assert.match(result.stdout, /message\.out = HELLO/);
+  assert.match(result.stdout, /import text/);
+  assert.match(result.stdout, /message = text\.upper/);
+});

--- a/test/loom-repl-cli.test.mjs
+++ b/test/loom-repl-cli.test.mjs
@@ -17,6 +17,8 @@ test('repl smoke flow works', () => {
       input: [
         'import text',
         'message = text.upper("hello")',
+        'import console',
+        'console.log(message)',
         ':source',
         ':quit'
       ].join('\n'),
@@ -27,6 +29,9 @@ test('repl smoke flow works', () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Loom REPL/);
   assert.match(result.stdout, /message\.out = HELLO/);
+  assert.match(result.stderr, /\[log\] HELLO/);
   assert.match(result.stdout, /import text/);
+  assert.match(result.stdout, /import console/);
   assert.match(result.stdout, /message = text\.upper/);
+  assert.match(result.stdout, /import text\s+import console\s+\s*message = text\.upper/s);
 });

--- a/test/loom-repl-session.test.mjs
+++ b/test/loom-repl-session.test.mjs
@@ -36,6 +36,35 @@ test('imports persist', () => {
   assert.match(session.getSource(), /message = text\.upper/);
 });
 
+test('late import is hoisted above existing statements', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import text').ok, true);
+  assert.equal(session.evaluateSnippet('message = text.upper("hello")').ok, true);
+  assert.equal(session.evaluateSnippet('import console').ok, true);
+
+  assert.equal(
+    session.getSource(),
+    [
+      'import text',
+      'import console',
+      '',
+      'message = text.upper("hello")'
+    ].join('\n')
+  );
+});
+
+test('duplicate imports are not added twice', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import text').ok, true);
+  assert.equal(session.evaluateSnippet('message = text.upper("hello")').ok, true);
+  assert.equal(session.evaluateSnippet('import text').ok, true);
+
+  const matches = session.getSource().match(/^import text$/gm) || [];
+  assert.equal(matches.length, 1);
+});
+
 test('console effect works', () => {
   const session = new LoomReplSession();
 

--- a/test/loom-repl-session.test.mjs
+++ b/test/loom-repl-session.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LoomReplSession } from '../src/toolchain/repl-session.js';
+
+test('evaluates assignment snippet', () => {
+  const session = new LoomReplSession();
+  const result = session.evaluateSnippet('x = constant(value: 1)');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.values['x.out'], 1);
+  assert.match(session.getSource(), /x = constant/);
+});
+
+test('invalid snippet does not pollute source', () => {
+  const session = new LoomReplSession();
+
+  let result = session.evaluateSnippet('x = constant(value: 1)');
+  assert.equal(result.ok, true);
+
+  result = session.evaluateSnippet('bad =');
+  assert.equal(result.ok, false);
+
+  assert.equal(session.getSource().includes('bad ='), false);
+  assert.equal(session.getSource().includes('x = constant'), true);
+});
+
+test('imports persist', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import text').ok, true);
+  const result = session.evaluateSnippet('message = text.upper("hello")');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.values['message.out'], 'HELLO');
+  assert.match(session.getSource(), /import text/);
+  assert.match(session.getSource(), /message = text\.upper/);
+});
+
+test('console effect works', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import console').ok, true);
+  assert.equal(session.evaluateSnippet('message = constant(value: "hello")').ok, true);
+
+  const result = session.evaluateSnippet('console.log(message)');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.effects.length, 1);
+  assert.equal(result.effects[0].level, 'log');
+  assert.equal(result.effects[0].value, 'hello');
+});
+
+test('reset clears source and graph', () => {
+  const session = new LoomReplSession();
+
+  session.evaluateSnippet('x = constant(value: 1)');
+  session.reset();
+
+  assert.equal(session.getSource(), '');
+  assert.equal(session.getGraph(), null);
+});
+
+test('inspect returns summary', () => {
+  const session = new LoomReplSession();
+
+  session.evaluateSnippet('x = constant(value: 1)');
+  const inspection = session.inspect();
+
+  assert.equal(inspection.ok, true);
+  assert.equal(inspection.summary.nodeCount >= 1, true);
+});


### PR DESCRIPTION
## Summary
- add a reusable `LoomReplSession` toolchain API that accumulates source and rejects invalid snippets without polluting session state
- add `loom repl` with basic REPL commands, snippet evaluation output, and stderr effect printing
- add REPL session tests, CLI smoke coverage, and README/roadmap docs for the new interactive workflow

## Testing
- `npm run test:cli`
- `npm run test:repl`
- `npm test` *(fails in this environment because Playwright Chromium is not installed: `chromium_headless_shell-1217` is missing for `browserType.launch`)*
