### PR TITLE
Prevent repeated REPL effects and expose per-snippet metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ loom> console.log(message)
 [log] HELLO LOOM
 loom> :source
 import text
-message = text.upper("hello loom")
 import console
+
+message = text.upper("hello loom")
 console.log(message)
 loom> :quit
 ```

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ loom> :quit
 
 The REPL currently recompiles the accumulated source after each snippet. Invalid snippets are rejected and do not modify the current session.
 Import snippets are hoisted into the import block automatically, so you can add imports later while exploring.
+The REPL recompiles the accumulated source after each snippet, but it only displays effects introduced by the latest snippet.
 
 ## ライブエディタと DSL
 

--- a/src/loom.js
+++ b/src/loom.js
@@ -981,7 +981,7 @@ export const NODE_TYPES = {
     outputs: [],
     params: [],
     evaluate: (inputs, params, ctx) => {
-      ctx.engine?._recordEffect({ type: 'console.log', level: 'log', value: inputs.value });
+      ctx.engine?._recordEffect({ type: 'console.log', level: 'log', value: inputs.value, nodeId: ctx.currentNodeId });
       return {};
     }
   },
@@ -991,7 +991,7 @@ export const NODE_TYPES = {
     outputs: [],
     params: [],
     evaluate: (inputs, params, ctx) => {
-      ctx.engine?._recordEffect({ type: 'console.warn', level: 'warn', value: inputs.value });
+      ctx.engine?._recordEffect({ type: 'console.warn', level: 'warn', value: inputs.value, nodeId: ctx.currentNodeId });
       return {};
     }
   },
@@ -1001,7 +1001,7 @@ export const NODE_TYPES = {
     outputs: [],
     params: [],
     evaluate: (inputs, params, ctx) => {
-      ctx.engine?._recordEffect({ type: 'console.error', level: 'error', value: inputs.value });
+      ctx.engine?._recordEffect({ type: 'console.error', level: 'error', value: inputs.value, nodeId: ctx.currentNodeId });
       return {};
     }
   },
@@ -1298,7 +1298,7 @@ export class Loom {
           outputs = { out: stateCtx.prevOut };
         }
       } else {
-        outputs = nodeType.evaluate(inputs, params, ctx);
+        outputs = nodeType.evaluate(inputs, params, { ...ctx, currentNodeId: nodeId });
       }
 
       // 出力値を保存

--- a/src/toolchain/repl-session.js
+++ b/src/toolchain/repl-session.js
@@ -64,6 +64,7 @@ export class LoomReplSession {
     this.source = '';
     this.graph = null;
     this.lastResult = null;
+    this.seenEffectNodeIds = new Set();
   }
 
   evaluateSnippet(source) {
@@ -100,10 +101,26 @@ export class LoomReplSession {
       };
     }
 
+    const allEffects = result.effects || [];
+    const newEffects = allEffects.filter((effect) => {
+      if (!effect?.nodeId) {
+        return true;
+      }
+      return !this.seenEffectNodeIds.has(effect.nodeId);
+    });
+
     this.source = nextSource;
     this.sourceLines = this.source.split(/\r?\n/);
     this.graph = result.graph;
-    this.lastResult = result;
+    this.lastResult = {
+      ...result,
+      effects: newEffects
+    };
+    this.seenEffectNodeIds = new Set(
+      allEffects
+        .map((effect) => effect?.nodeId)
+        .filter((nodeId) => typeof nodeId === 'string' && nodeId.length > 0)
+    );
 
     return {
       ok: true,
@@ -111,7 +128,7 @@ export class LoomReplSession {
       source: this.source,
       graph: result.graph,
       values: result.values,
-      effects: result.effects || [],
+      effects: newEffects,
       errors: []
     };
   }
@@ -125,6 +142,7 @@ export class LoomReplSession {
     this.source = '';
     this.graph = null;
     this.lastResult = null;
+    this.seenEffectNodeIds = new Set();
   }
 
   inspect() {

--- a/test/loom-repl-cli.test.mjs
+++ b/test/loom-repl-cli.test.mjs
@@ -35,3 +35,26 @@ test('repl smoke flow works', () => {
   assert.match(result.stdout, /message = text\.upper/);
   assert.match(result.stdout, /import text\s+import console\s+\s*message = text\.upper/s);
 });
+
+test('repl does not print previous console effect again after later snippet', () => {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'repl'],
+    {
+      cwd: projectRoot,
+      input: [
+        'import console',
+        'message = constant(value: "hello")',
+        'console.log(message)',
+        'x = constant(value: 1)',
+        ':quit'
+      ].join('\n'),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const matches = result.stderr.match(/\[log\] hello/g) || [];
+  assert.equal(matches.length, 1);
+  assert.match(result.stdout, /x\.out = 1/);
+});

--- a/test/loom-repl-session.test.mjs
+++ b/test/loom-repl-session.test.mjs
@@ -77,6 +77,55 @@ test('console effect works', () => {
   assert.equal(result.effects.length, 1);
   assert.equal(result.effects[0].level, 'log');
   assert.equal(result.effects[0].value, 'hello');
+  assert.equal(result.effects[0].nodeId, '_effect1');
+});
+
+test('previous console effects are not returned again after later snippets', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import console').ok, true);
+  assert.equal(session.evaluateSnippet('message = constant(value: "hello")').ok, true);
+
+  const firstEffect = session.evaluateSnippet('console.log(message)');
+  assert.equal(firstEffect.ok, true);
+  assert.equal(firstEffect.effects.length, 1);
+  assert.equal(firstEffect.effects[0].value, 'hello');
+
+  const later = session.evaluateSnippet('x = constant(value: 1)');
+  assert.equal(later.ok, true);
+  assert.equal(later.values['x.out'], 1);
+  assert.equal(later.effects.length, 0);
+});
+
+test('new console effect is returned after previous effect', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import console').ok, true);
+  assert.equal(session.evaluateSnippet('a = constant(value: "a")').ok, true);
+  assert.equal(session.evaluateSnippet('console.log(a)').effects.length, 1);
+  assert.equal(session.evaluateSnippet('b = constant(value: "b")').ok, true);
+
+  const result = session.evaluateSnippet('console.log(b)');
+  assert.equal(result.ok, true);
+  assert.equal(result.effects.length, 1);
+  assert.equal(result.effects[0].value, 'b');
+});
+
+test('reset clears effect tracking', () => {
+  const session = new LoomReplSession();
+
+  assert.equal(session.evaluateSnippet('import console').ok, true);
+  assert.equal(session.evaluateSnippet('message = constant(value: "hello")').ok, true);
+  assert.equal(session.evaluateSnippet('console.log(message)').effects.length, 1);
+
+  session.reset();
+
+  assert.equal(session.evaluateSnippet('import console').ok, true);
+  assert.equal(session.evaluateSnippet('message = constant(value: "hello")').ok, true);
+
+  const result = session.evaluateSnippet('console.log(message)');
+  assert.equal(result.ok, true);
+  assert.equal(result.effects.length, 1);
 });
 
 test('reset clears source and graph', () => {


### PR DESCRIPTION
## Summary
- add node-level effect metadata for CLI-safe console nodes so REPL can distinguish previously executed effects from new ones
- track seen effect node ids in `LoomReplSession` and return only effects introduced by the latest successful snippet
- add REPL session and CLI smoke coverage for repeated-effect suppression, reset behavior, and keep README REPL docs aligned

## Testing
- `npm run test:repl`
- `npm run test:cli`
