### PR TITLE
Split default CI from manual browser tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,25 @@
+name: Browser Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  browser:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: npm run test:browser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,13 @@
-name: Tests
+name: Unit Tests
 
 on:
   pull_request:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
-  test:
+  unit:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,12 +16,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Run tests
-        run: npm test
+      - name: Run unit tests
+        run: npm run test:unit

--- a/README.md
+++ b/README.md
@@ -390,7 +390,24 @@ GitHub Pages で公開されているデモを、ブラウザから直接確認�
 
 ## CI と自動テスト
 
-GitHub Actions で自動テストを実行しています。ローカルで `npm test` を実行する場合は、`package.json` が必要ですが、これは CI 自動化専用です。`src/loom.js` は依存ライブラリゼロの単一ファイル配布であり、package.json は開発用ツール（Playwright、http-server）のみを含みます。
+Fast Node/unit tests:
+
+```bash
+npm test
+# or
+npm run test:unit
+```
+
+Browser tests:
+
+```bash
+npm run test:browser
+```
+
+GitHub Actions runs unit tests automatically for pull requests and pushes to `main`.
+Browser tests are available as a manual GitHub Actions workflow and should be run when changing browser examples, renderer behavior, Web Studio, or DOM/Canvas-related code.
+
+`src/loom.js` は依存ライブラリゼロの単一ファイル配布であり、`package.json` は開発用ツール（Playwright、http-server）と CLI / toolchain 用テストを含みます。
 
 ## ライセンス
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "loom": "./bin/loom.mjs"
   },
   "scripts": {
-    "test": "node ci/run-tests.mjs",
+    "test": "npm run test:unit",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
     "loom": "node bin/loom.mjs",
-    "test:cli": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
-    "test:repl": "node test/loom-repl-session.test.mjs"
+    "test:cli": "node test/loom-cli.test.mjs",
+    "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
+    "test:browser": "node ci/run-tests.mjs"
   },
   "devDependencies": {
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Summary
- split test scripts so `npm test` and default CI run only fast Node/unit coverage for CLI and REPL work
- update the default GitHub Actions workflow to use `npm ci` plus `npm run test:unit` without Playwright browser install
- add a separate manual `Browser Tests` workflow and document when to run it in the README

## Testing
- `npm test`
- `npm run test:cli`
- `npm run test:repl`
