### PR TITLE
Add Scene Sync probe commands to Loom CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ The REPL currently recompiles the accumulated source after each snippet. Invalid
 Import snippets are hoisted into the import block automatically, so you can add imports later while exploring.
 The REPL recompiles the accumulated source after each snippet, but it only displays effects introduced by the latest snippet.
 
+### Scene Sync probe commands
+
+Loom CLI includes early read-only Scene Sync probe commands.
+
+```bash
+node bin/loom.mjs scenesync ping --room 121555
+node bin/loom.mjs scenesync objects --room 121555
+node bin/loom.mjs scenesync info --room 121555
+```
+
+You can also configure defaults:
+
+```bash
+export LOOM_SCENESYNC_ENDPOINT=https://afjk.jp/pipe
+export LOOM_SCENESYNC_ROOM=121555
+```
+
+These commands are read-only. Sending Loom graphs to Scene Sync is planned for a later phase.
+
 ## ライブエディタと DSL
 
 ### エディタ一覧

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -14,6 +14,11 @@ import {
   isKnownRuntimeTarget,
   LoomReplSession
 } from '../src/toolchain/index.js';
+import {
+  DEFAULT_ENDPOINT as DEFAULT_SCENESYNC_ENDPOINT,
+  SceneSyncClient,
+  formatSceneSyncError
+} from '../src/scenesync/index.js';
 
 function print(message = '') {
   process.stdout.write(`${message}\n`);
@@ -99,6 +104,7 @@ Commands:
   inspect <file>   Inspect Loom DSL and print a summary
   run <file>       Evaluate a Loom graph once
   repl             Start an interactive Loom REPL
+  scenesync        Probe Scene Sync rooms
   help             Show help
 
 Examples:
@@ -106,6 +112,7 @@ Examples:
   loom format examples/cli-basic.loom --check
   loom inspect examples/cli-basic.loom --json
   loom run examples/cli-basic.loom --get x.out --time 0.25
+  loom scenesync ping --room 121555
   loom repl`;
 }
 
@@ -166,6 +173,22 @@ Commands:
   :exit      Exit the REPL`;
 }
 
+function getSceneSyncHelp() {
+  return `Usage:
+  loom scenesync <command> [options]
+
+Commands:
+  ping              Check Scene Sync command connection
+  info              Get room information
+  objects           List scene objects
+  list-objects      Alias for objects
+
+Options:
+  --room <room>        Scene Sync room code
+  --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
+  --json               Print raw JSON response`;
+}
+
 function formatValue(value) {
   if (typeof value === 'string') return value;
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
@@ -213,6 +236,101 @@ function printSnippetResult(snippet, result) {
 
 async function readSourceFile(file) {
   return readFile(path.resolve(process.cwd(), file), 'utf8');
+}
+
+function parseSceneSyncArgs(args) {
+  let room = process.env.LOOM_SCENESYNC_ROOM || '';
+  let endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || DEFAULT_SCENESYNC_ENDPOINT;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--room') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--room requires a room code');
+      }
+      room = next;
+      index += 1;
+    } else if (arg === '--endpoint') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--endpoint requires a URL');
+      }
+      endpoint = next;
+      index += 1;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { room, endpoint, json };
+}
+
+function requireSceneSyncRoom(room) {
+  if (!room) {
+    throw new Error('Scene Sync room is required. Pass --room <room> or set LOOM_SCENESYNC_ROOM.');
+  }
+}
+
+function formatSceneSyncPosition(position) {
+  if (Array.isArray(position)) {
+    return `(${position.join(', ')})`;
+  }
+  if (position && typeof position === 'object') {
+    return `(${position.x ?? '?'}, ${position.y ?? '?'}, ${position.z ?? '?'})`;
+  }
+  return String(position);
+}
+
+function printSceneSyncInfo(room, result) {
+  const info = result?.result || {};
+  const lines = [`Room: ${room}`];
+
+  if (typeof info.clients === 'number') {
+    lines.push(`Clients: ${info.clients}`);
+  } else if (typeof info.clientCount === 'number') {
+    lines.push(`Clients: ${info.clientCount}`);
+  }
+
+  if (typeof info.objects === 'number') {
+    lines.push(`Objects: ${info.objects}`);
+  } else if (typeof info.objectCount === 'number') {
+    lines.push(`Objects: ${info.objectCount}`);
+  }
+
+  if (lines.length === 1 && Object.keys(info).length > 0) {
+    print(stringifyJson(info));
+    return;
+  }
+
+  print(lines.join('\n'));
+}
+
+function printSceneSyncObjects(result) {
+  const objects = Array.isArray(result?.result?.objects) ? result.result.objects : null;
+
+  if (objects === null) {
+    print(stringifyJson(result.result ?? result));
+    return;
+  }
+
+  if (objects.length === 0) {
+    print('Objects: none');
+    return;
+  }
+
+  print('Objects:');
+  for (const object of objects) {
+    const id = object.id || object.name || '<unknown>';
+    const type = object.type || '<unknown>';
+    const position = object.position !== undefined
+      ? `  position=${formatSceneSyncPosition(object.position)}`
+      : '';
+    print(`- ${id}  ${type}${position}`);
+  }
 }
 
 async function handleCompile(args) {
@@ -519,6 +637,58 @@ async function handleRepl(args) {
   });
 }
 
+async function handleSceneSync(args) {
+  if (args.length === 0 || args.includes('--help')) {
+    print(getSceneSyncHelp());
+    return 0;
+  }
+
+  const [subcommand, ...rest] = args;
+  if (rest.includes('--help')) {
+    print(getSceneSyncHelp());
+    return 0;
+  }
+
+  const { room, endpoint, json } = parseSceneSyncArgs(rest);
+  requireSceneSyncRoom(room);
+
+  const client = new SceneSyncClient({ endpoint });
+  let result;
+
+  if (subcommand === 'ping') {
+    result = await client.ping({ room });
+  } else if (subcommand === 'info') {
+    result = await client.info({ room });
+  } else if (subcommand === 'objects' || subcommand === 'list-objects') {
+    result = await client.listObjects({ room });
+  } else {
+    throw new Error(`Unknown scenesync command: ${subcommand}`);
+  }
+
+  if (!result.ok) {
+    printError(formatSceneSyncError(result.error));
+    return 1;
+  }
+
+  if (json) {
+    print(stringifyJson(result));
+    return 0;
+  }
+
+  if (subcommand === 'ping') {
+    print(`Scene Sync room ${room} is reachable.`);
+    return 0;
+  }
+
+  if (subcommand === 'info') {
+    printSceneSyncInfo(room, result);
+    return 0;
+  }
+
+  printSceneSyncObjects(result);
+  return 0;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
@@ -540,6 +710,8 @@ async function main() {
       exitCode = await handleRun(args.slice(1));
     } else if (command === 'repl') {
       exitCode = await handleRepl(args.slice(1));
+    } else if (command === 'scenesync') {
+      exitCode = await handleSceneSync(args.slice(1));
     } else {
       throw new Error(`unknown command: ${command}`);
     }

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -42,20 +42,36 @@
 
 ## Phase 6: SceneSync integration
 
+- read-only room probes via `loom scenesync ping`
+- read-only room probes via `loom scenesync info`
+- read-only room probes via `loom scenesync objects`
+- reusable Scene Sync command schema and client layer
 - compile DSL and send graph
 - target scene scope
 - target object scope
 - clear graph
 - patch graph
 
-## Phase 7: Web Studio integration
+## Phase 7: SceneSync follow-up
+
+- compile DSL and send graph
+- `loom scenesync run <file.loom>`
+- `loom scenesync send-graph <file.json>`
+- target scene scope
+- target object scope
+- clear graph
+- patch graph
+- `loom repl :connect scenesync`
+- `loom repl :objects`
+
+## Phase 8: Web Studio integration
 
 - reuse toolchain modules
 - shared diagnostics
 - target/import compatibility panel
 - inspect panel
 
-## Phase 8: AI/MCP integration
+## Phase 9: AI/MCP integration
 
 - expose compile/format/inspect as tools
 - use inspect summaries to reduce context size

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/scenesync/client.js
+++ b/src/scenesync/client.js
@@ -1,0 +1,107 @@
+import {
+  createSceneInfoCommand,
+  createSceneListObjectsCommand,
+  createScenePingCommand,
+  normalizeSceneSyncResponse
+} from './commands.js';
+
+const DEFAULT_ENDPOINT = 'https://afjk.jp/pipe';
+
+function normalizeEndpoint(endpoint) {
+  if (typeof endpoint !== 'string' || endpoint.trim().length === 0) {
+    return DEFAULT_ENDPOINT;
+  }
+  return endpoint.trim();
+}
+
+function buildCommandUrl(endpoint, room) {
+  const base = normalizeEndpoint(endpoint).replace(/\/+$/, '');
+  return `${base}/api/scenesync/command/${encodeURIComponent(room)}`;
+}
+
+function createRoomRequiredError() {
+  return {
+    ok: false,
+    error: {
+      code: 'ROOM_REQUIRED',
+      message: 'Scene Sync room is required'
+    }
+  };
+}
+
+export class SceneSyncClient {
+  constructor(options = {}) {
+    this.endpoint = normalizeEndpoint(options.endpoint);
+    this.fetchImpl = options.fetchImpl || globalThis.fetch;
+  }
+
+  async sendCommand(command) {
+    if (!command || typeof command !== 'object' || !command.room) {
+      return createRoomRequiredError();
+    }
+
+    if (typeof this.fetchImpl !== 'function') {
+      return {
+        ok: false,
+        error: {
+          code: 'FETCH_UNAVAILABLE',
+          message: 'fetch is not available in this runtime'
+        }
+      };
+    }
+
+    try {
+      const response = await this.fetchImpl(buildCommandUrl(this.endpoint, command.room), {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify(command)
+      });
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: {
+            code: 'HTTP_ERROR',
+            message: `HTTP ${response.status}`
+          }
+        };
+      }
+
+      const payload = await response.json();
+      return normalizeSceneSyncResponse(payload);
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: 'NETWORK_ERROR',
+          message: error instanceof Error ? error.message : String(error)
+        }
+      };
+    }
+  }
+
+  async ping({ room } = {}) {
+    if (!room) {
+      return createRoomRequiredError();
+    }
+    return this.sendCommand(createScenePingCommand({ room }));
+  }
+
+  async info({ room } = {}) {
+    if (!room) {
+      return createRoomRequiredError();
+    }
+    return this.sendCommand(createSceneInfoCommand({ room }));
+  }
+
+  async listObjects({ room } = {}) {
+    if (!room) {
+      return createRoomRequiredError();
+    }
+    return this.sendCommand(createSceneListObjectsCommand({ room }));
+  }
+}
+
+export { DEFAULT_ENDPOINT };

--- a/src/scenesync/commands.js
+++ b/src/scenesync/commands.js
@@ -1,0 +1,91 @@
+function createRequestId() {
+  return `loom-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function createCommand(type, { room, requestId } = {}) {
+  return {
+    type,
+    requestId: requestId || createRequestId(),
+    room,
+    payload: {}
+  };
+}
+
+export function createScenePingCommand(options = {}) {
+  return createCommand('scene.ping', options);
+}
+
+export function createSceneInfoCommand(options = {}) {
+  return createCommand('scene.info', options);
+}
+
+export function createSceneListObjectsCommand(options = {}) {
+  return createCommand('scene.listObjects', options);
+}
+
+export function normalizeSceneSyncResponse(response) {
+  if (!response || typeof response !== 'object') {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_RESPONSE',
+        message: 'Invalid Scene Sync response'
+      }
+    };
+  }
+
+  if (response.ok === true) {
+    if (typeof response.type !== 'string') {
+      return {
+        ok: false,
+        error: {
+          code: 'INVALID_RESPONSE',
+          message: 'Invalid Scene Sync response'
+        }
+      };
+    }
+
+    return {
+      ok: true,
+      type: response.type,
+      requestId: typeof response.requestId === 'string' ? response.requestId : null,
+      result: response.result ?? {}
+    };
+  }
+
+  if (response.ok === false) {
+    const error = response.error || {};
+    return {
+      ok: false,
+      type: typeof response.type === 'string' ? response.type : 'error',
+      requestId: typeof response.requestId === 'string' ? response.requestId : null,
+      error: {
+        code: typeof error.code === 'string' ? error.code : 'SCENESYNC_ERROR',
+        message: typeof error.message === 'string' ? error.message : 'Scene Sync request failed'
+      }
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'INVALID_RESPONSE',
+      message: 'Invalid Scene Sync response'
+    }
+  };
+}
+
+export function formatSceneSyncError(error) {
+  if (!error || typeof error !== 'object') {
+    return 'SCENESYNC_ERROR - Unknown Scene Sync error';
+  }
+
+  const code = typeof error.code === 'string' && error.code.length > 0
+    ? error.code
+    : 'SCENESYNC_ERROR';
+  const message = typeof error.message === 'string' && error.message.length > 0
+    ? error.message
+    : 'Scene Sync request failed';
+
+  return `${code} - ${message}`;
+}

--- a/src/scenesync/index.js
+++ b/src/scenesync/index.js
@@ -1,0 +1,2 @@
+export * from './client.js';
+export * from './commands.js';

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -18,6 +18,17 @@ function runCli(args) {
   });
 }
 
+function runCliWithEnv(args, env) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env
+    }
+  });
+}
+
 test('compile outputs GraphJSON', () => {
   const result = runCli(['compile', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);
@@ -211,6 +222,23 @@ test('inspect includes qualified function node names', async () => {
   const result = runCli(['inspect', file]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /text\.upper/);
+});
+
+test('scenesync help prints command group usage', () => {
+  const result = runCli(['scenesync', '--help']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /loom scenesync <command>/);
+  assert.match(result.stdout, /ping/);
+  assert.match(result.stdout, /objects/);
+});
+
+test('scenesync requires room via arg or env', () => {
+  const result = runCliWithEnv(['scenesync', 'ping'], {
+    LOOM_SCENESYNC_ROOM: '',
+    LOOM_SCENESYNC_ENDPOINT: ''
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Scene Sync room is required/);
 });
 
 test('parse error exits 1', async () => {

--- a/test/scenesync-client.test.mjs
+++ b/test/scenesync-client.test.mjs
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createSceneListObjectsCommand,
+  SceneSyncClient
+} from '../src/scenesync/index.js';
+
+test('command helper creates listObjects command', () => {
+  const command = createSceneListObjectsCommand({ room: '121555', requestId: 'test-1' });
+  assert.equal(command.type, 'scene.listObjects');
+  assert.equal(command.room, '121555');
+  assert.equal(command.requestId, 'test-1');
+  assert.deepEqual(command.payload, {});
+});
+
+test('client sends command to expected URL', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          ok: true,
+          type: 'scene.ping.result',
+          requestId: 'test',
+          result: { pong: true }
+        };
+      }
+    };
+  };
+
+  const client = new SceneSyncClient({
+    endpoint: 'https://example.com/pipe',
+    fetchImpl
+  });
+
+  const result = await client.ping({ room: '121555' });
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.match(String(calls[0].url), /121555/);
+  assert.equal(JSON.parse(calls[0].options.body).type, 'scene.ping');
+});
+
+test('HTTP error returns normalized error', async () => {
+  const client = new SceneSyncClient({
+    endpoint: 'https://example.com/pipe',
+    fetchImpl: async () => ({
+      ok: false,
+      status: 404,
+      async json() {
+        return {};
+      }
+    })
+  });
+
+  const result = await client.info({ room: '121555' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'HTTP_ERROR');
+});
+
+test('malformed response returns INVALID_RESPONSE', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {};
+      }
+    })
+  });
+
+  const result = await client.listObjects({ room: '121555' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'INVALID_RESPONSE');
+});
+
+test('room required', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.listObjects();
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'ROOM_REQUIRED');
+});
+
+test('network error returns NETWORK_ERROR', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('boom');
+    }
+  });
+
+  const result = await client.ping({ room: '121555' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'NETWORK_ERROR');
+});


### PR DESCRIPTION
## Summary
- add reusable Scene Sync command schema and client modules for read-only room probes
- add `loom scenesync ping|info|objects` with room/endpoint env fallbacks and defensive human-readable output
- cover the new client with mocked fetch unit tests and document the initial read-only Scene Sync CLI workflow

## Testing
- `npm run test:unit`
- `npm test`
