### PR TITLE
Fix: Align Loom Scene Sync client with existing afjk.jp AI wrapper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,19 +235,51 @@ The REPL recompiles the accumulated source after each snippet, but it only displ
 
 ### Scene Sync probe commands
 
-Loom CLI includes early read-only Scene Sync probe commands.
+Loom CLI includes read-only Scene Sync probe commands to interact with the afjk.jp AI wrapper.
+
+#### Redeem a code
 
 ```bash
-node bin/loom.mjs scenesync ping --room 121555
-node bin/loom.mjs scenesync objects --room 121555
-node bin/loom.mjs scenesync info --room 121555
+node bin/loom.mjs scenesync redeem 238909
 ```
 
-You can also configure defaults:
+Output:
+```
+Linked Scene Sync room.
+Room: <roomId>
+Session: <sessionId>
+Expires At: <expiresAt>
+```
+
+#### List objects in a room
 
 ```bash
-export LOOM_SCENESYNC_ENDPOINT=https://afjk.jp/pipe
-export LOOM_SCENESYNC_ROOM=121555
+node bin/loom.mjs scenesync objects --room <roomId> --session <sessionId>
+```
+
+#### Get room information
+
+```bash
+node bin/loom.mjs scenesync info --room <roomId> --session <sessionId>
+```
+
+#### Check room connectivity
+
+```bash
+node bin/loom.mjs scenesync ping --room <roomId> --session <sessionId>
+```
+
+`ping` currently performs a lightweight scene snapshot request because the existing AI wrapper does not expose a dedicated ping endpoint.
+
+#### Configure defaults
+
+```bash
+export LOOM_SCENESYNC_ROOM=<roomId>
+export LOOM_SCENESYNC_SESSION=<sessionId>
+export LOOM_SCENESYNC_ENDPOINT=https://afjk.jp/presence/api/ai
+
+# Now you can omit --room and --session
+node bin/loom.mjs scenesync objects
 ```
 
 These commands are read-only. Sending Loom graphs to Scene Sync is planned for a later phase.

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -649,25 +649,29 @@ async function handleSceneSync(args) {
   }
 
   if (subcommand === 'redeem') {
-    const { endpoint, json } = parseSceneSyncArgs(rest);
     let code = null;
+    let codeIndex = -1;
 
     for (let index = 0; index < rest.length; index += 1) {
       const arg = rest[index];
       if (!arg.startsWith('-') && !['--room', '--session', '--endpoint', '--json'].includes(rest[index - 1])) {
         code = arg;
+        codeIndex = index;
         break;
       }
     }
 
     if (!code && rest.length > 0 && !rest[0].startsWith('-')) {
       code = rest[0];
+      codeIndex = 0;
     }
 
     if (!code) {
       throw new Error('redeem requires a code argument');
     }
 
+    const argsWithoutCode = codeIndex >= 0 ? rest.filter((_, i) => i !== codeIndex) : rest;
+    const { endpoint, json } = parseSceneSyncArgs(argsWithoutCode);
     const client = new SceneSyncClient({ endpoint });
     const result = await client.redeem({ code });
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -648,11 +648,8 @@ async function handleSceneSync(args) {
     return 0;
   }
 
-  const client = new SceneSyncClient({ endpoint: process.env.LOOM_SCENESYNC_ENDPOINT || DEFAULT_SCENESYNC_ENDPOINT });
-  let result;
-
   if (subcommand === 'redeem') {
-    const { room, session, endpoint, json } = parseSceneSyncArgs(rest);
+    const { endpoint, json } = parseSceneSyncArgs(rest);
     let code = null;
 
     for (let index = 0; index < rest.length; index += 1) {
@@ -671,8 +668,8 @@ async function handleSceneSync(args) {
       throw new Error('redeem requires a code argument');
     }
 
-    const newClient = new SceneSyncClient({ endpoint });
-    result = await newClient.redeem({ code });
+    const client = new SceneSyncClient({ endpoint });
+    const result = await client.redeem({ code });
 
     if (!result.ok) {
       printError(formatSceneSyncError(result.error));
@@ -700,6 +697,9 @@ async function handleSceneSync(args) {
   if (subcommand === 'ping' || subcommand === 'info' || subcommand === 'objects' || subcommand === 'list-objects') {
     requireSceneSyncRoom(room);
     requireSceneSyncSession(session);
+
+    const client = new SceneSyncClient({ endpoint });
+    let result;
 
     if (subcommand === 'ping') {
       result = await client.ping({ room, session });

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -112,7 +112,8 @@ Examples:
   loom format examples/cli-basic.loom --check
   loom inspect examples/cli-basic.loom --json
   loom run examples/cli-basic.loom --get x.out --time 0.25
-  loom scenesync ping --room 121555
+  loom scenesync redeem 238909
+  loom scenesync objects --room <roomId> --session <sessionId>
   loom repl`;
 }
 
@@ -178,15 +179,22 @@ function getSceneSyncHelp() {
   loom scenesync <command> [options]
 
 Commands:
-  ping              Check Scene Sync command connection
+  redeem            Redeem a code for a session
+  ping              Check Scene Sync room connection
   info              Get room information
   objects           List scene objects
   list-objects      Alias for objects
 
 Options:
   --room <room>        Scene Sync room code
+  --session <id>       Scene Sync session ID
   --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
-  --json               Print raw JSON response`;
+  --json               Print raw JSON response
+
+Environment Variables:
+  LOOM_SCENESYNC_ROOM              Default room code
+  LOOM_SCENESYNC_SESSION           Default session ID
+  LOOM_SCENESYNC_ENDPOINT          Default endpoint`;
 }
 
 function formatValue(value) {
@@ -240,6 +248,7 @@ async function readSourceFile(file) {
 
 function parseSceneSyncArgs(args) {
   let room = process.env.LOOM_SCENESYNC_ROOM || '';
+  let session = process.env.LOOM_SCENESYNC_SESSION || '';
   let endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || DEFAULT_SCENESYNC_ENDPOINT;
   let json = false;
 
@@ -251,6 +260,13 @@ function parseSceneSyncArgs(args) {
         throw new Error('--room requires a room code');
       }
       room = next;
+      index += 1;
+    } else if (arg === '--session') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--session requires a session ID');
+      }
+      session = next;
       index += 1;
     } else if (arg === '--endpoint') {
       const next = args[index + 1];
@@ -266,12 +282,18 @@ function parseSceneSyncArgs(args) {
     }
   }
 
-  return { room, endpoint, json };
+  return { room, session, endpoint, json };
 }
 
 function requireSceneSyncRoom(room) {
   if (!room) {
-    throw new Error('Scene Sync room is required. Pass --room <room> or set LOOM_SCENESYNC_ROOM.');
+    throw new Error('Scene Sync room is required. Pass --room <roomId> or set LOOM_SCENESYNC_ROOM.');
+  }
+}
+
+function requireSceneSyncSession(session) {
+  if (!session) {
+    throw new Error('Scene Sync session is required. Pass --session <sessionId> or set LOOM_SCENESYNC_SESSION.');
   }
 }
 
@@ -285,48 +307,25 @@ function formatSceneSyncPosition(position) {
   return String(position);
 }
 
-function printSceneSyncInfo(room, result) {
-  const info = result?.result || {};
-  const lines = [`Room: ${room}`];
-
-  if (typeof info.clients === 'number') {
-    lines.push(`Clients: ${info.clients}`);
-  } else if (typeof info.clientCount === 'number') {
-    lines.push(`Clients: ${info.clientCount}`);
-  }
-
-  if (typeof info.objects === 'number') {
-    lines.push(`Objects: ${info.objects}`);
-  } else if (typeof info.objectCount === 'number') {
-    lines.push(`Objects: ${info.objectCount}`);
-  }
-
-  if (lines.length === 1 && Object.keys(info).length > 0) {
-    print(stringifyJson(info));
-    return;
-  }
-
+function printSceneSyncInfo(room, envId, objectCount) {
+  const lines = [
+    `Room: ${room}`,
+    `Environment: ${envId || '<unknown>'}`,
+    `Objects: ${objectCount ?? 0}`
+  ];
   print(lines.join('\n'));
 }
 
-function printSceneSyncObjects(result) {
-  const objects = Array.isArray(result?.result?.objects) ? result.result.objects : null;
-
-  if (objects === null) {
-    print(stringifyJson(result.result ?? result));
-    return;
-  }
-
-  if (objects.length === 0) {
+function printSceneSyncObjects(objects) {
+  if (!objects || typeof objects !== 'object' || Object.keys(objects).length === 0) {
     print('Objects: none');
     return;
   }
 
   print('Objects:');
-  for (const object of objects) {
-    const id = object.id || object.name || '<unknown>';
-    const type = object.type || '<unknown>';
-    const position = object.position !== undefined
+  for (const [id, object] of Object.entries(objects)) {
+    const type = object?.type || '<unknown>';
+    const position = object?.position !== undefined
       ? `  position=${formatSceneSyncPosition(object.position)}`
       : '';
     print(`- ${id}  ${type}${position}`);
@@ -649,44 +648,97 @@ async function handleSceneSync(args) {
     return 0;
   }
 
-  const { room, endpoint, json } = parseSceneSyncArgs(rest);
-  requireSceneSyncRoom(room);
-
-  const client = new SceneSyncClient({ endpoint });
+  const client = new SceneSyncClient({ endpoint: process.env.LOOM_SCENESYNC_ENDPOINT || DEFAULT_SCENESYNC_ENDPOINT });
   let result;
 
-  if (subcommand === 'ping') {
-    result = await client.ping({ room });
-  } else if (subcommand === 'info') {
-    result = await client.info({ room });
-  } else if (subcommand === 'objects' || subcommand === 'list-objects') {
-    result = await client.listObjects({ room });
-  } else {
-    throw new Error(`Unknown scenesync command: ${subcommand}`);
-  }
+  if (subcommand === 'redeem') {
+    const { room, session, endpoint, json } = parseSceneSyncArgs(rest);
+    let code = null;
 
-  if (!result.ok) {
-    printError(formatSceneSyncError(result.error));
-    return 1;
-  }
+    for (let index = 0; index < rest.length; index += 1) {
+      const arg = rest[index];
+      if (!arg.startsWith('-') && !['--room', '--session', '--endpoint', '--json'].includes(rest[index - 1])) {
+        code = arg;
+        break;
+      }
+    }
 
-  if (json) {
-    print(stringifyJson(result));
+    if (!code && rest.length > 0 && !rest[0].startsWith('-')) {
+      code = rest[0];
+    }
+
+    if (!code) {
+      throw new Error('redeem requires a code argument');
+    }
+
+    const newClient = new SceneSyncClient({ endpoint });
+    result = await newClient.redeem({ code });
+
+    if (!result.ok) {
+      printError(formatSceneSyncError(result.error));
+      return 1;
+    }
+
+    if (json) {
+      print(stringifyJson(result.data));
+      return 0;
+    }
+
+    const data = result.data || {};
+    const lines = [
+      'Linked Scene Sync room.',
+      `Room: ${data.roomId || '<unknown>'}`,
+      `Session: ${data.sessionId || '<unknown>'}`,
+      `Expires At: ${data.expiresAt || '<unknown>'}`
+    ];
+    print(lines.join('\n'));
     return 0;
   }
 
-  if (subcommand === 'ping') {
-    print(`Scene Sync room ${room} is reachable.`);
+  const { room, session, endpoint, json } = parseSceneSyncArgs(rest);
+
+  if (subcommand === 'ping' || subcommand === 'info' || subcommand === 'objects' || subcommand === 'list-objects') {
+    requireSceneSyncRoom(room);
+    requireSceneSyncSession(session);
+
+    if (subcommand === 'ping') {
+      result = await client.ping({ room, session });
+    } else if (subcommand === 'info') {
+      result = await client.info({ room, session });
+    } else {
+      result = await client.listObjects({ room, session });
+    }
+
+    if (!result.ok) {
+      printError(formatSceneSyncError(result.error));
+      return 1;
+    }
+
+    if (json) {
+      print(stringifyJson(result.data));
+      return 0;
+    }
+
+    if (subcommand === 'ping') {
+      print(`Scene Sync room ${room} is reachable.`);
+      return 0;
+    }
+
+    const data = result.data || {};
+    const envId = data.envId || '<unknown>';
+    const objects = data.objects || {};
+    const objectCount = Object.keys(objects).length;
+
+    if (subcommand === 'info') {
+      printSceneSyncInfo(room, envId, objectCount);
+      return 0;
+    }
+
+    printSceneSyncObjects(objects);
     return 0;
   }
 
-  if (subcommand === 'info') {
-    printSceneSyncInfo(room, result);
-    return 0;
-  }
-
-  printSceneSyncObjects(result);
-  return 0;
+  throw new Error(`Unknown scenesync command: ${subcommand}`);
 }
 
 async function main() {

--- a/src/scenesync/client.js
+++ b/src/scenesync/client.js
@@ -1,11 +1,4 @@
-import {
-  createSceneInfoCommand,
-  createSceneListObjectsCommand,
-  createScenePingCommand,
-  normalizeSceneSyncResponse
-} from './commands.js';
-
-const DEFAULT_ENDPOINT = 'https://afjk.jp/pipe';
+const DEFAULT_ENDPOINT = 'https://afjk.jp/presence/api/ai';
 
 function normalizeEndpoint(endpoint) {
   if (typeof endpoint !== 'string' || endpoint.trim().length === 0) {
@@ -14,17 +7,41 @@ function normalizeEndpoint(endpoint) {
   return endpoint.trim();
 }
 
-function buildCommandUrl(endpoint, room) {
-  const base = normalizeEndpoint(endpoint).replace(/\/+$/, '');
-  return `${base}/api/scenesync/command/${encodeURIComponent(room)}`;
-}
+function normalizeApiResponse(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_RESPONSE',
+        message: 'Invalid response'
+      }
+    };
+  }
 
-function createRoomRequiredError() {
+  if (payload.ok === false) {
+    const error = payload.error || {};
+    return {
+      ok: false,
+      error: {
+        code: typeof error.code === 'string' ? error.code : 'API_ERROR',
+        message: typeof error.message === 'string' ? error.message : 'API request failed',
+        retryable: typeof error.retryable === 'boolean' ? error.retryable : undefined
+      }
+    };
+  }
+
+  if (payload.ok === true) {
+    return {
+      ok: true,
+      data: payload
+    };
+  }
+
   return {
     ok: false,
     error: {
-      code: 'ROOM_REQUIRED',
-      message: 'Scene Sync room is required'
+      code: 'INVALID_RESPONSE',
+      message: 'Invalid response'
     }
   };
 }
@@ -35,11 +52,7 @@ export class SceneSyncClient {
     this.fetchImpl = options.fetchImpl || globalThis.fetch;
   }
 
-  async sendCommand(command) {
-    if (!command || typeof command !== 'object' || !command.room) {
-      return createRoomRequiredError();
-    }
-
+  async #request(path, body) {
     if (typeof this.fetchImpl !== 'function') {
       return {
         ok: false,
@@ -51,26 +64,22 @@ export class SceneSyncClient {
     }
 
     try {
-      const response = await this.fetchImpl(buildCommandUrl(this.endpoint, command.room), {
+      const url = `${this.endpoint.replace(/\/+$/, '')}${path}`;
+      const response = await this.fetchImpl(url, {
         method: 'POST',
         headers: {
           'content-type': 'application/json'
         },
-        body: JSON.stringify(command)
+        body: JSON.stringify(body)
       });
 
+      const payload = await response.json();
+
       if (!response.ok) {
-        return {
-          ok: false,
-          error: {
-            code: 'HTTP_ERROR',
-            message: `HTTP ${response.status}`
-          }
-        };
+        return normalizeApiResponse(payload);
       }
 
-      const payload = await response.json();
-      return normalizeSceneSyncResponse(payload);
+      return normalizeApiResponse(payload);
     } catch (error) {
       return {
         ok: false,
@@ -82,25 +91,68 @@ export class SceneSyncClient {
     }
   }
 
-  async ping({ room } = {}) {
-    if (!room) {
-      return createRoomRequiredError();
+  async redeem({ code } = {}) {
+    if (!code) {
+      return {
+        ok: false,
+        error: {
+          code: 'CODE_REQUIRED',
+          message: 'Redeem code is required'
+        }
+      };
     }
-    return this.sendCommand(createScenePingCommand({ room }));
+
+    return this.#request('/link/redeem', { code });
   }
 
-  async info({ room } = {}) {
+  async getScene({ room, session } = {}) {
     if (!room) {
-      return createRoomRequiredError();
+      return {
+        ok: false,
+        error: {
+          code: 'ROOM_REQUIRED',
+          message: 'Scene Sync room is required'
+        }
+      };
     }
-    return this.sendCommand(createSceneInfoCommand({ room }));
+
+    if (!session) {
+      return {
+        ok: false,
+        error: {
+          code: 'SESSION_REQUIRED',
+          message: 'Scene Sync session is required'
+        }
+      };
+    }
+
+    return this.#request(`/room/${encodeURIComponent(room)}/scene`, { sessionId: session });
   }
 
-  async listObjects({ room } = {}) {
-    if (!room) {
-      return createRoomRequiredError();
+  async revoke({ session } = {}) {
+    if (!session) {
+      return {
+        ok: false,
+        error: {
+          code: 'SESSION_REQUIRED',
+          message: 'Scene Sync session is required'
+        }
+      };
     }
-    return this.sendCommand(createSceneListObjectsCommand({ room }));
+
+    return this.#request('/link/revoke', { sessionId: session });
+  }
+
+  async ping({ room, session } = {}) {
+    return this.getScene({ room, session });
+  }
+
+  async info({ room, session } = {}) {
+    return this.getScene({ room, session });
+  }
+
+  async listObjects({ room, session } = {}) {
+    return this.getScene({ room, session });
   }
 }
 

--- a/src/scenesync/commands.js
+++ b/src/scenesync/commands.js
@@ -1,80 +1,3 @@
-function createRequestId() {
-  return `loom-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
-function createCommand(type, { room, requestId } = {}) {
-  return {
-    type,
-    requestId: requestId || createRequestId(),
-    room,
-    payload: {}
-  };
-}
-
-export function createScenePingCommand(options = {}) {
-  return createCommand('scene.ping', options);
-}
-
-export function createSceneInfoCommand(options = {}) {
-  return createCommand('scene.info', options);
-}
-
-export function createSceneListObjectsCommand(options = {}) {
-  return createCommand('scene.listObjects', options);
-}
-
-export function normalizeSceneSyncResponse(response) {
-  if (!response || typeof response !== 'object') {
-    return {
-      ok: false,
-      error: {
-        code: 'INVALID_RESPONSE',
-        message: 'Invalid Scene Sync response'
-      }
-    };
-  }
-
-  if (response.ok === true) {
-    if (typeof response.type !== 'string') {
-      return {
-        ok: false,
-        error: {
-          code: 'INVALID_RESPONSE',
-          message: 'Invalid Scene Sync response'
-        }
-      };
-    }
-
-    return {
-      ok: true,
-      type: response.type,
-      requestId: typeof response.requestId === 'string' ? response.requestId : null,
-      result: response.result ?? {}
-    };
-  }
-
-  if (response.ok === false) {
-    const error = response.error || {};
-    return {
-      ok: false,
-      type: typeof response.type === 'string' ? response.type : 'error',
-      requestId: typeof response.requestId === 'string' ? response.requestId : null,
-      error: {
-        code: typeof error.code === 'string' ? error.code : 'SCENESYNC_ERROR',
-        message: typeof error.message === 'string' ? error.message : 'Scene Sync request failed'
-      }
-    };
-  }
-
-  return {
-    ok: false,
-    error: {
-      code: 'INVALID_RESPONSE',
-      message: 'Invalid Scene Sync response'
-    }
-  };
-}
-
 export function formatSceneSyncError(error) {
   if (!error || typeof error !== 'object') {
     return 'SCENESYNC_ERROR - Unknown Scene Sync error';
@@ -88,4 +11,15 @@ export function formatSceneSyncError(error) {
     : 'Scene Sync request failed';
 
   return `${code} - ${message}`;
+}
+
+export function formatObjectMap(objects) {
+  if (!objects || typeof objects !== 'object') {
+    return [];
+  }
+
+  return Object.entries(objects).map(([id, object]) => ({
+    id,
+    ...object
+  }));
 }

--- a/test/scenesync-client.test.mjs
+++ b/test/scenesync-client.test.mjs
@@ -1,19 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  createSceneListObjectsCommand,
   SceneSyncClient
 } from '../src/scenesync/index.js';
 
-test('command helper creates listObjects command', () => {
-  const command = createSceneListObjectsCommand({ room: '121555', requestId: 'test-1' });
-  assert.equal(command.type, 'scene.listObjects');
-  assert.equal(command.room, '121555');
-  assert.equal(command.requestId, 'test-1');
-  assert.deepEqual(command.payload, {});
-});
-
-test('client sends command to expected URL', async () => {
+test('redeem posts to /link/redeem', async () => {
   const calls = [];
   const fetchImpl = async (url, options) => {
     calls.push({ url, options });
@@ -23,69 +14,126 @@ test('client sends command to expected URL', async () => {
       async json() {
         return {
           ok: true,
-          type: 'scene.ping.result',
-          requestId: 'test',
-          result: { pong: true }
+          roomId: 'room-123',
+          sessionId: 'v1.test',
+          expiresAt: 1234567890
         };
       }
     };
   };
 
   const client = new SceneSyncClient({
-    endpoint: 'https://example.com/pipe',
+    endpoint: 'https://example.com/presence/api/ai',
     fetchImpl
   });
 
-  const result = await client.ping({ room: '121555' });
+  const result = await client.redeem({ code: '238909' });
   assert.equal(result.ok, true);
   assert.equal(calls.length, 1);
-  assert.match(String(calls[0].url), /121555/);
-  assert.equal(JSON.parse(calls[0].options.body).type, 'scene.ping');
+  assert.match(String(calls[0].url), /\/link\/redeem$/);
+  assert.deepEqual(JSON.parse(calls[0].options.body), { code: '238909' });
+  assert.equal(result.data.roomId, 'room-123');
+  assert.equal(result.data.sessionId, 'v1.test');
 });
 
-test('HTTP error returns normalized error', async () => {
-  const client = new SceneSyncClient({
-    endpoint: 'https://example.com/pipe',
-    fetchImpl: async () => ({
-      ok: false,
-      status: 404,
-      async json() {
-        return {};
-      }
-    })
-  });
-
-  const result = await client.info({ room: '121555' });
-  assert.equal(result.ok, false);
-  assert.equal(result.error.code, 'HTTP_ERROR');
-});
-
-test('malformed response returns INVALID_RESPONSE', async () => {
-  const client = new SceneSyncClient({
-    fetchImpl: async () => ({
+test('getScene posts sessionId to /room/:room/scene', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return {
       ok: true,
       status: 200,
       async json() {
-        return {};
+        return {
+          ok: true,
+          envId: 'studio',
+          objects: {
+            cube1: { type: 'Cube', position: [0, 0.5, 0] }
+          }
+        };
       }
-    })
+    };
+  };
+
+  const client = new SceneSyncClient({
+    endpoint: 'https://example.com/presence/api/ai',
+    fetchImpl
   });
 
-  const result = await client.listObjects({ room: '121555' });
-  assert.equal(result.ok, false);
-  assert.equal(result.error.code, 'INVALID_RESPONSE');
+  const result = await client.getScene({
+    room: 'room-1',
+    session: 'v1.test'
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.match(String(calls[0].url), /\/room\/room-1\/scene$/);
+  assert.deepEqual(JSON.parse(calls[0].options.body), { sessionId: 'v1.test' });
+  assert.equal(result.data.envId, 'studio');
+  assert.deepEqual(result.data.objects.cube1, { type: 'Cube', position: [0, 0.5, 0] });
 });
 
-test('room required', async () => {
+test('missing code returns CODE_REQUIRED', async () => {
   const client = new SceneSyncClient({
     fetchImpl: async () => {
       throw new Error('should not be called');
     }
   });
 
-  const result = await client.listObjects();
+  const result = await client.redeem();
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'CODE_REQUIRED');
+});
+
+test('missing session returns SESSION_REQUIRED', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.getScene({ room: 'room-1' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'SESSION_REQUIRED');
+});
+
+test('missing room returns ROOM_REQUIRED', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.getScene({ session: 'v1.test' });
   assert.equal(result.ok, false);
   assert.equal(result.error.code, 'ROOM_REQUIRED');
+});
+
+test('HTTP error preserves API error', async () => {
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 401,
+    async json() {
+      return {
+        ok: false,
+        error: {
+          code: 'unauthorized',
+          message: 'session expired',
+          retryable: false
+        }
+      };
+    }
+  });
+
+  const client = new SceneSyncClient({
+    endpoint: 'https://example.com/presence/api/ai',
+    fetchImpl
+  });
+
+  const result = await client.getScene({ room: 'room-1', session: 'v1.invalid' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'unauthorized');
+  assert.equal(result.error.message, 'session expired');
+  assert.equal(result.error.retryable, false);
 });
 
 test('network error returns NETWORK_ERROR', async () => {
@@ -95,7 +143,7 @@ test('network error returns NETWORK_ERROR', async () => {
     }
   });
 
-  const result = await client.ping({ room: '121555' });
+  const result = await client.redeem({ code: '238909' });
   assert.equal(result.ok, false);
   assert.equal(result.error.code, 'NETWORK_ERROR');
 });


### PR DESCRIPTION
## Summary

Updates Loom's Scene Sync probe CLI to use the correct existing afjk.jp AI wrapper API instead of the placeholder endpoint. The client now correctly interfaces with the actual API endpoints.

## Changes

### Core API Updates
- **Endpoint**: Changed from `https://afjk.jp/pipe` to `https://afjk.jp/presence/api/ai`
- **Response normalization**: Updated to accept API response shapes without envelope fields (no `type`, `requestId`)
- **Error handling**: Preserves API error fields (`code`, `message`, `retryable`)

### New Client Methods
- `redeem({ code })` → `POST /link/redeem`
- `getScene({ room, session })` → `POST /room/{roomId}/scene`
- `revoke({ session })` → `POST /link/revoke`

### CLI Commands

#### New: Redeem Code
```bash
node bin/loom.mjs scenesync redeem 238909
```

Output:
```
Linked Scene Sync room.
Room: <roomId>
Session: <sessionId>
Expires At: <expiresAt>
```

#### Updated: Scene Reads Now Require Session
All scene reads now require both `--room` and `--session`:
```bash
node bin/loom.mjs scenesync objects --room <roomId> --session <sessionId>
node bin/loom.mjs scenesync info --room <roomId> --session <sessionId>
node bin/loom.mjs scenesync ping --room <roomId> --session <sessionId>
```

Support for environment variables:
```bash
export LOOM_SCENESYNC_ROOM=<roomId>
export LOOM_SCENESYNC_SESSION=<sessionId>
export LOOM_SCENESYNC_ENDPOINT=https://afjk.jp/presence/api/ai
```

### Implementation Details
- Simplified command structure: Removed placeholder command envelope
- Object map formatter: Converts API response objects to displayable format
- Session requirement: Added validation and helpful error messages
- Tests: Updated to mock actual API requests/responses

## Testing
- ✅ All 7 new Scene Sync client tests pass
- ✅ All 40 CLI tests pass
- ✅ No regressions in other test suites

## Acceptance Criteria Met
- ✅ Default endpoint is `https://afjk.jp/presence/api/ai`
- ✅ `loom scenesync redeem <code>` calls `/link/redeem`
- ✅ `objects/info/ping` use `/room/{roomId}/scene`
- ✅ `objects/info/ping` require room and session
- ✅ `LOOM_SCENESYNC_SESSION` environment variable is supported
- ✅ Scene object map responses display correctly
- ✅ No real network calls in tests
- ✅ `npm run test:unit` passes (47 total tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSuoJePtJ4Q9F2WK7AZcej)_