### PR TITLE
Add Scene Sync session persistence and management

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,18 +237,48 @@ The REPL recompiles the accumulated source after each snippet, but it only displ
 
 Loom CLI includes read-only Scene Sync probe commands to interact with the afjk.jp AI wrapper.
 
-#### Redeem a code
+#### Save a Scene Sync session
+
+Redeem and save a Scene Sync AI link code:
 
 ```bash
-node bin/loom.mjs scenesync redeem 238909
+node bin/loom.mjs scenesync redeem 301398 --save
 ```
 
 Output:
 ```
 Linked Scene Sync room.
 Room: <roomId>
-Session: <sessionId>
+Session: saved to ~/.config/loom/scenesync-session.json
 Expires At: <expiresAt>
+```
+
+Then use probe commands without passing a long session token:
+
+```bash
+node bin/loom.mjs scenesync ping
+node bin/loom.mjs scenesync info
+node bin/loom.mjs scenesync objects
+```
+
+Saved sessions are stored in `~/.config/loom/scenesync-session.json`. The session token is a secret and should not be committed to a repository.
+
+#### Show saved session
+
+```bash
+node bin/loom.mjs scenesync session
+```
+
+or the alias:
+
+```bash
+node bin/loom.mjs scenesync status
+```
+
+#### Clear saved session
+
+```bash
+node bin/loom.mjs scenesync logout
 ```
 
 #### List objects in a room

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -17,7 +17,12 @@ import {
 import {
   DEFAULT_ENDPOINT as DEFAULT_SCENESYNC_ENDPOINT,
   SceneSyncClient,
-  formatSceneSyncError
+  formatSceneSyncError,
+  getDefaultSceneSyncSessionPath,
+  saveSceneSyncSession,
+  loadSceneSyncSession,
+  clearSceneSyncSession,
+  maskSessionId
 } from '../src/scenesync/index.js';
 
 function print(message = '') {
@@ -179,13 +184,17 @@ function getSceneSyncHelp() {
   loom scenesync <command> [options]
 
 Commands:
-  redeem            Redeem a code for a session
-  ping              Check Scene Sync room connection
-  info              Get room information
-  objects           List scene objects
-  list-objects      Alias for objects
+  redeem <code>      Redeem a Scene Sync AI link code
+  session            Show saved Scene Sync session
+  status             Alias for session
+  logout             Clear saved Scene Sync session
+  ping               Check Scene Sync room connection
+  info               Get room information
+  objects            List scene objects
+  list-objects       Alias for objects
 
 Options:
+  --save               Save redeemed session locally
   --room <room>        Scene Sync room code
   --session <id>       Scene Sync session ID
   --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
@@ -194,7 +203,10 @@ Options:
 Environment Variables:
   LOOM_SCENESYNC_ROOM              Default room code
   LOOM_SCENESYNC_SESSION           Default session ID
-  LOOM_SCENESYNC_ENDPOINT          Default endpoint`;
+  LOOM_SCENESYNC_ENDPOINT          Default endpoint
+
+Saved session path:
+  ~/.config/loom/scenesync-session.json`;
 }
 
 function formatValue(value) {
@@ -246,10 +258,11 @@ async function readSourceFile(file) {
   return readFile(path.resolve(process.cwd(), file), 'utf8');
 }
 
-function parseSceneSyncArgs(args) {
-  let room = process.env.LOOM_SCENESYNC_ROOM || '';
-  let session = process.env.LOOM_SCENESYNC_SESSION || '';
-  let endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || DEFAULT_SCENESYNC_ENDPOINT;
+async function parseSceneSyncArgs(args) {
+  let room = '';
+  let session = '';
+  let endpoint = '';
+  let save = false;
   let json = false;
 
   for (let index = 0; index < args.length; index += 1) {
@@ -275,6 +288,8 @@ function parseSceneSyncArgs(args) {
       }
       endpoint = next;
       index += 1;
+    } else if (arg === '--save') {
+      save = true;
     } else if (arg === '--json') {
       json = true;
     } else {
@@ -282,7 +297,34 @@ function parseSceneSyncArgs(args) {
     }
   }
 
-  return { room, session, endpoint, json };
+  const savedSession = await loadSceneSyncSession();
+  const savedData = savedSession.ok && savedSession.session ? savedSession.session : null;
+
+  if (!room) {
+    room = process.env.LOOM_SCENESYNC_ROOM || '';
+    if (!room && savedData) {
+      room = savedData.roomId || '';
+    }
+  }
+
+  if (!session) {
+    session = process.env.LOOM_SCENESYNC_SESSION || '';
+    if (!session && savedData) {
+      session = savedData.sessionId || '';
+    }
+  }
+
+  if (!endpoint) {
+    endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || '';
+    if (!endpoint && savedData) {
+      endpoint = savedData.endpoint || '';
+    }
+    if (!endpoint) {
+      endpoint = DEFAULT_SCENESYNC_ENDPOINT;
+    }
+  }
+
+  return { room, session, endpoint, save, json };
 }
 
 function requireSceneSyncRoom(room) {
@@ -648,13 +690,60 @@ async function handleSceneSync(args) {
     return 0;
   }
 
+  if (subcommand === 'session' || subcommand === 'status') {
+    const { json } = await parseSceneSyncArgs(rest);
+    const result = await loadSceneSyncSession();
+
+    if (!result.ok) {
+      printError(formatSceneSyncError(result.error));
+      return 1;
+    }
+
+    if (!result.session) {
+      print('No saved Scene Sync session.');
+      print('Use: loom scenesync redeem <code> --save');
+      return 0;
+    }
+
+    if (json) {
+      print(stringifyJson(result.session));
+      return 0;
+    }
+
+    const session = result.session;
+    const sessionPath = getDefaultSceneSyncSessionPath();
+    const maskedId = maskSessionId(session.sessionId);
+    const lines = [
+      'Scene Sync session:',
+      `Endpoint: ${session.endpoint || DEFAULT_SCENESYNC_ENDPOINT}`,
+      `Room: ${session.roomId || '<unknown>'}`,
+      `Session: ${maskedId}`,
+      `Expires At: ${session.expiresAt || '<unknown>'}`,
+      `Path: ${sessionPath}`
+    ];
+    print(lines.join('\n'));
+    return 0;
+  }
+
+  if (subcommand === 'logout') {
+    const result = await clearSceneSyncSession();
+
+    if (!result.ok) {
+      printError(formatSceneSyncError(result.error));
+      return 1;
+    }
+
+    print('Cleared saved Scene Sync session.');
+    return 0;
+  }
+
   if (subcommand === 'redeem') {
     let code = null;
     let codeIndex = -1;
 
     for (let index = 0; index < rest.length; index += 1) {
       const arg = rest[index];
-      if (!arg.startsWith('-') && !['--room', '--session', '--endpoint', '--json'].includes(rest[index - 1])) {
+      if (!arg.startsWith('-') && !['--room', '--session', '--endpoint', '--json', '--save'].includes(rest[index - 1])) {
         code = arg;
         codeIndex = index;
         break;
@@ -671,7 +760,7 @@ async function handleSceneSync(args) {
     }
 
     const argsWithoutCode = codeIndex >= 0 ? rest.filter((_, i) => i !== codeIndex) : rest;
-    const { endpoint, json } = parseSceneSyncArgs(argsWithoutCode);
+    const { endpoint, save, json } = await parseSceneSyncArgs(argsWithoutCode);
     const client = new SceneSyncClient({ endpoint });
     const result = await client.redeem({ code });
 
@@ -680,12 +769,45 @@ async function handleSceneSync(args) {
       return 1;
     }
 
+    const data = result.data || {};
+
+    if (save) {
+      try {
+        const savedPath = await saveSceneSyncSession({
+          endpoint,
+          roomId: data.roomId,
+          sessionId: data.sessionId,
+          expiresAt: data.expiresAt
+        });
+
+        if (json) {
+          print(stringifyJson({
+            ok: true,
+            data,
+            savedPath
+          }));
+          return 0;
+        }
+
+        const lines = [
+          'Linked Scene Sync room.',
+          `Room: ${data.roomId || '<unknown>'}`,
+          `Session: saved to ${savedPath}`,
+          `Expires At: ${data.expiresAt || '<unknown>'}`
+        ];
+        print(lines.join('\n'));
+        return 0;
+      } catch (error) {
+        printError(`Failed to save session: ${error.message || String(error)}`);
+        return 1;
+      }
+    }
+
     if (json) {
       print(stringifyJson(result.data));
       return 0;
     }
 
-    const data = result.data || {};
     const lines = [
       'Linked Scene Sync room.',
       `Room: ${data.roomId || '<unknown>'}`,
@@ -696,7 +818,7 @@ async function handleSceneSync(args) {
     return 0;
   }
 
-  const { room, session, endpoint, json } = parseSceneSyncArgs(rest);
+  const { room, session, endpoint, json } = await parseSceneSyncArgs(rest);
 
   if (subcommand === 'ping' || subcommand === 'info' || subcommand === 'objects' || subcommand === 'list-objects') {
     requireSceneSyncRoom(room);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/scenesync/index.js
+++ b/src/scenesync/index.js
@@ -1,2 +1,3 @@
 export * from './client.js';
 export * from './commands.js';
+export * from './session-store.js';

--- a/src/scenesync/session-store.js
+++ b/src/scenesync/session-store.js
@@ -1,0 +1,130 @@
+import { mkdir, writeFile, readFile, chmod, rm } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+export function getDefaultSceneSyncSessionPath(env = process.env) {
+  const configHome = env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  return path.join(configHome, 'loom', 'scenesync-session.json');
+}
+
+export async function saveSceneSyncSession(session, options = {}) {
+  const { path: filePath = getDefaultSceneSyncSessionPath(), now = Date.now() } = options;
+
+  if (!session.roomId || typeof session.roomId !== 'string') {
+    throw new Error('Session roomId is required and must be a string');
+  }
+
+  if (!session.sessionId || typeof session.sessionId !== 'string') {
+    throw new Error('Session sessionId is required and must be a string');
+  }
+
+  const data = {
+    endpoint: session.endpoint || 'https://afjk.jp/presence/api/ai',
+    roomId: session.roomId,
+    sessionId: session.sessionId,
+    expiresAt: session.expiresAt,
+    savedAt: now
+  };
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  await chmod(filePath, 0o600).catch(() => {});
+
+  return filePath;
+}
+
+export async function loadSceneSyncSession(options = {}) {
+  const { path: filePath = getDefaultSceneSyncSessionPath() } = options;
+
+  try {
+    const content = await readFile(filePath, 'utf8');
+    const data = JSON.parse(content);
+
+    if (!data || typeof data !== 'object') {
+      return {
+        ok: false,
+        error: {
+          code: 'SESSION_FILE_INVALID',
+          message: 'Scene Sync session file is invalid'
+        }
+      };
+    }
+
+    if (!data.roomId || !data.sessionId) {
+      return {
+        ok: false,
+        error: {
+          code: 'SESSION_FILE_INVALID',
+          message: 'Scene Sync session file is missing roomId or sessionId'
+        }
+      };
+    }
+
+    return {
+      ok: true,
+      session: data
+    };
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return {
+        ok: true,
+        session: null
+      };
+    }
+
+    if (error instanceof SyntaxError) {
+      return {
+        ok: false,
+        error: {
+          code: 'SESSION_FILE_INVALID',
+          message: 'Scene Sync session file is invalid'
+        }
+      };
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: 'SESSION_FILE_ERROR',
+        message: error instanceof Error ? error.message : 'Failed to read session file'
+      }
+    };
+  }
+}
+
+export async function clearSceneSyncSession(options = {}) {
+  const { path: filePath = getDefaultSceneSyncSessionPath() } = options;
+
+  try {
+    await rm(filePath);
+    return {
+      ok: true,
+      path: filePath
+    };
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return {
+        ok: true,
+        path: filePath
+      };
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: 'SESSION_CLEAR_ERROR',
+        message: error instanceof Error ? error.message : 'Failed to clear session'
+      }
+    };
+  }
+}
+
+export function maskSessionId(sessionId) {
+  if (!sessionId || typeof sessionId !== 'string' || sessionId.length <= 8) {
+    return '****';
+  }
+
+  const start = sessionId.substring(0, 6);
+  const end = sessionId.substring(sessionId.length - 4);
+  return `${start}...${end}`;
+}

--- a/test/scenesync-session-store.test.mjs
+++ b/test/scenesync-session-store.test.mjs
@@ -1,0 +1,195 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  getDefaultSceneSyncSessionPath,
+  saveSceneSyncSession,
+  loadSceneSyncSession,
+  clearSceneSyncSession,
+  maskSessionId
+} from '../src/scenesync/session-store.js';
+
+test('getDefaultSceneSyncSessionPath respects XDG_CONFIG_HOME', () => {
+  const result = getDefaultSceneSyncSessionPath({
+    XDG_CONFIG_HOME: '/tmp/config'
+  });
+
+  assert.equal(result, '/tmp/config/loom/scenesync-session.json');
+});
+
+test('getDefaultSceneSyncSessionPath uses ~/.config when XDG_CONFIG_HOME is not set', () => {
+  const result = getDefaultSceneSyncSessionPath({});
+  assert.match(result, /\.config.*loom.*scenesync-session\.json/);
+});
+
+test('save and load session', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  await saveSceneSyncSession({
+    endpoint: 'https://example.com/presence/api/ai',
+    roomId: 'room-1',
+    sessionId: 'v1.test',
+    expiresAt: 123
+  }, { path: filePath, now: 100 });
+
+  const loaded = await loadSceneSyncSession({ path: filePath });
+
+  assert.equal(loaded.ok, true);
+  assert.equal(loaded.session.roomId, 'room-1');
+  assert.equal(loaded.session.sessionId, 'v1.test');
+  assert.equal(loaded.session.endpoint, 'https://example.com/presence/api/ai');
+  assert.equal(loaded.session.expiresAt, 123);
+  assert.equal(loaded.session.savedAt, 100);
+});
+
+test('saved file is readable as JSON', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  await saveSceneSyncSession({
+    roomId: 'room-1',
+    sessionId: 'v1.test',
+    expiresAt: 123
+  }, { path: filePath, now: 100 });
+
+  const content = await readFile(filePath, 'utf8');
+  const data = JSON.parse(content);
+
+  assert.equal(data.roomId, 'room-1');
+  assert.equal(data.sessionId, 'v1.test');
+});
+
+test('saved file has 0600 permissions on supported platforms', async () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  await saveSceneSyncSession({
+    roomId: 'room-1',
+    sessionId: 'v1.test',
+    expiresAt: 123
+  }, { path: filePath, now: 100 });
+
+  const stats = await stat(filePath);
+  assert.equal(stats.mode & 0o777, 0o600);
+});
+
+test('missing session returns ok with null session', async () => {
+  const filePath = path.join(tmpdir(), `nonexistent-${Date.now()}-${Math.random()}.json`);
+  const loaded = await loadSceneSyncSession({ path: filePath });
+
+  assert.equal(loaded.ok, true);
+  assert.equal(loaded.session, null);
+});
+
+test('invalid JSON returns error', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  await new Promise((resolve) => {
+    import('node:fs').then(({ writeFileSync }) => {
+      writeFileSync(filePath, 'not valid json');
+      resolve();
+    });
+  });
+
+  const loaded = await loadSceneSyncSession({ path: filePath });
+
+  assert.equal(loaded.ok, false);
+  assert.equal(loaded.error.code, 'SESSION_FILE_INVALID');
+});
+
+test('missing roomId or sessionId returns error', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  await new Promise((resolve) => {
+    import('node:fs').then(({ writeFileSync }) => {
+      writeFileSync(filePath, JSON.stringify({ roomId: 'room-1' }));
+      resolve();
+    });
+  });
+
+  const loaded = await loadSceneSyncSession({ path: filePath });
+
+  assert.equal(loaded.ok, false);
+  assert.equal(loaded.error.code, 'SESSION_FILE_INVALID');
+});
+
+test('save validates roomId', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  try {
+    await saveSceneSyncSession({
+      sessionId: 'v1.test'
+    }, { path: filePath });
+    assert.fail('Should have thrown');
+  } catch (error) {
+    assert.match(error.message, /roomId/i);
+  }
+});
+
+test('save validates sessionId', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  try {
+    await saveSceneSyncSession({
+      roomId: 'room-1'
+    }, { path: filePath });
+    assert.fail('Should have thrown');
+  } catch (error) {
+    assert.match(error.message, /sessionId/i);
+  }
+});
+
+test('clear session removes file', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loom-session-'));
+  const filePath = path.join(dir, 'session.json');
+
+  await saveSceneSyncSession({
+    roomId: 'room-1',
+    sessionId: 'v1.test',
+    expiresAt: 123
+  }, { path: filePath });
+
+  const result = await clearSceneSyncSession({ path: filePath });
+  assert.equal(result.ok, true);
+
+  const loaded = await loadSceneSyncSession({ path: filePath });
+  assert.equal(loaded.ok, true);
+  assert.equal(loaded.session, null);
+});
+
+test('clear session succeeds on missing file', async () => {
+  const filePath = path.join(tmpdir(), `nonexistent-${Date.now()}-${Math.random()}.json`);
+  const result = await clearSceneSyncSession({ path: filePath });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.path, filePath);
+});
+
+test('maskSessionId masks long IDs', () => {
+  const masked = maskSessionId('v1.abcdefghijklmnopqrstuvwxyz');
+  assert.equal(masked, 'v1.abc...wxyz');
+});
+
+test('maskSessionId returns **** for short IDs', () => {
+  assert.equal(maskSessionId('short'), '****');
+  assert.equal(maskSessionId(''), '****');
+  assert.equal(maskSessionId(null), '****');
+});
+
+test('maskSessionId works with prefixed IDs', () => {
+  const masked = maskSessionId('v1.4ONCabcdefghijklmnopqrstuvwxyz123fBg');
+  assert.match(masked, /^v1\.4/);
+  assert.match(masked, /fBg$/);
+  assert.match(masked, /\.\.\./);
+});


### PR DESCRIPTION
## Summary
This PR adds session persistence capabilities to the Scene Sync CLI, allowing users to save and reuse Scene Sync sessions without repeatedly entering long session tokens.

## Key Changes

- **New session store module** (`src/scenesync/session-store.js`):
  - `getDefaultSceneSyncSessionPath()`: Returns the default session file path, respecting `XDG_CONFIG_HOME` environment variable
  - `saveSceneSyncSession()`: Persists session data to disk with secure file permissions (0600)
  - `loadSceneSyncSession()`: Loads and validates saved sessions with proper error handling
  - `clearSceneSyncSession()`: Removes saved session files
  - `maskSessionId()`: Masks sensitive session IDs for display (shows first 6 and last 4 characters)

- **CLI enhancements** (`bin/loom.mjs`):
  - New `--save` flag for `redeem` command to persist redeemed sessions
  - New `session`/`status` commands to display saved session information
  - New `logout` command to clear saved sessions
  - Updated `parseSceneSyncArgs()` to load and use saved session data as fallback
  - Automatic session loading from `~/.config/loom/scenesync-session.json`
  - Updated help text with new commands and options

- **Comprehensive test suite** (`test/scenesync-session-store.test.mjs`):
  - Tests for path resolution with XDG_CONFIG_HOME support
  - Save/load round-trip validation
  - File permission verification (0600 on Unix)
  - JSON validity and schema validation
  - Error handling for invalid/missing files
  - Session ID masking behavior

## Implementation Details

- Session files are stored in `~/.config/loom/scenesync-session.json` by default
- File permissions are set to 0600 (read/write for owner only) for security
- Sessions include endpoint, roomId, sessionId, expiresAt, and savedAt timestamp
- Saved sessions are automatically used as fallback when room/session/endpoint are not explicitly provided
- Session tokens are masked in CLI output to prevent accidental exposure in logs

https://claude.ai/code/session_012qibpn4F3tfzYRDQYDNCWU