### PR TITLE
Add Scene Sync effect nodes for 3D object transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,12 @@ x = constant(value: 1)
 
 `compile` と `inspect` の `--target` は省略時に `any` として扱われ、runtime-specific import を generic workflow 用に許可します。`run` は省略時に `cli` で検証するため、たとえば `import dom` は CLI 実行時に失敗します。
 
-初期の CLI-safe library nodes:
+CLI-safe library nodes:
 
 - `text.upper`, `text.lower`, `text.trim`, `text.replace`
 - `json.parse`, `json.stringify`
 - `console.log`, `console.warn`, `console.error`
+- `scene.setPosition`, `scene.setRotation`, `scene.setScale`
 
 ### REPL
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -217,7 +217,18 @@ function formatValue(value) {
 
 function printEffects(effects) {
   for (const effect of effects || []) {
-    printError(`[${effect.level}] ${formatEffectValue(effect.value)}`);
+    if (effect.type === 'scene.setPosition') {
+      const [x, y, z] = effect.position || [];
+      printError(`[scene.setPosition] ${effect.objectId} position=(${x}, ${y}, ${z})`);
+    } else if (effect.type === 'scene.setRotation') {
+      const [x, y, z, w] = effect.rotation || [];
+      printError(`[scene.setRotation] ${effect.objectId} rotation=(${x}, ${y}, ${z}, ${w})`);
+    } else if (effect.type === 'scene.setScale') {
+      const [x, y, z] = effect.scale || [];
+      printError(`[scene.setScale] ${effect.objectId} scale=(${x}, ${y}, ${z})`);
+    } else {
+      printError(`[${effect.level}] ${formatEffectValue(effect.value)}`);
+    }
   }
 }
 

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -9,10 +9,10 @@
 
 ## Phase 2: Import syntax
 
-- minimal `import math` / `import fs` / `import scene`
+✓ import math / import fs / import scene (Phase 2 complete)
 - runtime target validation
 - import math
-- import scene
+- import scene (with scene.setPosition, scene.setRotation, scene.setScale)
 - import fs
 - target compatibility validation
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -433,6 +433,52 @@ const graph = {
 
 ※ `delay1` は `out = prevOut` を返し、現在の入力を次フレームに渡す state ノードです。
 
+## Scene library (scene objects control)
+
+Loom includes early Scene Sync-oriented scene effect nodes. These nodes describe operations on 3D scene objects.
+
+### scene.setPosition — オブジェクトの位置を設定
+
+```loom
+import scene
+
+scene.setPosition("sample-cube", x: 1, y: 0.5, z: 0)
+```
+
+オブジェクト ID とワールド座標 (x, y, z) を指定します。
+
+### scene.setRotation — オブジェクトの回転を設定
+
+```loom
+import scene
+
+scene.setRotation("sample-cube", x: 0, y: 0, z: 0, w: 1)
+```
+
+オブジェクト ID とクォータニオン (x, y, z, w) を指定します。w はスカラー成分（デフォルト 1）。
+
+### scene.setScale — オブジェクトのスケールを設定
+
+```loom
+import scene
+
+scene.setScale("sample-cube", x: 2, y: 2, z: 2)
+```
+
+オブジェクト ID と均一なスケール (x, y, z) を指定します。
+
+### まとめた例
+
+```loom
+import scene
+
+scene.setPosition("sample-cube", x: 1, y: 0.5, z: 0)
+scene.setRotation("sample-cube", x: 0, y: 0, z: 0, w: 1)
+scene.setScale("sample-cube", x: 2, y: 2, z: 2)
+```
+
+現在の段階では、これらのノードは local effect records を生成します。実際の Scene Sync への送信は今後の PR で実装予定です。
+
 ## Programmatic API
 
 Loom は DSL を Source AST 経由で扱う関数を公開している。AI 補助編集・DSL formatter・ビジュアルエディタの基盤として使う。

--- a/examples/scene-effects.loom
+++ b/examples/scene-effects.loom
@@ -1,0 +1,5 @@
+import scene
+
+scene.setPosition("sample-cube", x: 1, y: 0.5, z: 0)
+scene.setRotation("sample-cube", x: 0, y: 0, z: 0, w: 1)
+scene.setScale("sample-cube", x: 2, y: 2, z: 2)

--- a/src/loom.js
+++ b/src/loom.js
@@ -1006,6 +1006,90 @@ export const NODE_TYPES = {
     }
   },
 
+  // Scene Sync effect nodes
+  'scene.setPosition': {
+    category: 'sink',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'x', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'y', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'z', type: 'number', default: 0, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'x', type: 'number', default: 0 },
+      { name: 'y', type: 'number', default: 0 },
+      { name: 'z', type: 'number', default: 0 }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.setPosition',
+        objectId: inputs.objectId,
+        position: [inputs.x, inputs.y, inputs.z],
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  },
+
+  'scene.setRotation': {
+    category: 'sink',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'x', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'y', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'z', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'w', type: 'number', default: 1, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'x', type: 'number', default: 0 },
+      { name: 'y', type: 'number', default: 0 },
+      { name: 'z', type: 'number', default: 0 },
+      { name: 'w', type: 'number', default: 1 }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.setRotation',
+        objectId: inputs.objectId,
+        rotation: [inputs.x, inputs.y, inputs.z, inputs.w],
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  },
+
+  'scene.setScale': {
+    category: 'sink',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'x', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'y', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'z', type: 'number', default: 1, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'x', type: 'number', default: 1 },
+      { name: 'y', type: 'number', default: 1 },
+      { name: 'z', type: 'number', default: 1 }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.setScale',
+        objectId: inputs.objectId,
+        scale: [inputs.x, inputs.y, inputs.z],
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  },
+
   // DOM シンクノード
   setText: {
     category: 'sink',

--- a/src/toolchain/run.js
+++ b/src/toolchain/run.js
@@ -5,7 +5,8 @@ import { normalizeLoomError } from './errors.js';
 const CLI_SAFE_CATEGORIES = new Set(['source', 'transform', 'state']);
 
 function isCliSafeSink(nodeTypeName) {
-  return nodeTypeName === 'console.log' || nodeTypeName === 'console.warn' || nodeTypeName === 'console.error';
+  return nodeTypeName === 'console.log' || nodeTypeName === 'console.warn' || nodeTypeName === 'console.error'
+    || nodeTypeName === 'scene.setPosition' || nodeTypeName === 'scene.setRotation' || nodeTypeName === 'scene.setScale';
 }
 
 function getRefsToRead(graph, get) {

--- a/src/toolchain/runtime-targets.js
+++ b/src/toolchain/runtime-targets.js
@@ -42,7 +42,7 @@ export const LIBRARY_COMPATIBILITY = {
     description: 'Canvas preview renderer'
   },
   scene: {
-    targets: ['scenesync', 'unity', 'web'],
+    targets: ['cli', 'scenesync', 'unity', 'web'],
     kind: 'effect',
     description: 'Scene object control through a host adapter'
   },

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -376,6 +376,72 @@ test('run rejects browser-only nodes with a clear error', async () => {
   assert.match(result.stderr, /UNSUPPORTED_RUNTIME_NODE/);
 });
 
+test('scene.setPosition effect statement compiles', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-scene-setpos-'));
+  const file = path.join(tmpDir, 'scene-setpos.loom');
+  await fsp.writeFile(file, 'import scene\nscene.setPosition("sample-cube", x: 1, y: 0.5, z: 0)\n', 'utf8');
+
+  const result = runCli(['compile', file]);
+  assert.equal(result.status, 0, result.stderr);
+  const graph = JSON.parse(result.stdout);
+  assert.ok(graph.nodes.some((node) => node.type === 'scene.setPosition'));
+  assert.ok(graph.nodes.some((node) => node.id === '_effect1'));
+});
+
+test('scene.setRotation effect statement compiles', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-scene-setrot-'));
+  const file = path.join(tmpDir, 'scene-setrot.loom');
+  await fsp.writeFile(file, 'import scene\nscene.setRotation("sample-cube", x: 0, y: 0, z: 0, w: 1)\n', 'utf8');
+
+  const result = runCli(['compile', file]);
+  assert.equal(result.status, 0, result.stderr);
+  const graph = JSON.parse(result.stdout);
+  assert.ok(graph.nodes.some((node) => node.type === 'scene.setRotation'));
+  assert.ok(graph.nodes.some((node) => node.id === '_effect1'));
+});
+
+test('scene.setScale effect statement compiles', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-scene-setscale-'));
+  const file = path.join(tmpDir, 'scene-setscale.loom');
+  await fsp.writeFile(file, 'import scene\nscene.setScale("sample-cube", x: 2, y: 2, z: 2)\n', 'utf8');
+
+  const result = runCli(['compile', file]);
+  assert.equal(result.status, 0, result.stderr);
+  const graph = JSON.parse(result.stdout);
+  assert.ok(graph.nodes.some((node) => node.type === 'scene.setScale'));
+  assert.ok(graph.nodes.some((node) => node.id === '_effect1'));
+});
+
+test('scene.setPosition run produces effect on stderr', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-scene-run-'));
+  const file = path.join(tmpDir, 'scene-run.loom');
+  await fsp.writeFile(file, 'import scene\nscene.setPosition("sample-cube", x: 1, y: 0.5, z: 0)\n', 'utf8');
+
+  const result = runCli(['run', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /\[scene\.setPosition\] sample-cube position=\(1, 0\.5, 0\)/);
+});
+
+test('scene.setRotation run produces effect on stderr', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-scene-rot-'));
+  const file = path.join(tmpDir, 'scene-rot.loom');
+  await fsp.writeFile(file, 'import scene\nscene.setRotation("sample-cube", x: 0, y: 0, z: 0, w: 1)\n', 'utf8');
+
+  const result = runCli(['run', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /\[scene\.setRotation\] sample-cube rotation=\(0, 0, 0, 1\)/);
+});
+
+test('scene.setScale run produces effect on stderr', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-scene-scale-'));
+  const file = path.join(tmpDir, 'scene-scale.loom');
+  await fsp.writeFile(file, 'import scene\nscene.setScale("sample-cube", x: 2, y: 2, z: 2)\n', 'utf8');
+
+  const result = runCli(['run', file]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /\[scene\.setScale\] sample-cube scale=\(2, 2, 2\)/);
+});
+
 test('evaluateOnce supports Node-safe one-shot evaluation', async () => {
   const { Loom } = await import(path.join(projectRoot, 'src', 'loom.js'));
   const graph = {


### PR DESCRIPTION
## Summary

This PR introduces three new Scene Sync-oriented effect nodes to Loom for controlling 3D scene objects: `scene.setPosition`, `scene.setRotation`, and `scene.setScale`. These nodes enable users to describe transformations on scene objects through the Loom DSL.

## Key Changes

- **New Node Types**: Added three sink nodes to `NODE_TYPES` in `src/loom.js`:
  - `scene.setPosition`: Sets object position with x, y, z coordinates
  - `scene.setRotation`: Sets object rotation as a quaternion (x, y, z, w)
  - `scene.setScale`: Sets object scale with x, y, z factors
  
- **CLI Support**: Updated `src/toolchain/run.js` to mark these nodes as CLI-safe sinks, allowing them to execute in the CLI runtime

- **Runtime Target Compatibility**: Modified `src/toolchain/runtime-targets.js` to include `cli` as a valid target for the `scene` library (previously only `scenesync`, `unity`, `web`)

- **Effect Output Formatting**: Enhanced `bin/loom.mjs` to format and display scene effect records with human-readable output (e.g., `[scene.setPosition] sample-cube position=(1, 0.5, 0)`)

- **Documentation**: 
  - Added comprehensive documentation in `docs/DSL.md` with usage examples
  - Updated `docs/CLI_ROADMAP.md` to mark Phase 2 import syntax as complete
  - Updated `README.md` to list the new scene nodes as CLI-safe library nodes
  - Added example file `examples/scene-effects.loom` demonstrating all three nodes

- **Tests**: Added six new test cases in `test/loom-cli.test.mjs` covering:
  - Compilation of each node type
  - Runtime execution and effect output verification

## Implementation Details

Each node follows the standard Loom sink pattern:
- Accepts behavior-kind inputs for dynamic values
- Records effects via `ctx.engine?._recordEffect()` with target `'scenesync'`
- Returns empty object (no outputs)
- Includes both input and parameter definitions for flexibility

The nodes are currently designed to generate local effect records. Actual Scene Sync transmission is deferred to future work.

https://claude.ai/code/session_0111sn2DZAiUVogcFonEM8Hq