### PR TITLE
Add Scene Sync broadcast payload generation from Loom effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,35 @@ export LOOM_SCENESYNC_ENDPOINT=https://afjk.jp/presence/api/ai
 node bin/loom.mjs scenesync objects
 ```
 
-These commands are read-only. Sending Loom graphs to Scene Sync is planned for a later phase.
+### Dry-run Scene Sync broadcasts
+
+Loom scene effects can be converted to Scene Sync broadcast payloads:
+
+```bash
+node bin/loom.mjs scenesync run examples/scene-effects.loom
+```
+
+By default this is a dry run and only prints the payload.
+
+To send it to the linked Scene Sync room:
+
+```bash
+node bin/loom.mjs scenesync run examples/scene-effects.loom --send
+```
+
+`--send` uses the saved session from:
+
+```text
+~/.config/loom/scenesync-session.json
+```
+
+or `LOOM_SCENESYNC_ROOM` / `LOOM_SCENESYNC_SESSION`.
+
+The `--json` flag outputs the payload and effects as JSON:
+
+```bash
+node bin/loom.mjs scenesync run examples/scene-effects.loom --json
+```
 
 ## ライブエディタと DSL
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -22,7 +22,8 @@ import {
   saveSceneSyncSession,
   loadSceneSyncSession,
   clearSceneSyncSession,
-  maskSessionId
+  maskSessionId,
+  sceneEffectsToBroadcastPayload
 } from '../src/scenesync/index.js';
 
 function print(message = '') {
@@ -188,6 +189,7 @@ Commands:
   session            Show saved Scene Sync session
   status             Alias for session
   logout             Clear saved Scene Sync session
+  run <file>         Convert Loom scene effects to Scene Sync broadcast payload
   ping               Check Scene Sync room connection
   info               Get room information
   objects            List scene objects
@@ -195,10 +197,16 @@ Commands:
 
 Options:
   --save               Save redeemed session locally
+  --dry-run            Print payload without sending (default for run)
+  --send               Broadcast payload to Scene Sync (run only)
   --room <room>        Scene Sync room code
   --session <id>       Scene Sync session ID
   --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
   --json               Print raw JSON response
+
+Examples:
+  loom scenesync run examples/scene-effects.loom
+  loom scenesync run examples/scene-effects.loom --send
 
 Environment Variables:
   LOOM_SCENESYNC_ROOM              Default room code
@@ -383,6 +391,86 @@ function printSceneSyncObjects(objects) {
       : '';
     print(`- ${id}  ${type}${position}`);
   }
+}
+
+async function parseSceneSyncRunArgs(args) {
+  let file = null;
+  let room = '';
+  let session = '';
+  let endpoint = '';
+  let dryRun = true;
+  let send = false;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (file === null && !arg.startsWith('-')) {
+      file = arg;
+    } else if (arg === '--room') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--room requires a room code');
+      }
+      room = next;
+      index += 1;
+    } else if (arg === '--session') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--session requires a session ID');
+      }
+      session = next;
+      index += 1;
+    } else if (arg === '--endpoint') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--endpoint requires a URL');
+      }
+      endpoint = next;
+      index += 1;
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--send') {
+      send = true;
+      dryRun = false;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!file) {
+    throw new Error('scenesync run requires a file path');
+  }
+
+  const savedSession = await loadSceneSyncSession();
+  const savedData = savedSession.ok && savedSession.session ? savedSession.session : null;
+
+  if (!room) {
+    room = process.env.LOOM_SCENESYNC_ROOM || '';
+    if (!room && savedData) {
+      room = savedData.roomId || '';
+    }
+  }
+
+  if (!session) {
+    session = process.env.LOOM_SCENESYNC_SESSION || '';
+    if (!session && savedData) {
+      session = savedData.sessionId || '';
+    }
+  }
+
+  if (!endpoint) {
+    endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || '';
+    if (!endpoint && savedData) {
+      endpoint = savedData.endpoint || '';
+    }
+    if (!endpoint) {
+      endpoint = DEFAULT_SCENESYNC_ENDPOINT;
+    }
+  }
+
+  return { file, room, session, endpoint, dryRun, send, json };
 }
 
 async function handleCompile(args) {
@@ -827,6 +915,77 @@ async function handleSceneSync(args) {
     ];
     print(lines.join('\n'));
     return 0;
+  }
+
+  if (subcommand === 'run') {
+    const { file, room, session, endpoint, dryRun, send, json } = await parseSceneSyncRunArgs(rest);
+
+    try {
+      const source = await readSourceFile(file);
+      const result = runLoomSource(source, { target: 'cli' });
+
+      if (!result.ok) {
+        printToolErrors(result.errors);
+        return 1;
+      }
+
+      const payload = sceneEffectsToBroadcastPayload(result.effects || []);
+
+      if (!payload) {
+        print('No Scene Sync scene effects found.');
+        return 0;
+      }
+
+      if (dryRun) {
+        if (json) {
+          print(stringifyJson({
+            ok: true,
+            dryRun: true,
+            payload,
+            effects: result.effects
+          }));
+        } else {
+          print('Scene Sync broadcast payload:');
+          print(stringifyJson(payload, true));
+          print('Dry run only. Pass --send to broadcast to Scene Sync.');
+        }
+        return 0;
+      }
+
+      if (send) {
+        requireSceneSyncRoom(room);
+        requireSceneSyncSession(session);
+
+        const client = new SceneSyncClient({ endpoint });
+        const broadcastResult = await client.broadcast({ room, session, payload });
+
+        if (!broadcastResult.ok) {
+          printError(formatSceneSyncError(broadcastResult.error));
+          return 1;
+        }
+
+        if (json) {
+          print(stringifyJson({
+            ok: true,
+            payload,
+            room,
+            operationCount: Array.isArray(payload.ops) ? payload.ops.length : 1
+          }));
+        } else {
+          const opCount = Array.isArray(payload.ops) ? payload.ops.length : 1;
+          const lines = [
+            'Sent Scene Sync broadcast payload.',
+            `Room: ${room}`,
+            `Operations: ${opCount}`
+          ];
+          print(lines.join('\n'));
+        }
+        return 0;
+      }
+    } catch (error) {
+      printError(error.message || String(error));
+      return 1;
+    }
   }
 
   const { room, session, endpoint, json } = await parseSceneSyncArgs(rest);

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -55,7 +55,7 @@
 ## Phase 7: SceneSync follow-up
 
 - compile DSL and send graph
-- `loom scenesync run <file.loom>`
+- ✓ `loom scenesync run <file.loom>` (with dry-run payload generation)
 - `loom scenesync send-graph <file.json>`
 - target scene scope
 - target object scope

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/scenesync/client.js
+++ b/src/scenesync/client.js
@@ -161,6 +161,43 @@ export class SceneSyncClient {
   async listObjects({ room, session } = {}) {
     return this.getScene({ room, session });
   }
+
+  async broadcast({ room, session, payload } = {}) {
+    if (!room) {
+      return {
+        ok: false,
+        error: {
+          code: 'ROOM_REQUIRED',
+          message: 'Scene Sync room is required'
+        }
+      };
+    }
+
+    if (!session) {
+      return {
+        ok: false,
+        error: {
+          code: 'SESSION_REQUIRED',
+          message: 'Scene Sync session is required'
+        }
+      };
+    }
+
+    if (!payload || typeof payload !== 'object') {
+      return {
+        ok: false,
+        error: {
+          code: 'PAYLOAD_REQUIRED',
+          message: 'Scene Sync payload is required'
+        }
+      };
+    }
+
+    return this.#request(`/room/${encodeURIComponent(room)}/broadcast`, {
+      sessionId: session,
+      payload
+    });
+  }
 }
 
 export { DEFAULT_ENDPOINT };

--- a/src/scenesync/effects.js
+++ b/src/scenesync/effects.js
@@ -1,0 +1,85 @@
+function isSceneSyncEffect(effect) {
+  if (!effect || typeof effect !== 'object') {
+    return false;
+  }
+
+  const validTypes = new Set([
+    'scene.setPosition',
+    'scene.setRotation',
+    'scene.setScale'
+  ]);
+
+  return validTypes.has(effect.type) && effect.target === 'scenesync';
+}
+
+function validateObjectId(objectId) {
+  if (typeof objectId !== 'string' || objectId.trim().length === 0) {
+    throw new Error('Invalid scene effect: objectId is required');
+  }
+}
+
+function validateVector(value, length, fieldName) {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid scene effect: ${fieldName} must be an array`);
+  }
+  if (value.length !== length) {
+    throw new Error(`Invalid scene effect: ${fieldName} must have length ${length}`);
+  }
+}
+
+function sceneEffectToBroadcastOp(effect) {
+  if (!effect || typeof effect !== 'object') {
+    throw new Error('Invalid scene effect: effect must be an object');
+  }
+
+  validateObjectId(effect.objectId);
+
+  const op = {
+    kind: 'scene-delta',
+    objectId: effect.objectId
+  };
+
+  if (effect.type === 'scene.setPosition') {
+    validateVector(effect.position, 3, 'position');
+    op.position = effect.position;
+  } else if (effect.type === 'scene.setRotation') {
+    validateVector(effect.rotation, 4, 'rotation');
+    op.rotation = effect.rotation;
+  } else if (effect.type === 'scene.setScale') {
+    validateVector(effect.scale, 3, 'scale');
+    op.scale = effect.scale;
+  } else {
+    throw new Error(`Invalid scene effect: unknown type ${effect.type}`);
+  }
+
+  return op;
+}
+
+function sceneEffectsToBroadcastPayload(effects) {
+  if (!Array.isArray(effects)) {
+    return null;
+  }
+
+  const ops = effects
+    .filter(isSceneSyncEffect)
+    .map(sceneEffectToBroadcastOp);
+
+  if (ops.length === 0) {
+    return null;
+  }
+
+  if (ops.length === 1) {
+    return ops[0];
+  }
+
+  return {
+    kind: 'scene-batch',
+    ops
+  };
+}
+
+export {
+  isSceneSyncEffect,
+  sceneEffectToBroadcastOp,
+  sceneEffectsToBroadcastPayload
+};

--- a/src/scenesync/index.js
+++ b/src/scenesync/index.js
@@ -1,3 +1,4 @@
 export * from './client.js';
 export * from './commands.js';
 export * from './session-store.js';
+export * from './effects.js';

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -460,3 +460,56 @@ test('evaluateOnce supports Node-safe one-shot evaluation', async () => {
 
   assert.equal(Number.isFinite(value), true);
 });
+
+test('scenesync run prints dry-run payload', () => {
+  const result = runCli(['scenesync', 'run', 'examples/scene-effects.loom']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Scene Sync broadcast payload/);
+  assert.match(result.stdout, /scene-batch/);
+  assert.match(result.stdout, /sample-cube/);
+  assert.match(result.stdout, /Dry run only/);
+});
+
+test('scenesync run --dry-run prints payload', () => {
+  const result = runCli(['scenesync', 'run', 'examples/scene-effects.loom', '--dry-run']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Scene Sync broadcast payload/);
+  assert.match(result.stdout, /scene-batch/);
+});
+
+test('scenesync run --json prints JSON', () => {
+  const result = runCli(['scenesync', 'run', 'examples/scene-effects.loom', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.ok, true);
+  assert.equal(output.dryRun, true);
+  assert.ok(output.payload);
+  assert.ok(Array.isArray(output.effects));
+});
+
+test('scenesync run exits 0 with no scene effects', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-no-effects-'));
+  const file = path.join(tmpDir, 'no-effects.loom');
+  await fsp.writeFile(file, 'x = constant(value: 1)\n', 'utf8');
+
+  const result = runCli(['scenesync', 'run', file]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /No Scene Sync scene effects found/);
+});
+
+test('scenesync run without file exits 1', () => {
+  const result = runCli(['scenesync', 'run']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /file path/);
+});
+
+test('scenesync run with invalid file exits 1', () => {
+  const result = runCli(['scenesync', 'run', 'nonexistent.loom']);
+
+  assert.equal(result.status, 1);
+});

--- a/test/scenesync-client.test.mjs
+++ b/test/scenesync-client.test.mjs
@@ -221,3 +221,108 @@ test('null response returns INVALID_RESPONSE', async () => {
   assert.equal(result.ok, false);
   assert.equal(result.error.code, 'INVALID_RESPONSE');
 });
+
+test('broadcast posts to /room/:room/broadcast', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          ok: true
+        };
+      }
+    };
+  };
+
+  const client = new SceneSyncClient({
+    endpoint: 'https://example.com/presence/api/ai',
+    fetchImpl
+  });
+
+  const payload = {
+    kind: 'scene-delta',
+    objectId: 'sample-cube',
+    position: [1, 0.5, 0]
+  };
+
+  const result = await client.broadcast({
+    room: 'room-1',
+    session: 'v1.test',
+    payload
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.match(String(calls[0].url), /\/room\/room-1\/broadcast$/);
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(body.sessionId, 'v1.test');
+  assert.deepEqual(body.payload, payload);
+});
+
+test('broadcast missing room returns ROOM_REQUIRED', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.broadcast({
+    session: 'v1.test',
+    payload: { kind: 'scene-delta' }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'ROOM_REQUIRED');
+});
+
+test('broadcast missing session returns SESSION_REQUIRED', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.broadcast({
+    room: 'room-1',
+    payload: { kind: 'scene-delta' }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'SESSION_REQUIRED');
+});
+
+test('broadcast missing payload returns PAYLOAD_REQUIRED', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.broadcast({
+    room: 'room-1',
+    session: 'v1.test'
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'PAYLOAD_REQUIRED');
+});
+
+test('broadcast with invalid payload returns PAYLOAD_REQUIRED', async () => {
+  const client = new SceneSyncClient({
+    fetchImpl: async () => {
+      throw new Error('should not be called');
+    }
+  });
+
+  const result = await client.broadcast({
+    room: 'room-1',
+    session: 'v1.test',
+    payload: null
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'PAYLOAD_REQUIRED');
+});

--- a/test/scenesync-effects.test.mjs
+++ b/test/scenesync-effects.test.mjs
@@ -1,0 +1,250 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isSceneSyncEffect,
+  sceneEffectToBroadcastOp,
+  sceneEffectsToBroadcastPayload
+} from '../src/scenesync/effects.js';
+
+test('isSceneSyncEffect returns true for scene.setPosition', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    target: 'scenesync',
+    objectId: 'sample-cube',
+    position: [1, 0.5, 0]
+  };
+  assert.equal(isSceneSyncEffect(effect), true);
+});
+
+test('isSceneSyncEffect returns true for scene.setRotation', () => {
+  const effect = {
+    type: 'scene.setRotation',
+    target: 'scenesync',
+    objectId: 'sample-cube',
+    rotation: [0, 0, 0, 1]
+  };
+  assert.equal(isSceneSyncEffect(effect), true);
+});
+
+test('isSceneSyncEffect returns true for scene.setScale', () => {
+  const effect = {
+    type: 'scene.setScale',
+    target: 'scenesync',
+    objectId: 'sample-cube',
+    scale: [2, 2, 2]
+  };
+  assert.equal(isSceneSyncEffect(effect), true);
+});
+
+test('isSceneSyncEffect returns false for non-scenesync target', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    target: 'other',
+    objectId: 'sample-cube',
+    position: [1, 0.5, 0]
+  };
+  assert.equal(isSceneSyncEffect(effect), false);
+});
+
+test('isSceneSyncEffect returns false for unknown type', () => {
+  const effect = {
+    type: 'scene.unknown',
+    target: 'scenesync',
+    objectId: 'sample-cube'
+  };
+  assert.equal(isSceneSyncEffect(effect), false);
+});
+
+test('sceneEffectToBroadcastOp converts position', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    objectId: 'sample-cube',
+    position: [1, 0.5, 0]
+  };
+
+  const op = sceneEffectToBroadcastOp(effect);
+  assert.deepEqual(op, {
+    kind: 'scene-delta',
+    objectId: 'sample-cube',
+    position: [1, 0.5, 0]
+  });
+});
+
+test('sceneEffectToBroadcastOp converts rotation', () => {
+  const effect = {
+    type: 'scene.setRotation',
+    objectId: 'sample-cube',
+    rotation: [0, 0, 0, 1]
+  };
+
+  const op = sceneEffectToBroadcastOp(effect);
+  assert.deepEqual(op, {
+    kind: 'scene-delta',
+    objectId: 'sample-cube',
+    rotation: [0, 0, 0, 1]
+  });
+});
+
+test('sceneEffectToBroadcastOp converts scale', () => {
+  const effect = {
+    type: 'scene.setScale',
+    objectId: 'sample-cube',
+    scale: [2, 2, 2]
+  };
+
+  const op = sceneEffectToBroadcastOp(effect);
+  assert.deepEqual(op, {
+    kind: 'scene-delta',
+    objectId: 'sample-cube',
+    scale: [2, 2, 2]
+  });
+});
+
+test('sceneEffectToBroadcastOp throws for missing objectId', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    position: [1, 0.5, 0]
+  };
+
+  assert.throws(() => sceneEffectToBroadcastOp(effect), /objectId/);
+});
+
+test('sceneEffectToBroadcastOp throws for empty objectId', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    objectId: '',
+    position: [1, 0.5, 0]
+  };
+
+  assert.throws(() => sceneEffectToBroadcastOp(effect), /objectId/);
+});
+
+test('sceneEffectToBroadcastOp throws for non-array position', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    objectId: 'sample-cube',
+    position: { x: 1, y: 0.5, z: 0 }
+  };
+
+  assert.throws(() => sceneEffectToBroadcastOp(effect), /position/);
+});
+
+test('sceneEffectToBroadcastOp throws for wrong position length', () => {
+  const effect = {
+    type: 'scene.setPosition',
+    objectId: 'sample-cube',
+    position: [1, 0.5]
+  };
+
+  assert.throws(() => sceneEffectToBroadcastOp(effect), /position/);
+});
+
+test('sceneEffectToBroadcastOp throws for wrong rotation length', () => {
+  const effect = {
+    type: 'scene.setRotation',
+    objectId: 'sample-cube',
+    rotation: [0, 0, 0]
+  };
+
+  assert.throws(() => sceneEffectToBroadcastOp(effect), /rotation/);
+});
+
+test('sceneEffectToBroadcastOp throws for wrong scale length', () => {
+  const effect = {
+    type: 'scene.setScale',
+    objectId: 'sample-cube',
+    scale: [2, 2]
+  };
+
+  assert.throws(() => sceneEffectToBroadcastOp(effect), /scale/);
+});
+
+test('sceneEffectsToBroadcastPayload returns null for empty array', () => {
+  const result = sceneEffectsToBroadcastPayload([]);
+  assert.equal(result, null);
+});
+
+test('sceneEffectsToBroadcastPayload returns single op directly', () => {
+  const effects = [
+    {
+      type: 'scene.setPosition',
+      target: 'scenesync',
+      objectId: 'sample-cube',
+      position: [1, 0.5, 0]
+    }
+  ];
+
+  const payload = sceneEffectsToBroadcastPayload(effects);
+  assert.equal(payload.kind, 'scene-delta');
+  assert.equal(payload.objectId, 'sample-cube');
+  assert.deepEqual(payload.position, [1, 0.5, 0]);
+});
+
+test('sceneEffectsToBroadcastPayload returns scene-batch for multiple ops', () => {
+  const effects = [
+    {
+      type: 'scene.setPosition',
+      target: 'scenesync',
+      objectId: 'sample-cube',
+      position: [1, 0.5, 0]
+    },
+    {
+      type: 'scene.setScale',
+      target: 'scenesync',
+      objectId: 'sample-cube',
+      scale: [2, 2, 2]
+    }
+  ];
+
+  const payload = sceneEffectsToBroadcastPayload(effects);
+  assert.equal(payload.kind, 'scene-batch');
+  assert.equal(payload.ops.length, 2);
+  assert.equal(payload.ops[0].kind, 'scene-delta');
+  assert.equal(payload.ops[0].position[0], 1);
+  assert.equal(payload.ops[1].kind, 'scene-delta');
+  assert.equal(payload.ops[1].scale[0], 2);
+});
+
+test('sceneEffectsToBroadcastPayload filters out non-scenesync effects', () => {
+  const effects = [
+    {
+      type: 'scene.setPosition',
+      target: 'scenesync',
+      objectId: 'sample-cube',
+      position: [1, 0.5, 0]
+    },
+    {
+      type: 'log',
+      target: 'console',
+      message: 'test'
+    },
+    {
+      type: 'scene.setScale',
+      target: 'scenesync',
+      objectId: 'sample-cube',
+      scale: [2, 2, 2]
+    }
+  ];
+
+  const payload = sceneEffectsToBroadcastPayload(effects);
+  assert.equal(payload.kind, 'scene-batch');
+  assert.equal(payload.ops.length, 2);
+});
+
+test('sceneEffectsToBroadcastPayload returns null for effects with no scenesync targets', () => {
+  const effects = [
+    {
+      type: 'log',
+      target: 'console',
+      message: 'test'
+    }
+  ];
+
+  const result = sceneEffectsToBroadcastPayload(effects);
+  assert.equal(result, null);
+});
+
+test('sceneEffectsToBroadcastPayload handles null effects gracefully', () => {
+  const result = sceneEffectsToBroadcastPayload(null);
+  assert.equal(result, null);
+});


### PR DESCRIPTION
## Summary

This PR adds support for converting Loom scene effects into Scene Sync broadcast payloads, enabling users to run Loom graphs and send the resulting scene transformations to Scene Sync rooms.

## Key Changes

- **New effects module** (`src/scenesync/effects.js`): Provides three core functions:
  - `isSceneSyncEffect()`: Validates if an effect targets Scene Sync and has a supported type (position, rotation, scale)
  - `sceneEffectToBroadcastOp()`: Converts individual effects to broadcast operations with validation
  - `sceneEffectsToBroadcastPayload()`: Aggregates effects into a single operation or batch payload

- **Scene Sync client enhancement** (`src/scenesync/client.js`): Added `broadcast()` method to post payloads to `/room/:room/broadcast` endpoint with proper validation

- **CLI command** (`bin/loom.mjs`): New `scenesync run <file>` subcommand that:
  - Parses Loom source files and extracts scene effects
  - Converts effects to broadcast payloads
  - Supports `--dry-run` (default) to preview payloads
  - Supports `--send` to broadcast to Scene Sync
  - Supports `--json` for structured output
  - Reuses saved session credentials from `~/.config/loom/scenesync-session.json`

- **Comprehensive test coverage**: 
  - 20 tests for effects module covering validation, conversion, and edge cases
  - 5 tests for client broadcast method
  - 5 CLI integration tests

## Implementation Details

- Effects validation includes checks for required `objectId`, correct vector dimensions (3 for position/scale, 4 for rotation), and proper array types
- Payload generation intelligently returns single operations directly or wraps multiple operations in a `scene-batch` structure
- Non-Scene Sync effects are filtered out silently, allowing mixed effect types in Loom graphs
- CLI defaults to dry-run mode for safety, requiring explicit `--send` flag to broadcast

https://claude.ai/code/session_01V4xRmGpUULpadvbakdiiKK