### PR TITLE
Add Scene Graph set/clear commands to Scene Sync CLI

### DIFF
--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -24,7 +24,9 @@ import {
   clearSceneSyncSession,
   maskSessionId,
   sceneEffectsToBroadcastOps,
-  sceneEffectsToBroadcastPayload
+  sceneEffectsToBroadcastPayload,
+  createSceneGraphSetPayload,
+  createSceneGraphClearPayload
 } from '../src/scenesync/index.js';
 
 function print(message = '') {
@@ -186,20 +188,22 @@ function getSceneSyncHelp() {
   loom scenesync <command> [options]
 
 Commands:
-  redeem <code>      Redeem a Scene Sync AI link code
-  session            Show saved Scene Sync session
-  status             Alias for session
-  logout             Clear saved Scene Sync session
-  run <file>         Convert Loom scene effects to Scene Sync broadcast payload
-  ping               Check Scene Sync room connection
-  info               Get room information
-  objects            List scene objects
-  list-objects       Alias for objects
+  redeem <code>        Redeem a Scene Sync AI link code
+  session              Show saved Scene Sync session
+  status               Alias for session
+  logout               Clear saved Scene Sync session
+  run <file>           Convert Loom scene effects to Scene Sync broadcast payload
+  graph-set <obj> <g>  Set a Loom graph behavior on a Scene Sync object
+  graph-clear <obj>    Clear Loom graph behavior from a Scene Sync object
+  ping                 Check Scene Sync room connection
+  info                 Get room information
+  objects              List scene objects
+  list-objects         Alias for objects
 
 Options:
   --save               Save redeemed session locally
-  --dry-run            Print payload without sending (default for run)
-  --send               Broadcast payload to Scene Sync (run only)
+  --dry-run            Print payload without sending (default for run, graph-set, graph-clear)
+  --send               Broadcast payload to Scene Sync
   --room <room>        Scene Sync room code
   --session <id>       Scene Sync session ID
   --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
@@ -208,6 +212,13 @@ Options:
 Examples:
   loom scenesync run examples/scene-effects.loom
   loom scenesync run examples/scene-effects.loom --send
+  loom scenesync graph-set sample-cube examples/scene-graphs/lissajous.json
+  loom scenesync graph-set sample-cube examples/scene-graphs/lissajous.json --send
+  loom scenesync graph-clear sample-cube --send
+
+Graph Commands:
+  By default graph-set and graph-clear are dry-run. Pass --send to broadcast.
+  graph-set does not require room/session in dry-run mode.
 
 Environment Variables:
   LOOM_SCENESYNC_ROOM              Default room code
@@ -472,6 +483,178 @@ async function parseSceneSyncRunArgs(args) {
   }
 
   return { file, room, session, endpoint, dryRun, send, json };
+}
+
+async function parseSceneSyncGraphSetArgs(args) {
+  let objectId = null;
+  let graphFile = null;
+  let room = '';
+  let session = '';
+  let endpoint = '';
+  let dryRun = true;
+  let send = false;
+  let json = false;
+  let positionalIndex = 0;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith('-')) {
+      if (positionalIndex === 0) {
+        objectId = arg;
+        positionalIndex += 1;
+      } else if (positionalIndex === 1) {
+        graphFile = arg;
+        positionalIndex += 1;
+      }
+    } else if (arg === '--room') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--room requires a room code');
+      }
+      room = next;
+      index += 1;
+    } else if (arg === '--session') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--session requires a session ID');
+      }
+      session = next;
+      index += 1;
+    } else if (arg === '--endpoint') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--endpoint requires a URL');
+      }
+      endpoint = next;
+      index += 1;
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--send') {
+      send = true;
+      dryRun = false;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!objectId) {
+    throw new Error('graph-set requires <objectId>');
+  }
+
+  if (!graphFile) {
+    throw new Error('graph-set requires <graph.json>');
+  }
+
+  const savedSession = await loadSceneSyncSession();
+  const savedData = savedSession.ok && savedSession.session ? savedSession.session : null;
+
+  if (!room && send) {
+    room = process.env.LOOM_SCENESYNC_ROOM || '';
+    if (!room && savedData) {
+      room = savedData.roomId || '';
+    }
+  }
+
+  if (!session && send) {
+    session = process.env.LOOM_SCENESYNC_SESSION || '';
+    if (!session && savedData) {
+      session = savedData.sessionId || '';
+    }
+  }
+
+  if (!endpoint) {
+    endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || '';
+    if (!endpoint && savedData) {
+      endpoint = savedData.endpoint || '';
+    }
+    if (!endpoint) {
+      endpoint = DEFAULT_SCENESYNC_ENDPOINT;
+    }
+  }
+
+  return { objectId, graphFile, room, session, endpoint, dryRun, send, json };
+}
+
+async function parseSceneSyncGraphClearArgs(args) {
+  let objectId = null;
+  let room = '';
+  let session = '';
+  let endpoint = '';
+  let dryRun = true;
+  let send = false;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith('-') && !objectId) {
+      objectId = arg;
+    } else if (arg === '--room') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--room requires a room code');
+      }
+      room = next;
+      index += 1;
+    } else if (arg === '--session') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--session requires a session ID');
+      }
+      session = next;
+      index += 1;
+    } else if (arg === '--endpoint') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--endpoint requires a URL');
+      }
+      endpoint = next;
+      index += 1;
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--send') {
+      send = true;
+      dryRun = false;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!objectId) {
+    throw new Error('graph-clear requires <objectId>');
+  }
+
+  const savedSession = await loadSceneSyncSession();
+  const savedData = savedSession.ok && savedSession.session ? savedSession.session : null;
+
+  if (!room && send) {
+    room = process.env.LOOM_SCENESYNC_ROOM || '';
+    if (!room && savedData) {
+      room = savedData.roomId || '';
+    }
+  }
+
+  if (!session && send) {
+    session = process.env.LOOM_SCENESYNC_SESSION || '';
+    if (!session && savedData) {
+      session = savedData.sessionId || '';
+    }
+  }
+
+  if (!endpoint) {
+    endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || '';
+    if (!endpoint && savedData) {
+      endpoint = savedData.endpoint || '';
+    }
+    if (!endpoint) {
+      endpoint = DEFAULT_SCENESYNC_ENDPOINT;
+    }
+  }
+
+  return { objectId, room, session, endpoint, dryRun, send, json };
 }
 
 async function handleCompile(args) {
@@ -992,6 +1175,122 @@ async function handleSceneSync(args) {
             'Sent Scene Sync broadcast operations.',
             `Room: ${room}`,
             `Operations: ${sentOps.length}`
+          ];
+          print(lines.join('\n'));
+        }
+        return 0;
+      }
+    } catch (error) {
+      printError(error.message || String(error));
+      return 1;
+    }
+  }
+
+  if (subcommand === 'graph-set') {
+    const { objectId, graphFile, room, session, endpoint, dryRun, send, json: jsonOutput } = await parseSceneSyncGraphSetArgs(rest);
+
+    try {
+      const graphContent = await readSourceFile(graphFile);
+      const graph = JSON.parse(graphContent);
+      const payload = createSceneGraphSetPayload(objectId, graph);
+
+      if (dryRun) {
+        if (jsonOutput) {
+          print(stringifyJson({
+            ok: true,
+            dryRun: true,
+            payload
+          }));
+        } else {
+          print('Scene Sync graph-set payload:');
+          print(stringifyJson(payload, true));
+          print('Dry run only. Pass --send to broadcast to Scene Sync.');
+        }
+        return 0;
+      }
+
+      if (send) {
+        requireSceneSyncRoom(room);
+        requireSceneSyncSession(session);
+
+        const client = new SceneSyncClient({ endpoint });
+        const broadcastResult = await client.broadcast({ room, session, payload });
+
+        if (!broadcastResult.ok) {
+          printError(formatSceneSyncError(broadcastResult.error));
+          return 1;
+        }
+
+        if (jsonOutput) {
+          print(stringifyJson({
+            ok: true,
+            room,
+            objectId,
+            nodeCount: graph.nodes ? graph.nodes.length : 0,
+            edgeCount: graph.edges ? graph.edges.length : 0
+          }));
+        } else {
+          const lines = [
+            'Sent Scene Sync graph.',
+            `Room: ${room}`,
+            `Object: ${objectId}`,
+            `Nodes: ${graph.nodes ? graph.nodes.length : 0}`,
+            `Edges: ${graph.edges ? graph.edges.length : 0}`
+          ];
+          print(lines.join('\n'));
+        }
+        return 0;
+      }
+    } catch (error) {
+      printError(error.message || String(error));
+      return 1;
+    }
+  }
+
+  if (subcommand === 'graph-clear') {
+    const { objectId, room, session, endpoint, dryRun, send, json: jsonOutput } = await parseSceneSyncGraphClearArgs(rest);
+
+    try {
+      const payload = createSceneGraphClearPayload(objectId);
+
+      if (dryRun) {
+        if (jsonOutput) {
+          print(stringifyJson({
+            ok: true,
+            dryRun: true,
+            payload
+          }));
+        } else {
+          print('Scene Sync graph-clear payload:');
+          print(stringifyJson(payload, true));
+          print('Dry run only. Pass --send to broadcast to Scene Sync.');
+        }
+        return 0;
+      }
+
+      if (send) {
+        requireSceneSyncRoom(room);
+        requireSceneSyncSession(session);
+
+        const client = new SceneSyncClient({ endpoint });
+        const broadcastResult = await client.broadcast({ room, session, payload });
+
+        if (!broadcastResult.ok) {
+          printError(formatSceneSyncError(broadcastResult.error));
+          return 1;
+        }
+
+        if (jsonOutput) {
+          print(stringifyJson({
+            ok: true,
+            room,
+            objectId
+          }));
+        } else {
+          const lines = [
+            'Cleared Scene Sync graph.',
+            `Room: ${room}`,
+            `Object: ${objectId}`
           ];
           print(lines.join('\n'));
         }

--- a/examples/scene-graphs/lissajous.json
+++ b/examples/scene-graphs/lissajous.json
@@ -1,0 +1,36 @@
+{
+  "nodes": [
+    { "id": "clock", "type": "serverClock" },
+    {
+      "id": "sine_x",
+      "type": "sine",
+      "params": {
+        "freq": 0.2,
+        "amplitude": 2,
+        "offset": 0
+      }
+    },
+    {
+      "id": "sine_y",
+      "type": "sine",
+      "params": {
+        "freq": 0.3,
+        "amplitude": 0.5,
+        "offset": 1.2
+      }
+    },
+    {
+      "id": "pos",
+      "type": "sceneSetPosition",
+      "params": {
+        "z": 0
+      }
+    }
+  ],
+  "edges": [
+    { "from": "clock.t", "to": "sine_x.t" },
+    { "from": "clock.t", "to": "sine_y.t" },
+    { "from": "sine_x.out", "to": "pos.x" },
+    { "from": "sine_y.out", "to": "pos.y" }
+  ]
+}

--- a/examples/scene-graphs/move-x.json
+++ b/examples/scene-graphs/move-x.json
@@ -1,0 +1,26 @@
+{
+  "nodes": [
+    { "id": "clock", "type": "serverClock" },
+    {
+      "id": "sine",
+      "type": "sine",
+      "params": {
+        "freq": 0.2,
+        "amplitude": 2,
+        "offset": 0
+      }
+    },
+    {
+      "id": "pos",
+      "type": "sceneSetPosition",
+      "params": {
+        "y": 0.5,
+        "z": 0
+      }
+    }
+  ],
+  "edges": [
+    { "from": "clock.t", "to": "sine.t" },
+    { "from": "sine.out", "to": "pos.x" }
+  ]
+}

--- a/examples/scene-graphs/rotate-y.json
+++ b/examples/scene-graphs/rotate-y.json
@@ -1,0 +1,24 @@
+{
+  "nodes": [
+    { "id": "clock", "type": "serverClock" },
+    {
+      "id": "angle",
+      "type": "multiply",
+      "params": {
+        "b": 0.5
+      }
+    },
+    {
+      "id": "rot",
+      "type": "sceneSetRotation",
+      "params": {
+        "x": 0,
+        "z": 0
+      }
+    }
+  ],
+  "edges": [
+    { "from": "clock.t", "to": "angle.a" },
+    { "from": "angle.out", "to": "rot.y" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/scenesync/graphs.js
+++ b/src/scenesync/graphs.js
@@ -1,0 +1,64 @@
+function validateSceneGraph(graph) {
+  if (!graph || typeof graph !== 'object') {
+    throw new Error('graph must be an object');
+  }
+
+  if (!Array.isArray(graph.nodes)) {
+    throw new Error('graph.nodes must be an array');
+  }
+
+  if (!Array.isArray(graph.edges)) {
+    throw new Error('graph.edges must be an array');
+  }
+
+  for (const node of graph.nodes) {
+    if (typeof node !== 'object' || node === null) {
+      throw new Error('each node must be an object');
+    }
+    if (typeof node.id !== 'string' || node.id.length === 0) {
+      throw new Error('each node must have a non-empty id string');
+    }
+    if (typeof node.type !== 'string' || node.type.length === 0) {
+      throw new Error('each node must have a non-empty type string');
+    }
+  }
+
+  for (const edge of graph.edges) {
+    if (typeof edge !== 'object' || edge === null) {
+      throw new Error('each edge must be an object');
+    }
+    if (typeof edge.from !== 'string' || edge.from.length === 0) {
+      throw new Error('each edge must have a non-empty from string');
+    }
+    if (typeof edge.to !== 'string' || edge.to.length === 0) {
+      throw new Error('each edge must have a non-empty to string');
+    }
+  }
+}
+
+export function createSceneGraphSetPayload(objectId, graph) {
+  if (typeof objectId !== 'string' || objectId.length === 0) {
+    throw new Error('objectId must be a non-empty string');
+  }
+
+  validateSceneGraph(graph);
+
+  return {
+    type: 'scene-graph-set',
+    scope: { object: objectId },
+    graph
+  };
+}
+
+export function createSceneGraphClearPayload(objectId) {
+  if (typeof objectId !== 'string' || objectId.length === 0) {
+    throw new Error('objectId must be a non-empty string');
+  }
+
+  return {
+    type: 'scene-graph-clear',
+    scope: { object: objectId }
+  };
+}
+
+export { validateSceneGraph };

--- a/src/scenesync/index.js
+++ b/src/scenesync/index.js
@@ -2,3 +2,4 @@ export * from './client.js';
 export * from './commands.js';
 export * from './session-store.js';
 export * from './effects.js';
+export * from './graphs.js';

--- a/test/scenesync-graphs.test.mjs
+++ b/test/scenesync-graphs.test.mjs
@@ -1,0 +1,181 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createSceneGraphSetPayload,
+  createSceneGraphClearPayload,
+  validateSceneGraph
+} from '../src/scenesync/index.js';
+
+test('createSceneGraphSetPayload creates valid payload', () => {
+  const graph = {
+    nodes: [{ id: 'node1', type: 'sine' }],
+    edges: [{ from: 'a.out', to: 'b.x' }]
+  };
+  const payload = createSceneGraphSetPayload('sample-cube', graph);
+  assert.equal(payload.type, 'scene-graph-set');
+  assert.equal(payload.scope.object, 'sample-cube');
+  assert.deepEqual(payload.graph, graph);
+});
+
+test('createSceneGraphClearPayload creates valid payload', () => {
+  const payload = createSceneGraphClearPayload('sample-cube');
+  assert.equal(payload.type, 'scene-graph-clear');
+  assert.equal(payload.scope.object, 'sample-cube');
+  assert(!Object.hasOwn(payload, 'graph'));
+});
+
+test('validateSceneGraph throws on invalid objectId - empty string', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('', {
+      nodes: [],
+      edges: []
+    });
+  }, /objectId must be a non-empty string/);
+});
+
+test('validateSceneGraph throws on invalid objectId - not string', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload(123, {
+      nodes: [],
+      edges: []
+    });
+  }, /objectId must be a non-empty string/);
+});
+
+test('validateSceneGraph throws when graph is not an object', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', null);
+  }, /graph must be an object/);
+});
+
+test('validateSceneGraph throws when nodes is not an array', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: 'not-array',
+      edges: []
+    });
+  }, /graph.nodes must be an array/);
+});
+
+test('validateSceneGraph throws when edges is not an array', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [],
+      edges: 'not-array'
+    });
+  }, /graph.edges must be an array/);
+});
+
+test('validateSceneGraph throws when node missing id', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ type: 'sine' }],
+      edges: []
+    });
+  }, /each node must have a non-empty id string/);
+});
+
+test('validateSceneGraph throws when node id is empty', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: '', type: 'sine' }],
+      edges: []
+    });
+  }, /each node must have a non-empty id string/);
+});
+
+test('validateSceneGraph throws when node missing type', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: 'node1' }],
+      edges: []
+    });
+  }, /each node must have a non-empty type string/);
+});
+
+test('validateSceneGraph throws when node type is empty', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: 'node1', type: '' }],
+      edges: []
+    });
+  }, /each node must have a non-empty type string/);
+});
+
+test('validateSceneGraph throws when edge missing from', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: 'node1', type: 'sine' }],
+      edges: [{ to: 'node1.x' }]
+    });
+  }, /each edge must have a non-empty from string/);
+});
+
+test('validateSceneGraph throws when edge from is empty', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: 'node1', type: 'sine' }],
+      edges: [{ from: '', to: 'node1.x' }]
+    });
+  }, /each edge must have a non-empty from string/);
+});
+
+test('validateSceneGraph throws when edge missing to', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: 'node1', type: 'sine' }],
+      edges: [{ from: 'node1.out' }]
+    });
+  }, /each edge must have a non-empty to string/);
+});
+
+test('validateSceneGraph throws when edge to is empty', () => {
+  assert.throws(() => {
+    createSceneGraphSetPayload('obj', {
+      nodes: [{ id: 'node1', type: 'sine' }],
+      edges: [{ from: 'node1.out', to: '' }]
+    });
+  }, /each edge must have a non-empty to string/);
+});
+
+test('validateSceneGraph accepts graph with multiple nodes and edges', () => {
+  const graph = {
+    nodes: [
+      { id: 'clock', type: 'serverClock' },
+      { id: 'sine', type: 'sine', params: { freq: 0.2 } },
+      { id: 'pos', type: 'sceneSetPosition', params: { y: 0.5 } }
+    ],
+    edges: [
+      { from: 'clock.t', to: 'sine.t' },
+      { from: 'sine.out', to: 'pos.x' }
+    ]
+  };
+  const payload = createSceneGraphSetPayload('sample-cube', graph);
+  assert.equal(payload.scope.object, 'sample-cube');
+  assert.equal(payload.graph.nodes.length, 3);
+  assert.equal(payload.graph.edges.length, 2);
+});
+
+test('validateSceneGraph accepts graph with optional node params', () => {
+  const graph = {
+    nodes: [
+      { id: 'node1', type: 'sine', params: { freq: 0.5, amplitude: 2 } }
+    ],
+    edges: []
+  };
+  const payload = createSceneGraphSetPayload('obj', graph);
+  assert.equal(payload.graph.nodes[0].params.freq, 0.5);
+  assert.equal(payload.graph.nodes[0].params.amplitude, 2);
+});
+
+test('createSceneGraphClearPayload throws on invalid objectId', () => {
+  assert.throws(() => {
+    createSceneGraphClearPayload('');
+  }, /objectId must be a non-empty string/);
+});
+
+test('createSceneGraphClearPayload throws on non-string objectId', () => {
+  assert.throws(() => {
+    createSceneGraphClearPayload(null);
+  }, /objectId must be a non-empty string/);
+});


### PR DESCRIPTION
## Summary
Add support for setting and clearing Loom graph behaviors on Scene Sync objects via two new CLI commands: `graph-set` and `graph-clear`.

## Key Changes
- **New CLI Commands**: Added `graph-set` and `graph-clear` subcommands to the `scenesync` command
  - `graph-set <objectId> <graph.json>`: Set a Loom graph behavior on a Scene Sync object
  - `graph-clear <objectId>`: Clear graph behavior from a Scene Sync object
  - Both commands default to dry-run mode; use `--send` to broadcast to Scene Sync
  - Support `--room`, `--session`, `--endpoint`, and `--json` options

- **New Graph Payload Functions** (`src/scenesync/graphs.js`):
  - `createSceneGraphSetPayload(objectId, graph)`: Creates a `scene-graph-set` payload with validation
  - `createSceneGraphClearPayload(objectId)`: Creates a `scene-graph-clear` payload
  - `validateSceneGraph(graph)`: Validates graph structure (nodes and edges arrays with required fields)

- **Example Graph Files**: Added three example scene graph JSON files demonstrating different animation patterns:
  - `lissajous.json`: Lissajous curve animation (2D parametric motion)
  - `move-x.json`: Simple sine wave motion along X axis
  - `rotate-y.json`: Rotation animation around Y axis

- **Comprehensive Tests** (`test/scenesync-graphs.test.mjs`): 181 lines of test coverage for graph payload creation and validation, including edge cases for invalid inputs

- **CLI Help Updates**: Updated help text with new commands, examples, and clarified that graph commands default to dry-run mode

## Implementation Details
- Argument parsing follows the same pattern as existing `run` command with support for positional arguments and optional flags
- Graph validation ensures objectId is a non-empty string and graph contains valid nodes/edges arrays
- Dry-run mode displays payload without requiring room/session credentials
- Send mode requires valid room and session (loaded from environment, saved session, or CLI args)
- Output supports both human-readable and JSON formats via `--json` flag

https://claude.ai/code/session_014QBsLpLJBnn8RcoGgm2wLd