### PR TITLE
Add graph-compile and graph-run commands for Scene Sync behavior graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,40 @@ The `--json` flag outputs the payload and effects as JSON:
 node bin/loom.mjs scenesync run examples/scene-effects.loom --json
 ```
 
+### Compile Loom DSL to a Scene Sync behavior graph
+
+Loom DSL can be compiled directly to Scene Sync behavior graphs with `graph-compile`:
+
+```bash
+node bin/loom.mjs scenesync graph-compile examples/lissajous.loom
+```
+
+This outputs a Scene Sync graph JSON containing `serverClock`, `sine`, and `sceneSetPosition` nodes.
+
+### Run a Loom behavior graph on a Scene Sync object
+
+Loom DSL graphs can be compiled and sent to Scene Sync objects using `graph-run`:
+
+```bash
+node bin/loom.mjs scenesync graph-run examples/lissajous.loom --object sample-cube
+```
+
+By default this is a dry run and only prints the `scene-graph-set` payload.
+
+To send it to the linked Scene Sync room:
+
+```bash
+node bin/loom.mjs scenesync graph-run examples/lissajous.loom --object sample-cube --send
+```
+
+The `--object` parameter can be omitted if the DSL includes an object ID in `scene.setPosition()`.
+
+Use `graph-clear` to stop a running graph:
+
+```bash
+node bin/loom.mjs scenesync graph-clear sample-cube --send
+```
+
 ## ライブエディタと DSL
 
 ### エディタ一覧

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -208,7 +208,8 @@ Options:
   --save               Save redeemed session locally
   --dry-run            Print payload without sending (default for run, graph-set, graph-clear)
   --send               Broadcast payload to Scene Sync
-  --object <id>        Scene object ID (for graph-compile and graph-run)
+  --object <id>        Compile/run as an object-level graph (for graph-compile and graph-run)
+  --scene              Compile/run as a scene-level graph (for graph-compile and graph-run)
   --room <room>        Scene Sync room code
   --session <id>       Scene Sync session ID
   --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
@@ -218,6 +219,8 @@ Examples:
   loom scenesync run examples/scene-effects.loom
   loom scenesync run examples/scene-effects.loom --send
   loom scenesync graph-compile examples/lissajous.loom
+  loom scenesync graph-compile examples/lissajous.loom --object sample-cube
+  loom scenesync graph-compile examples/lissajous.loom --scene
   loom scenesync graph-run examples/lissajous.loom --object sample-cube
   loom scenesync graph-run examples/lissajous.loom --object sample-cube --send
   loom scenesync graph-set sample-cube examples/scene-graphs/lissajous.json
@@ -227,6 +230,8 @@ Examples:
 Graph Commands:
   By default graph-set, graph-clear, and graph-run are dry-run. Pass --send to broadcast.
   graph-compile and graph-run do not require room/session in dry-run mode.
+  Use --object for object scope or --scene for scene scope (mutually exclusive).
+  If neither is specified, scope is inferred from DSL.
 
 Environment Variables:
   LOOM_SCENESYNC_ROOM              Default room code
@@ -668,6 +673,7 @@ async function parseSceneSyncGraphClearArgs(args) {
 async function parseSceneSyncGraphCompileArgs(args) {
   let file = null;
   let objectId = null;
+  let scene = false;
   let json = false;
 
   for (let index = 0; index < args.length; index += 1) {
@@ -681,6 +687,8 @@ async function parseSceneSyncGraphCompileArgs(args) {
       }
       objectId = next;
       index += 1;
+    } else if (arg === '--scene') {
+      scene = true;
     } else if (arg === '--json') {
       json = true;
     } else {
@@ -688,16 +696,28 @@ async function parseSceneSyncGraphCompileArgs(args) {
     }
   }
 
+  if (objectId && scene) {
+    throw new Error('SCOPE_CONFLICT - Use either --object or --scene, not both.');
+  }
+
   if (!file) {
     throw new Error('graph-compile requires a file path');
   }
 
-  return { file, objectId, json };
+  let scope = null;
+  if (objectId) {
+    scope = { object: objectId };
+  } else if (scene) {
+    scope = { scene: true };
+  }
+
+  return { file, scope, json };
 }
 
 async function parseSceneSyncGraphRunArgs(args) {
   let file = null;
   let objectId = null;
+  let scene = false;
   let room = '';
   let session = '';
   let endpoint = '';
@@ -716,6 +736,8 @@ async function parseSceneSyncGraphRunArgs(args) {
       }
       objectId = next;
       index += 1;
+    } else if (arg === '--scene') {
+      scene = true;
     } else if (arg === '--room') {
       const next = args[index + 1];
       if (!next || next.startsWith('-')) {
@@ -747,8 +769,19 @@ async function parseSceneSyncGraphRunArgs(args) {
     }
   }
 
+  if (objectId && scene) {
+    throw new Error('SCOPE_CONFLICT - Use either --object or --scene, not both.');
+  }
+
   if (!file) {
     throw new Error('graph-run requires a file path');
+  }
+
+  let scope = null;
+  if (objectId) {
+    scope = { object: objectId };
+  } else if (scene) {
+    scope = { scene: true };
   }
 
   const savedSession = await loadSceneSyncSession();
@@ -778,7 +811,7 @@ async function parseSceneSyncGraphRunArgs(args) {
     }
   }
 
-  return { file, objectId, room, session, endpoint, dryRun, send, json };
+  return { file, scope, room, session, endpoint, dryRun, send, json };
 }
 
 async function handleCompile(args) {
@@ -1427,16 +1460,20 @@ async function handleSceneSync(args) {
   }
 
   if (subcommand === 'graph-compile') {
-    const { file, objectId, json: jsonOutput } = await parseSceneSyncGraphCompileArgs(rest);
+    const { file, scope, json: jsonOutput } = await parseSceneSyncGraphCompileArgs(rest);
 
     try {
       const source = await readSourceFile(file);
-      const result = compileLoomToSceneSyncGraph(source, { objectId });
+      const result = compileLoomToSceneSyncGraph(source, { scope });
+
+      if (!result.scope) {
+        throw new Error('SCOPE_REQUIRED - Pass --object <objectId>, --scene, or include an object id in scene.setPosition(...)');
+      }
 
       if (jsonOutput) {
         print(stringifyJson({
           ok: true,
-          objectId: result.objectId,
+          scope: result.scope,
           graph: result.graph
         }));
       } else {
@@ -1450,17 +1487,17 @@ async function handleSceneSync(args) {
   }
 
   if (subcommand === 'graph-run') {
-    const { file, objectId, room, session, endpoint, dryRun, send, json: jsonOutput } = await parseSceneSyncGraphRunArgs(rest);
+    const { file, scope, room, session, endpoint, dryRun, send, json: jsonOutput } = await parseSceneSyncGraphRunArgs(rest);
 
     try {
       const source = await readSourceFile(file);
-      const result = compileLoomToSceneSyncGraph(source, { objectId });
+      const result = compileLoomToSceneSyncGraph(source, { scope });
 
-      if (!result.objectId) {
-        throw new Error('OBJECT_REQUIRED - Pass --object <objectId> or include an object id in scene.setPosition(...)');
+      if (!result.scope) {
+        throw new Error('SCOPE_REQUIRED - Pass --object <objectId>, --scene, or include an object id in scene.setPosition(...)');
       }
 
-      const payload = createSceneGraphSetPayload(result.objectId, result.graph);
+      const payload = createSceneGraphSetPayload(result.scope, result.graph);
 
       if (dryRun) {
         if (jsonOutput) {
@@ -1490,21 +1527,29 @@ async function handleSceneSync(args) {
         }
 
         if (jsonOutput) {
-          print(stringifyJson({
+          const output = {
             ok: true,
             room,
-            objectId: result.objectId,
+            scope: result.scope,
             nodeCount: result.graph.nodes.length,
             edgeCount: result.graph.edges.length
-          }));
+          };
+          if (result.scope.object) {
+            output.objectId = result.scope.object;
+          }
+          print(stringifyJson(output));
         } else {
           const lines = [
             'Sent Scene Sync graph.',
-            `Room: ${room}`,
-            `Object: ${result.objectId}`,
-            `Nodes: ${result.graph.nodes.length}`,
-            `Edges: ${result.graph.edges.length}`
+            `Room: ${room}`
           ];
+          if (result.scope.object) {
+            lines.push(`Object: ${result.scope.object}`);
+          } else if (result.scope.scene) {
+            lines.push('Scope: scene');
+          }
+          lines.push(`Nodes: ${result.graph.nodes.length}`);
+          lines.push(`Edges: ${result.graph.edges.length}`);
           print(lines.join('\n'));
         }
         return 0;

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -26,7 +26,9 @@ import {
   sceneEffectsToBroadcastOps,
   sceneEffectsToBroadcastPayload,
   createSceneGraphSetPayload,
-  createSceneGraphClearPayload
+  createSceneGraphClearPayload,
+  compileLoomToSceneSyncGraph,
+  loomGraphToSceneSyncGraph
 } from '../src/scenesync/index.js';
 
 function print(message = '') {
@@ -188,22 +190,25 @@ function getSceneSyncHelp() {
   loom scenesync <command> [options]
 
 Commands:
-  redeem <code>        Redeem a Scene Sync AI link code
-  session              Show saved Scene Sync session
-  status               Alias for session
-  logout               Clear saved Scene Sync session
-  run <file>           Convert Loom scene effects to Scene Sync broadcast payload
-  graph-set <obj> <g>  Set a Loom graph behavior on a Scene Sync object
-  graph-clear <obj>    Clear Loom graph behavior from a Scene Sync object
-  ping                 Check Scene Sync room connection
-  info                 Get room information
-  objects              List scene objects
-  list-objects         Alias for objects
+  redeem <code>            Redeem a Scene Sync AI link code
+  session                  Show saved Scene Sync session
+  status                   Alias for session
+  logout                   Clear saved Scene Sync session
+  run <file>               Convert Loom scene effects to Scene Sync broadcast payload
+  graph-compile <file>     Compile Loom DSL to Scene Sync behavior graph
+  graph-run <file>         Compile and set a Scene Sync graph from Loom DSL
+  graph-set <obj> <g>      Set a Loom graph behavior on a Scene Sync object
+  graph-clear <obj>        Clear Loom graph behavior from a Scene Sync object
+  ping                     Check Scene Sync room connection
+  info                     Get room information
+  objects                  List scene objects
+  list-objects             Alias for objects
 
 Options:
   --save               Save redeemed session locally
   --dry-run            Print payload without sending (default for run, graph-set, graph-clear)
   --send               Broadcast payload to Scene Sync
+  --object <id>        Scene object ID (for graph-compile and graph-run)
   --room <room>        Scene Sync room code
   --session <id>       Scene Sync session ID
   --endpoint <url>     Scene Sync command endpoint. Default: ${DEFAULT_SCENESYNC_ENDPOINT}
@@ -212,13 +217,16 @@ Options:
 Examples:
   loom scenesync run examples/scene-effects.loom
   loom scenesync run examples/scene-effects.loom --send
+  loom scenesync graph-compile examples/lissajous.loom
+  loom scenesync graph-run examples/lissajous.loom --object sample-cube
+  loom scenesync graph-run examples/lissajous.loom --object sample-cube --send
   loom scenesync graph-set sample-cube examples/scene-graphs/lissajous.json
   loom scenesync graph-set sample-cube examples/scene-graphs/lissajous.json --send
   loom scenesync graph-clear sample-cube --send
 
 Graph Commands:
-  By default graph-set and graph-clear are dry-run. Pass --send to broadcast.
-  graph-set does not require room/session in dry-run mode.
+  By default graph-set, graph-clear, and graph-run are dry-run. Pass --send to broadcast.
+  graph-compile and graph-run do not require room/session in dry-run mode.
 
 Environment Variables:
   LOOM_SCENESYNC_ROOM              Default room code
@@ -655,6 +663,122 @@ async function parseSceneSyncGraphClearArgs(args) {
   }
 
   return { objectId, room, session, endpoint, dryRun, send, json };
+}
+
+async function parseSceneSyncGraphCompileArgs(args) {
+  let file = null;
+  let objectId = null;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (file === null && !arg.startsWith('-')) {
+      file = arg;
+    } else if (arg === '--object') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--object requires an object ID');
+      }
+      objectId = next;
+      index += 1;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!file) {
+    throw new Error('graph-compile requires a file path');
+  }
+
+  return { file, objectId, json };
+}
+
+async function parseSceneSyncGraphRunArgs(args) {
+  let file = null;
+  let objectId = null;
+  let room = '';
+  let session = '';
+  let endpoint = '';
+  let dryRun = true;
+  let send = false;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (file === null && !arg.startsWith('-')) {
+      file = arg;
+    } else if (arg === '--object') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--object requires an object ID');
+      }
+      objectId = next;
+      index += 1;
+    } else if (arg === '--room') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--room requires a room code');
+      }
+      room = next;
+      index += 1;
+    } else if (arg === '--session') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--session requires a session ID');
+      }
+      session = next;
+      index += 1;
+    } else if (arg === '--endpoint') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('--endpoint requires a URL');
+      }
+      endpoint = next;
+      index += 1;
+    } else if (arg === '--send') {
+      send = true;
+      dryRun = false;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!file) {
+    throw new Error('graph-run requires a file path');
+  }
+
+  const savedSession = await loadSceneSyncSession();
+  const savedData = savedSession.ok && savedSession.session ? savedSession.session : null;
+
+  if (!room && send) {
+    room = process.env.LOOM_SCENESYNC_ROOM || '';
+    if (!room && savedData) {
+      room = savedData.roomId || '';
+    }
+  }
+
+  if (!session && send) {
+    session = process.env.LOOM_SCENESYNC_SESSION || '';
+    if (!session && savedData) {
+      session = savedData.sessionId || '';
+    }
+  }
+
+  if (!endpoint) {
+    endpoint = process.env.LOOM_SCENESYNC_ENDPOINT || '';
+    if (!endpoint && savedData) {
+      endpoint = savedData.endpoint || '';
+    }
+    if (!endpoint) {
+      endpoint = DEFAULT_SCENESYNC_ENDPOINT;
+    }
+  }
+
+  return { file, objectId, room, session, endpoint, dryRun, send, json };
 }
 
 async function handleCompile(args) {
@@ -1291,6 +1415,95 @@ async function handleSceneSync(args) {
             'Cleared Scene Sync graph.',
             `Room: ${room}`,
             `Object: ${objectId}`
+          ];
+          print(lines.join('\n'));
+        }
+        return 0;
+      }
+    } catch (error) {
+      printError(error.message || String(error));
+      return 1;
+    }
+  }
+
+  if (subcommand === 'graph-compile') {
+    const { file, objectId, json: jsonOutput } = await parseSceneSyncGraphCompileArgs(rest);
+
+    try {
+      const source = await readSourceFile(file);
+      const result = compileLoomToSceneSyncGraph(source, { objectId });
+
+      if (jsonOutput) {
+        print(stringifyJson({
+          ok: true,
+          objectId: result.objectId,
+          graph: result.graph
+        }));
+      } else {
+        print(stringifyJson(result.graph, true));
+      }
+      return 0;
+    } catch (error) {
+      printError(error.message || String(error));
+      return 1;
+    }
+  }
+
+  if (subcommand === 'graph-run') {
+    const { file, objectId, room, session, endpoint, dryRun, send, json: jsonOutput } = await parseSceneSyncGraphRunArgs(rest);
+
+    try {
+      const source = await readSourceFile(file);
+      const result = compileLoomToSceneSyncGraph(source, { objectId });
+
+      if (!result.objectId) {
+        throw new Error('OBJECT_REQUIRED - Pass --object <objectId> or include an object id in scene.setPosition(...)');
+      }
+
+      const payload = createSceneGraphSetPayload(result.objectId, result.graph);
+
+      if (dryRun) {
+        if (jsonOutput) {
+          print(stringifyJson({
+            ok: true,
+            dryRun: true,
+            payload
+          }));
+        } else {
+          print('Scene Sync graph-set payload:');
+          print(stringifyJson(payload, true));
+          print('Dry run only. Pass --send to broadcast to Scene Sync.');
+        }
+        return 0;
+      }
+
+      if (send) {
+        requireSceneSyncRoom(room);
+        requireSceneSyncSession(session);
+
+        const client = new SceneSyncClient({ endpoint });
+        const broadcastResult = await client.broadcast({ room, session, payload });
+
+        if (!broadcastResult.ok) {
+          printError(formatSceneSyncError(broadcastResult.error));
+          return 1;
+        }
+
+        if (jsonOutput) {
+          print(stringifyJson({
+            ok: true,
+            room,
+            objectId: result.objectId,
+            nodeCount: result.graph.nodes.length,
+            edgeCount: result.graph.edges.length
+          }));
+        } else {
+          const lines = [
+            'Sent Scene Sync graph.',
+            `Room: ${room}`,
+            `Object: ${result.objectId}`,
+            `Nodes: ${result.graph.nodes.length}`,
+            `Edges: ${result.graph.edges.length}`
           ];
           print(lines.join('\n'));
         }

--- a/docs/CLI_ROADMAP.md
+++ b/docs/CLI_ROADMAP.md
@@ -54,13 +54,13 @@
 
 ## Phase 7: SceneSync follow-up
 
-- compile DSL and send graph
+- ✓ compile DSL and send graph
 - ✓ `loom scenesync run <file.loom>` (with dry-run payload generation)
-- `loom scenesync send-graph <file.json>`
+- ✓ `loom scenesync graph-compile <file.loom>` (compile to Scene Sync behavior graph)
+- ✓ `loom scenesync graph-run <file.loom> --object <id> [--send]` (compile and set graph)
+- `loom scenesync graph-patch <file.loom>` (patch graph)
 - target scene scope
 - target object scope
-- clear graph
-- patch graph
 - `loom repl :connect scenesync`
 - `loom repl :objects`
 

--- a/examples/lissajous.loom
+++ b/examples/lissajous.loom
@@ -1,0 +1,10 @@
+import time
+import math
+import scene
+
+t = time.serverClock()
+
+x = math.sine(t, freq: 0.2, amplitude: 2, offset: 0)
+y = math.sine(t, freq: 0.3, amplitude: 0.5, offset: 1.2)
+
+scene.setPosition("sample-cube", x: x, y: y, z: 0)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/loom.js
+++ b/src/loom.js
@@ -1219,6 +1219,37 @@ export const NODE_TYPES = {
       console.log(params.label || 'log', inputs.value);
       return {};
     }
+  },
+
+  'time.serverClock': {
+    category: 'source',
+    inputs: [],
+    outputs: [{ name: 't', type: 'number', kind: 'behavior' }],
+    params: [],
+    evaluate: (inputs, params, ctx) => ({ t: ctx.time })
+  },
+
+  'math.sine': {
+    category: 'transform',
+    inputs: [
+      { name: 't', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'freq', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'amplitude', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'offset', type: 'number', default: 0, kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'number', kind: 'behavior' }],
+    params: [
+      { name: 'freq', type: 'number', default: 1 },
+      { name: 'amplitude', type: 'number', default: 1 },
+      { name: 'offset', type: 'number', default: 0 }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      const t = inputs.t;
+      const freq = inputs.freq;
+      const amplitude = inputs.amplitude;
+      const offset = inputs.offset;
+      return { out: Math.sin(t * freq * 2 * Math.PI) * amplitude + offset };
+    }
   }
 };
 

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -1,0 +1,134 @@
+import { compileLoomSource } from '../toolchain/compile.js';
+
+const SUPPORTED_NODES = new Set([
+  'time.serverClock',
+  'math.sine',
+  'scene.setPosition'
+]);
+
+const NODE_TYPE_MAPPING = {
+  'time.serverClock': 'serverClock',
+  'math.sine': 'sine',
+  'scene.setPosition': 'sceneSetPosition'
+};
+
+const OUTPUT_PORT_MAPPING = {
+  'time.serverClock': 't',
+  'serverClock': 't',
+  'math.sine': 'out',
+  'sine': 'out',
+  'scene.setPosition': undefined,
+  'sceneSetPosition': undefined
+};
+
+function getDefaultOutputPort(nodeType) {
+  const mapped = NODE_TYPE_MAPPING[nodeType] || nodeType;
+  return OUTPUT_PORT_MAPPING[mapped];
+}
+
+function generateStableNodeId(originalId, nodeType) {
+  const mapped = NODE_TYPE_MAPPING[nodeType] || nodeType;
+  if (mapped === 'serverClock') return 'clock';
+  if (originalId && !originalId.startsWith('_')) return originalId;
+  if (mapped === 'sine') {
+    const match = originalId?.match(/sine[_x_y]?(.*)$/);
+    if (match && match[1]) return `sine_${match[1]}`;
+    return 'sine';
+  }
+  if (mapped === 'sceneSetPosition') return 'pos';
+  return originalId;
+}
+
+export function compileLoomToSceneSyncGraph(source, options = {}) {
+  const result = compileLoomSource(source, { target: 'scenesync' });
+
+  if (!result.ok) {
+    throw new Error(`Compilation failed: ${result.errors.map(e => e.message).join(', ')}`);
+  }
+
+  return loomGraphToSceneSyncGraph(result.graph, options);
+}
+
+export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
+  if (!loomGraph || !loomGraph.nodes || !loomGraph.edges) {
+    throw new Error('loomGraph must have nodes and edges arrays');
+  }
+
+  const nodes = [];
+  const edges = [];
+  const nodeIdMap = new Map();
+
+  for (const node of loomGraph.nodes) {
+    if (!SUPPORTED_NODES.has(node.type)) {
+      throw new Error(`Unsupported Scene Sync graph node: ${node.type}`);
+    }
+
+    const sceneSyncType = NODE_TYPE_MAPPING[node.type];
+    const newId = generateStableNodeId(node.id, node.type);
+    nodeIdMap.set(node.id, newId);
+
+    const sceneSyncNode = {
+      id: newId,
+      type: sceneSyncType
+    };
+
+    if (node.type === 'scene.setPosition') {
+      sceneSyncNode.params = {};
+      if (node.params?.z !== undefined) {
+        sceneSyncNode.params.z = node.params.z;
+      }
+      if (node.params?.x !== undefined) {
+        sceneSyncNode.params.x = node.params.x;
+      }
+      if (node.params?.y !== undefined) {
+        sceneSyncNode.params.y = node.params.y;
+      }
+    } else if (node.type === 'math.sine') {
+      sceneSyncNode.params = {};
+      if (node.params?.freq !== undefined) {
+        sceneSyncNode.params.freq = node.params.freq;
+      }
+      if (node.params?.amplitude !== undefined) {
+        sceneSyncNode.params.amplitude = node.params.amplitude;
+      }
+      if (node.params?.offset !== undefined) {
+        sceneSyncNode.params.offset = node.params.offset;
+      }
+    }
+
+    nodes.push(sceneSyncNode);
+  }
+
+  for (const edge of loomGraph.edges) {
+    const [fromNodeId, fromPort] = edge.from.split('.');
+    const [toNodeId, toPort] = edge.to.split('.');
+
+    const newFromId = nodeIdMap.get(fromNodeId);
+    const newToId = nodeIdMap.get(toNodeId);
+
+    if (newFromId && newToId) {
+      edges.push({
+        from: `${newFromId}.${fromPort}`,
+        to: `${newToId}.${toPort}`
+      });
+    }
+  }
+
+  let objectId = options.objectId;
+  if (!objectId) {
+    for (const node of loomGraph.nodes) {
+      if (node.type === 'scene.setPosition' && node.params?.objectId) {
+        objectId = node.params.objectId;
+        break;
+      }
+    }
+  }
+
+  return {
+    graph: {
+      nodes,
+      edges
+    },
+    objectId
+  };
+}

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -39,6 +39,16 @@ function generateStableNodeId(originalId, nodeType) {
   return originalId;
 }
 
+function normalizeScope(options = {}) {
+  if (options.scope) {
+    return options.scope;
+  }
+  if (options.objectId) {
+    return { object: options.objectId };
+  }
+  return null;
+}
+
 export function compileLoomToSceneSyncGraph(source, options = {}) {
   const result = compileLoomSource(source, { target: 'scenesync' });
 
@@ -114,11 +124,12 @@ export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
     }
   }
 
-  let objectId = options.objectId;
-  if (!objectId) {
+  let scope = normalizeScope(options);
+
+  if (!scope) {
     for (const node of loomGraph.nodes) {
       if (node.type === 'scene.setPosition' && node.params?.objectId) {
-        objectId = node.params.objectId;
+        scope = { object: node.params.objectId };
         break;
       }
     }
@@ -129,6 +140,6 @@ export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
       nodes,
       edges
     },
-    objectId
+    scope
   };
 }

--- a/src/scenesync/graphs.js
+++ b/src/scenesync/graphs.js
@@ -36,16 +36,44 @@ function validateSceneGraph(graph) {
   }
 }
 
-export function createSceneGraphSetPayload(objectId, graph) {
-  if (typeof objectId !== 'string' || objectId.length === 0) {
+function validateScope(scope) {
+  if (!scope || typeof scope !== 'object') {
+    throw new Error('scope must be an object');
+  }
+  if (scope.object && (typeof scope.object !== 'string' || scope.object.length === 0)) {
+    throw new Error('scope.object must be a non-empty string');
+  }
+  if (scope.scene !== undefined && typeof scope.scene !== 'boolean') {
+    throw new Error('scope.scene must be a boolean');
+  }
+  if (!scope.object && !scope.scene) {
+    throw new Error('scope must have either object or scene');
+  }
+}
+
+export function createSceneGraphSetPayload(scopeOrObjectId, graphOrUndefined) {
+  let scope;
+  let graph;
+
+  if (typeof scopeOrObjectId === 'string') {
+    if (scopeOrObjectId.length === 0) {
+      throw new Error('objectId must be a non-empty string');
+    }
+    scope = { object: scopeOrObjectId };
+    graph = graphOrUndefined;
+  } else if (typeof scopeOrObjectId === 'object' && scopeOrObjectId !== null) {
+    scope = scopeOrObjectId;
+    graph = graphOrUndefined;
+  } else {
     throw new Error('objectId must be a non-empty string');
   }
 
+  validateScope(scope);
   validateSceneGraph(graph);
 
   return {
     type: 'scene-graph-set',
-    scope: { object: objectId },
+    scope,
     graph
   };
 }

--- a/src/scenesync/index.js
+++ b/src/scenesync/index.js
@@ -3,3 +3,4 @@ export * from './commands.js';
 export * from './session-store.js';
 export * from './effects.js';
 export * from './graphs.js';
+export * from './graph-adapter.js';

--- a/src/toolchain/runtime-targets.js
+++ b/src/toolchain/runtime-targets.js
@@ -1,6 +1,11 @@
 export const RUNTIME_TARGETS = ['cli', 'web', 'scenesync', 'unity', 'any'];
 
 export const LIBRARY_COMPATIBILITY = {
+  time: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'source',
+    description: 'Time-based source nodes'
+  },
   math: {
     targets: ['cli', 'web', 'scenesync', 'unity'],
     kind: 'pure',

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -532,7 +532,7 @@ test('scenesync graph-compile --json prints metadata', () => {
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.ok, true);
-  assert.equal(output.objectId, 'sample-cube');
+  assert.deepEqual(output.scope, { object: 'sample-cube' });
   assert.ok(output.graph.nodes);
   assert.ok(output.graph.edges);
 });
@@ -542,7 +542,7 @@ test('scenesync graph-compile --object overrides object id', () => {
 
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
-  assert.equal(output.objectId, 'other-cube');
+  assert.deepEqual(output.scope, { object: 'other-cube' });
 });
 
 test('scenesync graph-compile without file exits 1', () => {
@@ -579,7 +579,7 @@ test('scenesync graph-run without --object uses DSL object id', () => {
   assert.match(result.stdout, /sample-cube/);
 });
 
-test('scenesync graph-run without object id exits 1', async () => {
+test('scenesync graph-run without scope exits 1', async () => {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-no-object-'));
   const file = path.join(tmpDir, 'no-object.loom');
   await fsp.writeFile(file, 'import time\nimport math\n\nt = time.serverClock()\nx = math.sine(t, freq: 1, amplitude: 1, offset: 0)\n', 'utf8');
@@ -587,7 +587,7 @@ test('scenesync graph-run without object id exits 1', async () => {
   const result = runCli(['scenesync', 'graph-run', file]);
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /OBJECT_REQUIRED/);
+  assert.match(result.stderr, /SCOPE_REQUIRED/);
 });
 
 test('scenesync graph-run without file exits 1', () => {
@@ -595,4 +595,34 @@ test('scenesync graph-run without file exits 1', () => {
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /file path/);
+});
+
+test('scenesync graph-compile --scene creates scene scope', () => {
+  const result = runCli(['scenesync', 'graph-compile', 'examples/lissajous.loom', '--scene', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.scope, { scene: true });
+});
+
+test('scenesync graph-run --scene creates scene scope', () => {
+  const result = runCli(['scenesync', 'graph-run', 'examples/lissajous.loom', '--scene', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.payload.scope, { scene: true });
+});
+
+test('scenesync graph-compile --object and --scene exits 1', () => {
+  const result = runCli(['scenesync', 'graph-compile', 'examples/lissajous.loom', '--object', 'cube', '--scene']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /SCOPE_CONFLICT/);
+});
+
+test('scenesync graph-run --object and --scene exits 1', () => {
+  const result = runCli(['scenesync', 'graph-run', 'examples/lissajous.loom', '--object', 'cube', '--scene']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /SCOPE_CONFLICT/);
 });

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -513,3 +513,86 @@ test('scenesync run with invalid file exits 1', () => {
 
   assert.equal(result.status, 1);
 });
+
+test('scenesync graph-compile compiles example to Scene Sync graph', () => {
+  const result = runCli(['scenesync', 'graph-compile', 'examples/lissajous.loom']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.ok(output.nodes);
+  assert.ok(output.edges);
+  assert.ok(output.nodes.some((n) => n.type === 'serverClock'));
+  assert.ok(output.nodes.some((n) => n.type === 'sine'));
+  assert.ok(output.nodes.some((n) => n.type === 'sceneSetPosition'));
+});
+
+test('scenesync graph-compile --json prints metadata', () => {
+  const result = runCli(['scenesync', 'graph-compile', 'examples/lissajous.loom', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.ok, true);
+  assert.equal(output.objectId, 'sample-cube');
+  assert.ok(output.graph.nodes);
+  assert.ok(output.graph.edges);
+});
+
+test('scenesync graph-compile --object overrides object id', () => {
+  const result = runCli(['scenesync', 'graph-compile', 'examples/lissajous.loom', '--object', 'other-cube', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.objectId, 'other-cube');
+});
+
+test('scenesync graph-compile without file exits 1', () => {
+  const result = runCli(['scenesync', 'graph-compile']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /file path/);
+});
+
+test('scenesync graph-run dry-run prints payload', () => {
+  const result = runCli(['scenesync', 'graph-run', 'examples/lissajous.loom', '--object', 'sample-cube']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Scene Sync graph-set payload/);
+  assert.match(result.stdout, /"type":\s*"scene-graph-set"/);
+  assert.match(result.stdout, /sample-cube/);
+  assert.match(result.stdout, /Dry run only/);
+});
+
+test('scenesync graph-run --json prints JSON', () => {
+  const result = runCli(['scenesync', 'graph-run', 'examples/lissajous.loom', '--object', 'sample-cube', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.ok, true);
+  assert.equal(output.dryRun, true);
+  assert.ok(output.payload);
+});
+
+test('scenesync graph-run without --object uses DSL object id', () => {
+  const result = runCli(['scenesync', 'graph-run', 'examples/lissajous.loom']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /sample-cube/);
+});
+
+test('scenesync graph-run without object id exits 1', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'loom-cli-no-object-'));
+  const file = path.join(tmpDir, 'no-object.loom');
+  await fsp.writeFile(file, 'import time\nimport math\n\nt = time.serverClock()\nx = math.sine(t, freq: 1, amplitude: 1, offset: 0)\n', 'utf8');
+
+  const result = runCli(['scenesync', 'graph-run', file]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /OBJECT_REQUIRED/);
+});
+
+test('scenesync graph-run without file exits 1', () => {
+  const result = runCli(['scenesync', 'graph-run']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /file path/);
+});

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { compileLoomToSceneSyncGraph, loomGraphToSceneSyncGraph } from '../src/scenesync/graph-adapter.js';
+
+test('compiles lissajous example to Scene Sync graph', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+
+x = math.sine(t, freq: 0.2, amplitude: 2, offset: 0)
+y = math.sine(t, freq: 0.3, amplitude: 0.5, offset: 1.2)
+
+scene.setPosition("sample-cube", x: x, y: y, z: 0)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+
+  assert.equal(result.objectId, 'sample-cube');
+  assert.ok(result.graph.nodes.some((n) => n.type === 'serverClock'));
+  assert.equal(result.graph.nodes.filter((n) => n.type === 'sine').length, 2);
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetPosition'));
+  assert.equal(result.graph.edges.length, 4);
+});
+
+test('--object option overrides DSL object id', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+
+x = math.sine(t, freq: 0.2, amplitude: 2, offset: 0)
+y = math.sine(t, freq: 0.3, amplitude: 0.5, offset: 1.2)
+
+scene.setPosition("sample-cube", x: x, y: y, z: 0)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source, { objectId: 'cube2' });
+  assert.equal(result.objectId, 'cube2');
+});
+
+test('rejects unsupported node with clear error', () => {
+  const source = `
+import console
+
+console.log("hello")
+`;
+
+  assert.throws(
+    () => compileLoomToSceneSyncGraph(source),
+    (error) => error.message.includes('Unsupported Scene Sync graph node: console.log')
+  );
+});
+
+test('preserves literal position params', () => {
+  const source = `
+import scene
+
+scene.setPosition("sample-cube", x: 1, y: 0.5, z: 0)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+  const posNode = result.graph.nodes.find((n) => n.type === 'sceneSetPosition');
+
+  assert.ok(posNode);
+  assert.equal(posNode.params.x, 1);
+  assert.equal(posNode.params.y, 0.5);
+  assert.equal(posNode.params.z, 0);
+  assert.equal(result.graph.edges.length, 0);
+});
+
+test('converts only supported nodes in mixed graph', () => {
+  const loomGraph = {
+    nodes: [
+      { id: 'clock1', type: 'time.serverClock' },
+      { id: 'sine1', type: 'math.sine', params: { freq: 1, amplitude: 1, offset: 0 } },
+      { id: 'pos1', type: 'scene.setPosition', params: { objectId: 'cube', x: 0, y: 0, z: 0 } }
+    ],
+    edges: [
+      { from: 'clock1.t', to: 'sine1.t' },
+      { from: 'sine1.out', to: 'pos1.x' }
+    ]
+  };
+
+  const result = loomGraphToSceneSyncGraph(loomGraph);
+
+  assert.equal(result.graph.nodes.length, 3);
+  assert.ok(result.graph.nodes.some((n) => n.type === 'serverClock'));
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sine'));
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetPosition'));
+});
+
+test('maps node IDs to stable identifiers', () => {
+  const loomGraph = {
+    nodes: [
+      { id: '_anon1', type: 'time.serverClock' }
+    ],
+    edges: []
+  };
+
+  const result = loomGraphToSceneSyncGraph(loomGraph);
+  const clockNode = result.graph.nodes.find((n) => n.type === 'serverClock');
+
+  assert.equal(clockNode.id, 'clock');
+});
+
+test('preserves parameter values from Loom graph to Scene Sync graph', () => {
+  const loomGraph = {
+    nodes: [
+      { id: 'sine1', type: 'math.sine', params: { freq: 2, amplitude: 3, offset: 4 } }
+    ],
+    edges: []
+  };
+
+  const result = loomGraphToSceneSyncGraph(loomGraph);
+  const sineNode = result.graph.nodes.find((n) => n.type === 'sine');
+
+  assert.equal(sineNode.params.freq, 2);
+  assert.equal(sineNode.params.amplitude, 3);
+  assert.equal(sineNode.params.offset, 4);
+});

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -18,7 +18,7 @@ scene.setPosition("sample-cube", x: x, y: y, z: 0)
 
   const result = compileLoomToSceneSyncGraph(source);
 
-  assert.equal(result.objectId, 'sample-cube');
+  assert.deepEqual(result.scope, { object: 'sample-cube' });
   assert.ok(result.graph.nodes.some((n) => n.type === 'serverClock'));
   assert.equal(result.graph.nodes.filter((n) => n.type === 'sine').length, 2);
   assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetPosition'));
@@ -39,8 +39,8 @@ y = math.sine(t, freq: 0.3, amplitude: 0.5, offset: 1.2)
 scene.setPosition("sample-cube", x: x, y: y, z: 0)
 `;
 
-  const result = compileLoomToSceneSyncGraph(source, { objectId: 'cube2' });
-  assert.equal(result.objectId, 'cube2');
+  const result = compileLoomToSceneSyncGraph(source, { scope: { object: 'cube2' } });
+  assert.deepEqual(result.scope, { object: 'cube2' });
 });
 
 test('rejects unsupported node with clear error', () => {
@@ -122,4 +122,38 @@ test('preserves parameter values from Loom graph to Scene Sync graph', () => {
   assert.equal(sineNode.params.freq, 2);
   assert.equal(sineNode.params.amplitude, 3);
   assert.equal(sineNode.params.offset, 4);
+});
+
+test('scope option can use object scope', () => {
+  const source = `
+import scene
+scene.setPosition("cube1", x: 0, y: 0, z: 0)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source, { scope: { object: 'other-cube' } });
+  assert.deepEqual(result.scope, { object: 'other-cube' });
+});
+
+test('scope option can use scene scope', () => {
+  const loomGraph = {
+    nodes: [
+      { id: 'clock1', type: 'time.serverClock' }
+    ],
+    edges: []
+  };
+
+  const result = loomGraphToSceneSyncGraph(loomGraph, { scope: { scene: true } });
+  assert.deepEqual(result.scope, { scene: true });
+});
+
+test('objectId option normalizes to scope', () => {
+  const loomGraph = {
+    nodes: [
+      { id: 'clock1', type: 'time.serverClock' }
+    ],
+    edges: []
+  };
+
+  const result = loomGraphToSceneSyncGraph(loomGraph, { objectId: 'cube3' });
+  assert.deepEqual(result.scope, { object: 'cube3' });
 });


### PR DESCRIPTION
## Summary
This PR adds Scene Sync graph commands that compile Loom DSL into Scene Sync behavior graphs and send them using explicit graph scopes.

It supports both:

- Object-level graph scope: `{ object: "sample-cube" }`
- Scene-level graph scope: `{ scene: true }`

`--object` and `--scene` are scope selectors. If neither is provided, object scope can be inferred from DSL calls such as `scene.setPosition("sample-cube", ...)`.

## Key Changes

- **New `graph-compile` command**: Compiles Loom DSL source files to Scene Sync behavior graphs, with optional `--object` parameter to specify target object ID and `--json` flag for structured output
- **New `graph-run` command**: Compiles Loom DSL and immediately sets the resulting graph on a Scene Sync object, supporting dry-run mode (default) and `--send` flag to broadcast to the room
- **Graph adapter module** (`src/scenesync/graph-adapter.js`): New module that converts compiled Loom graphs to Scene Sync format, supporting `time.serverClock`, `math.sine`, and `scene.setPosition` nodes with stable node ID generation and parameter preservation
- **New node types**: Added `time.serverClock` and `math.sine` node definitions to the Loom runtime with proper inputs, outputs, and evaluation logic
- **Example file**: Added `examples/lissajous.loom` demonstrating a Lissajous curve animation using the new node types
- **Comprehensive test coverage**: Added 11 new tests covering both the graph adapter and CLI commands, including error cases and option handling
- **Updated documentation**: Added help text, examples, and README sections explaining the new commands and their usage

## Implementation Details

- The graph adapter maps Loom node types to Scene Sync equivalents (e.g., `time.serverClock` → `serverClock`, `math.sine` → `sine`)
- Node IDs are normalized to stable identifiers (e.g., anonymous nodes become `clock`, `sine`, `pos`)
- The `graph-run` command reuses existing Scene Sync session management and broadcast infrastructure
- Both commands support `--json` output for programmatic consumption
- Parameter values from Loom graphs are preserved during conversion to Scene Sync format

https://claude.ai/code/session_01Fe7eH2YJWJbW9ffjo948HM