### PR TITLE
Implement standard library baseline nodes (logic, list, text, math, random, debug, console.table, fs)

### DIFF
--- a/docs/NODE_GAPS.md
+++ b/docs/NODE_GAPS.md
@@ -1,20 +1,11 @@
 # Node Gaps
 
 ## High priority
-- logic.equals
-- logic.select
-- logic.and
-- logic.lessOrEqual
-- list.range
-- list.map
-- list.filter
-- text.stringify
+- function values for `list.map`, `list.filter`, `list.reduce`
 - scene.find
 - timeline.cue
 
 ## Medium priority
-- list.reduce
-- list.concat
 - signal.lfo
 - signal.smooth
 - signal.trigger
@@ -24,7 +15,6 @@
 - audio.level
 
 ## Low priority
-- console.table
 - random.seeded
-- debug.inspect
-- fs.list
+- random.noise
+- fs sandboxing and target policy hardening

--- a/docs/STANDARD_LIBRARY_PLAN.md
+++ b/docs/STANDARD_LIBRARY_PLAN.md
@@ -182,7 +182,7 @@ Current:
 Used by tour samples: none
 Recommended baseline: `random.value`, `random.range`, `random.int`, `random.choice`, `random.seeded`, `random.noise`
 Status summary: unseeded baseline implemented; seeded/noise planned
-Targets: cli, scenesync, unity, web
+Targets: cli, web
 
 ## debug
 Purpose: graph-level diagnostics.

--- a/docs/STANDARD_LIBRARY_PLAN.md
+++ b/docs/STANDARD_LIBRARY_PLAN.md
@@ -24,42 +24,49 @@ Targets: cli, scenesync, unity, web
 ## logic
 Purpose: boolean algebra and branching.
 Current:
-- none (no `logic` library today)
+- `logic.not`, `logic.and`, `logic.or`, `logic.equals`, `logic.notEquals`
+- `logic.greaterThan`, `logic.lessThan`, `logic.greaterOrEqual`, `logic.lessOrEqual`
+- `logic.select`, `logic.when`
 Used by tour samples:
 - `logic.equals`, `logic.select`, `logic.and`, `logic.greaterThan`, `logic.lessOrEqual`, `logic.lessThan`, `logic.greaterOrEqual`
 Recommended baseline:
 - `logic.not`, `logic.and`, `logic.or`, `logic.equals`, `logic.notEquals`, `logic.greaterThan`, `logic.lessThan`, `logic.greaterOrEqual`, `logic.lessOrEqual`, `logic.select`, `logic.when`
-Status summary: Implemented: none / Missing: baseline set / Planned: full baseline / Uncertain: event-gated forms
+Status summary: Implemented: baseline set / Missing: event-gated forms / Planned: portability polish / Uncertain: event-gated forms
 Targets: cli, scenesync, unity, web
 
 ## math
 Purpose: numeric transforms.
 Current:
 - `abs`, `add`, `clamp`, `cosine`, `divide`, `greaterThan`, `lerp`, `lessThan`, `map`, `mod`, `multiply`, `negate`, `math.sine`, `smoothstep`, `subtract`
+- `math.add`, `math.subtract`, `math.multiply`, `math.divide`, `math.mod`, `math.abs`
+- `math.floor`, `math.ceil`, `math.round`, `math.min`, `math.max`, `math.tan`, `math.sqrt`, `math.pow`
 Used by tour samples:
 - `add`, `multiply`, `map`, `clamp`, `math.sine`, `mod`
 Recommended baseline:
 - add missing candidates: `floor`, `ceil`, `round`, `min`, `max`, `tan`, `sqrt`, `pow`
-Status summary: Implemented: current set above / Missing: baseline expansion / Planned: portability review / Uncertain: naming unification (`sine` vs `math.sine`)
+Status summary: Implemented: current set above plus baseline expansion and namespace aliases / Missing: none for pure baseline / Planned: portability review / Uncertain: legacy unqualified aliases
 Targets: cli, scenesync, unity, web
 
 ## text
 Purpose: string processing.
 Current:
 - `text.upper`, `text.lower`, `text.trim`, `text.replace`
+- `text.concat`, `text.split`, `text.join`, `text.includes`, `text.startsWith`, `text.endsWith`, `text.length`, `text.isEmpty`, `text.stringify`
 Used by tour samples:
 - `text.upper`, `text.trim`, `text.replace`, `text.stringify` (draft)
 Recommended baseline:
 - `text.concat`, `text.split`, `text.join`, `text.includes`, `text.startsWith`, `text.endsWith`, `text.length`, `text.isEmpty`, `text.stringify`
-Status summary: Implemented: 4 core ops / Missing: stringify and composition helpers / Planned: baseline completion / Uncertain: locale-specific transforms
+Status summary: Implemented: core ops plus baseline additions / Missing: locale-specific transforms / Planned: portability polish / Uncertain: locale-specific transforms
 Targets: cli, scenesync, unity, web
 
 ## list
 Purpose: ordered collection processing.
-Current: none
+Current:
+- `list.of`, `list.range`, `list.length`, `list.at`, `list.first`, `list.last`, `list.join`, `list.reverse`, `list.sort`, `list.take`, `list.drop`, `list.concat`
+- `list.map`, `list.filter`, `list.reduce` are metadata/runtime placeholders that throw `UNSUPPORTED_FUNCTION_VALUE` until function values exist
 Used by tour samples: `list.of`, `list.range`, `list.map`, `list.filter`, `list.reduce`, `list.first`, `list.drop`, `list.concat`, `list.length`, `list.of`
 Recommended baseline: `list.of`, `list.range`, `list.length`, `list.at`, `list.first`, `list.last`, `list.map`, `list.filter`, `list.reduce`, `list.join`, `list.reverse`, `list.sort`, `list.take`, `list.drop`, `list.concat`
-Status summary: Implemented none / Missing foundational set / Planned high priority
+Status summary: Implemented foundational pure list set / Missing function-value execution for map/filter/reduce / Planned high priority
 Targets: cli, scenesync, unity, web
 
 ## object
@@ -117,18 +124,19 @@ Targets: cli, scenesync, unity, web
 ## console
 Purpose: host logging and diagnostics sink.
 Current:
-- `console.log`, `console.warn`, `console.error`
+- `console.log`, `console.warn`, `console.error`, `console.table`
 Used by tour samples: `console.log`
 Recommended baseline: `console.table`
-Status summary: mostly implemented
+Status summary: baseline implemented
 Targets: cli, scenesync, unity, web
 
 ## fs
 Purpose: file IO.
-Current: none (`fs` library is planned)
+Current:
+- CLI-only `fs.readText`, `fs.writeText`, `fs.exists`, `fs.list`
 Used by tour samples: none
 Recommended baseline: `fs.readText`, `fs.writeText`, `fs.exists`, `fs.list`
-Status summary: missing/planned
+Status summary: minimal CLI-only baseline implemented; no browser/web/scenesync/unity support and no sandboxing yet
 Targets: cli
 
 ## scene
@@ -168,16 +176,19 @@ Targets: cli, scenesync, unity, web
 
 ## random
 Purpose: controlled randomness.
-Current: none
+Current:
+- `random.value`, `random.range`, `random.int`, `random.choice`
+- `random.seeded`, `random.noise` are planned metadata only
 Used by tour samples: none
 Recommended baseline: `random.value`, `random.range`, `random.int`, `random.choice`, `random.seeded`, `random.noise`
-Status summary: planned
+Status summary: unseeded baseline implemented; seeded/noise planned
 Targets: cli, scenesync, unity, web
 
 ## debug
 Purpose: graph-level diagnostics.
-Current: none
+Current:
+- `debug.inspect`, `debug.trace`, `debug.assert`
 Used by tour samples: none
 Recommended baseline: `debug.inspect`, `debug.trace`, `debug.assert`
-Status summary: planned
-Targets: cli, scenesync, unity, web
+Status summary: baseline implemented
+Targets: cli, unity, web

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -43,38 +43,38 @@ Loomlet source files use the `.loom` extension.
 
 ### 06 Conditions
 - Path: `examples/tour/language/06-conditions.loom`
-- Status: Draft
+- Status: Runnable
 - Run: `loomlet run examples/tour/language/06-conditions.loom`
 - Teaches: declarative condition + selection
-- Missing: `logic.equals`, `logic.select`
+- Missing: none
 
 ### 07 FizzBuzz
 - Path: `examples/tour/language/07-fizzbuzz.loom`
 - Status: Draft
 - Run: `loomlet run examples/tour/language/07-fizzbuzz.loom`
 - Teaches: range generation, mapping, nested branching
-- Missing: `list.range`, `list.map`, `logic.equals`, `logic.and`, `logic.select`, `text.stringify`, function definitions
+- Missing: `list.map` function-value execution, function definitions
 
 ### 08 List Map Filter
 - Path: `examples/tour/language/08-list-map-filter.loom`
 - Status: Draft
 - Run: `loomlet run examples/tour/language/08-list-map-filter.loom`
 - Teaches: map/filter/reduce collection flow
-- Missing: `list.of`, `list.map`, `list.filter`, `list.reduce`, `logic.greaterThan`, function definitions
+- Missing: `list.map`, `list.filter`, and `list.reduce` function-value execution; function definitions
 
 ### 09 Factorial
 - Path: `examples/tour/language/09-factorial.loom`
 - Status: Draft
 - Run: `loomlet run examples/tour/language/09-factorial.loom`
 - Teaches: recursive definition with base case selection
-- Missing: `logic.lessOrEqual`, `logic.select`, function definitions, recursion
+- Missing: function definitions, recursion
 
 ### 10 Quicksort
 - Path: `examples/tour/language/10-quicksort.loom`
 - Status: Draft
 - Run: `loomlet run examples/tour/language/10-quicksort.loom`
 - Teaches: recursive partition/sort pattern
-- Missing: `list.first`, `list.drop`, `list.filter`, `list.concat`, `list.length`, `list.of`, `logic.lessThan`, `logic.greaterOrEqual`, `logic.lessOrEqual`, `logic.select`, function definitions, recursion
+- Missing: `list.filter` function-value execution, function definitions, recursion
 
 ## Signals
 

--- a/examples/tour/language/06-conditions.loom
+++ b/examples/tour/language/06-conditions.loom
@@ -1,19 +1,17 @@
 # Tour: Conditions
-# Goal: Draft future Loomlet style for value selection.
-# Status: draft
+# Goal: Value selection with logic nodes.
+# Status: runnable
 # Run:
 #   loomlet run examples/tour/language/06-conditions.loom
 # Requires:
 #   - logic.equals
 #   - logic.select
 #   - console.log
-# TODO NODE: logic.equals(value, other:)
-# TODO NODE: logic.select(condition, whenTrue:, whenFalse:)
 
 import logic
 import console
 
-n = 3
+n = constant(value: 3)
 isThree = logic.equals(n, other: 3)
 label = logic.select(isThree, whenTrue: "three", whenFalse: "other")
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/loom.js
+++ b/src/loom.js
@@ -362,6 +362,61 @@ function stringifyJsonValue(value, pretty = false) {
   return JSON.stringify(value, null, pretty ? 2 : 0);
 }
 
+
+function stringifyTextValue(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  const json = JSON.stringify(value);
+  return json === undefined ? '' : json;
+}
+
+function inspectValue(value) {
+  if (typeof value === 'string') return value;
+  const json = JSON.stringify(value, null, 2);
+  return json === undefined ? String(value) : json;
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectInputs(inputs, names) {
+  return names.map((name) => inputs[name]).filter((value) => value !== undefined);
+}
+
+function unsupportedFunctionValueNode(name) {
+  return {
+    category: 'transform',
+    inputs: [
+      { name: 'list', type: 'array', default: [], kind: 'behavior' },
+      { name: 'fn', type: 'function', default: null, kind: 'behavior' },
+      { name: 'initial', type: 'any', default: null, kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'array', kind: 'behavior' }],
+    params: [
+      { name: 'fn', type: 'function', default: null },
+      { name: 'initial', type: 'any', default: null }
+    ],
+    evaluate: () => {
+      throw new LoomError('UNSUPPORTED_FUNCTION_VALUE', `${name} requires function values, which are not implemented yet`);
+    }
+  };
+}
+
+function getNodeFs() {
+  const getBuiltinModule = globalThis.process?.getBuiltinModule;
+  if (typeof getBuiltinModule !== 'function') {
+    throw new LoomError('UNSUPPORTED_RUNTIME_NODE', 'fs nodes are only available in the Node.js CLI runtime');
+  }
+  return getBuiltinModule('fs');
+}
+
+function getNodePath() {
+  return globalThis.process.getBuiltinModule('path');
+}
+
+
 // ノード型レジストリ
 export const NODE_TYPES = {
   // Phase 0 ノード
@@ -952,6 +1007,77 @@ export const NODE_TYPES = {
       out: String(inputs.value ?? '').replaceAll(String(inputs.search ?? ''), String(inputs.replacement ?? ''))
     })
   },
+
+  'text.concat': {
+    category: 'transform',
+    commutative: true,
+    inputs: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined, kind: 'behavior' })),
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined })),
+    evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 8 }, (_, i) => `value${i + 1}`)).map((value) => stringifyTextValue(value)).join('') })
+  },
+  'text.split': {
+    category: 'transform',
+    inputs: [
+      { name: 'value', type: 'any', default: '', kind: 'behavior' },
+      { name: 'separator', type: 'any', default: ',', kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'array', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }, { name: 'separator', type: 'any', default: ',' }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value).split(stringifyTextValue(inputs.separator)) })
+  },
+  'text.join': {
+    category: 'transform',
+    inputs: [
+      { name: 'list', type: 'array', default: [], kind: 'behavior' },
+      { name: 'separator', type: 'any', default: ',', kind: 'behavior' }
+    ],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [{ name: 'list', type: 'array', default: [] }, { name: 'separator', type: 'any', default: ',' }],
+    evaluate: (inputs) => ({ out: toArray(inputs.list).map((value) => stringifyTextValue(value)).join(stringifyTextValue(inputs.separator)) })
+  },
+  'text.includes': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }, { name: 'search', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }, { name: 'search', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value).includes(stringifyTextValue(inputs.search)) })
+  },
+  'text.startsWith': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }, { name: 'search', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }, { name: 'search', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value).startsWith(stringifyTextValue(inputs.search)) })
+  },
+  'text.endsWith': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }, { name: 'search', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }, { name: 'search', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value).endsWith(stringifyTextValue(inputs.search)) })
+  },
+  'text.length': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'number', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value).length })
+  },
+  'text.isEmpty': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: '' }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value).length === 0 })
+  },
+  'text.stringify': {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
+    params: [{ name: 'value', type: 'any', default: null }],
+    evaluate: (inputs) => ({ out: stringifyTextValue(inputs.value) })
+  },
   'json.parse': {
     category: 'transform',
     inputs: [{ name: 'value', type: 'any', default: '', kind: 'behavior' }],
@@ -1005,6 +1131,81 @@ export const NODE_TYPES = {
       return {};
     }
   },
+
+
+  'console.table': {
+    category: 'sink',
+    inputs: [{ name: 'value', type: 'any', default: undefined, kind: 'behavior' }],
+    outputs: [],
+    params: [],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({ type: 'console.table', level: 'table', value: inputs.value, nodeId: ctx.currentNodeId });
+      if (typeof console.table === 'function' && ctx.emitConsole === true) console.table(inputs.value);
+      return {};
+    }
+  },
+
+  'logic.not': { category: 'transform', inputs: [{ name: 'value', type: 'any', default: false, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: false }], evaluate: (inputs) => ({ out: !inputs.value }) },
+  'logic.and': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'any', default: false, kind: 'behavior' }, { name: 'b', type: 'any', default: false, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'a', type: 'any', default: false }, { name: 'b', type: 'any', default: false }], evaluate: (inputs) => ({ out: Boolean(inputs.a && inputs.b) }) },
+  'logic.or': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'any', default: false, kind: 'behavior' }, { name: 'b', type: 'any', default: false, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'a', type: 'any', default: false }, { name: 'b', type: 'any', default: false }], evaluate: (inputs) => ({ out: Boolean(inputs.a || inputs.b) }) },
+  'logic.equals': { category: 'transform', inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }, { name: 'other', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: null }, { name: 'other', type: 'any', default: null }], evaluate: (inputs) => ({ out: Object.is(inputs.value, inputs.other) }) },
+  'logic.notEquals': { category: 'transform', inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }, { name: 'other', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: null }, { name: 'other', type: 'any', default: null }], evaluate: (inputs) => ({ out: !Object.is(inputs.value, inputs.other) }) },
+  'logic.greaterThan': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'other', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'other', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.value > inputs.other }) },
+  'logic.lessThan': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'other', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'other', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.value < inputs.other }) },
+  'logic.greaterOrEqual': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'other', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'other', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.value >= inputs.other }) },
+  'logic.lessOrEqual': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'other', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'other', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.value <= inputs.other }) },
+  'logic.select': { category: 'transform', inputs: [{ name: 'condition', type: 'any', default: false, kind: 'behavior' }, { name: 'whenTrue', type: 'any', default: null, kind: 'behavior' }, { name: 'whenFalse', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'condition', type: 'any', default: false }, { name: 'whenTrue', type: 'any', default: null }, { name: 'whenFalse', type: 'any', default: null }], evaluate: (inputs) => ({ out: inputs.condition ? inputs.whenTrue : inputs.whenFalse }) },
+  'logic.when': { category: 'transform', inputs: [{ name: 'condition', type: 'any', default: false, kind: 'behavior' }, { name: 'value', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'condition', type: 'any', default: false }, { name: 'value', type: 'any', default: null }], evaluate: (inputs) => ({ out: inputs.condition ? inputs.value : null }) },
+
+  'list.of': { category: 'transform', commutative: true, inputs: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined, kind: 'behavior' })), outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined })), evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 8 }, (_, i) => `value${i + 1}`)) }) },
+  'list.range': { category: 'transform', inputs: [{ name: 'start', type: 'number', default: 0, kind: 'behavior' }, { name: 'end', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'start', type: 'number', default: 0 }, { name: 'end', type: 'number', default: 0 }], evaluate: (inputs) => { const start = Math.trunc(inputs.start); const end = Math.trunc(inputs.end); const step = start <= end ? 1 : -1; const out = []; for (let n = start; step > 0 ? n <= end : n >= end; n += step) out.push(n); return { out }; } },
+  'list.length': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => ({ out: toArray(inputs.list).length }) },
+  'list.at': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'index', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'index', type: 'number', default: 0 }], evaluate: (inputs) => { const list = toArray(inputs.list); const raw = Math.trunc(inputs.index); const index = raw < 0 ? list.length + raw : raw; return { out: index >= 0 && index < list.length ? list[index] : null }; } },
+  'list.first': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => ({ out: toArray(inputs.list)[0] ?? null }) },
+  'list.last': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => { const list = toArray(inputs.list); return { out: list.length ? list[list.length - 1] : null }; } },
+  'list.map': unsupportedFunctionValueNode('list.map'),
+  'list.filter': unsupportedFunctionValueNode('list.filter'),
+  'list.reduce': unsupportedFunctionValueNode('list.reduce'),
+  'list.join': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'separator', type: 'any', default: ',', kind: 'behavior' }], outputs: [{ name: 'out', type: 'string', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'separator', type: 'any', default: ',' }], evaluate: (inputs) => ({ out: toArray(inputs.list).map((value) => stringifyTextValue(value)).join(stringifyTextValue(inputs.separator)) }) },
+  'list.reverse': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => ({ out: [...toArray(inputs.list)].reverse() }) },
+  'list.sort': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => { const list = [...toArray(inputs.list)]; if (list.every((value) => typeof value === 'number')) list.sort((a, b) => a - b); else list.sort((a, b) => String(a).localeCompare(String(b))); return { out: list }; } },
+  'list.take': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'count', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'count', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: toArray(inputs.list).slice(0, Math.max(0, Math.trunc(inputs.count))) }) },
+  'list.drop': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'count', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'count', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: toArray(inputs.list).slice(Math.max(0, Math.trunc(inputs.count))) }) },
+  'list.concat': { category: 'transform', commutative: true, inputs: Array.from({ length: 4 }, (_, i) => ({ name: `list${i + 1}`, type: 'array', default: undefined, kind: 'behavior' })), outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: Array.from({ length: 4 }, (_, i) => ({ name: `list${i + 1}`, type: 'array', default: undefined })), evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 4 }, (_, i) => `list${i + 1}`)).flatMap((value) => toArray(value)) }) },
+
+  'math.add': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.a + inputs.b }) },
+  'math.subtract': { category: 'transform', inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.a - inputs.b }) },
+  'math.multiply': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'number', default: 1, kind: 'behavior' }, { name: 'b', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 1 }, { name: 'b', type: 'number', default: 1 }], evaluate: (inputs) => ({ out: inputs.a * inputs.b }) },
+  'math.divide': { category: 'transform', inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 1 }], evaluate: (inputs) => ({ out: inputs.b === 0 ? 0 : inputs.a / inputs.b }) },
+  'math.mod': { category: 'transform', inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 1 }], evaluate: (inputs) => ({ out: inputs.b === 0 ? 0 : ((inputs.a % inputs.b) + inputs.b) % inputs.b }) },
+  'math.abs': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.abs(inputs.value) }) },
+  'math.clamp': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'min', type: 'number', default: 0, kind: 'behavior' }, { name: 'max', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'min', type: 'number', default: 0 }, { name: 'max', type: 'number', default: 1 }], evaluate: (inputs) => ({ out: inputs.min > inputs.max ? inputs.min : Math.max(inputs.min, Math.min(inputs.max, inputs.value)) }) },
+  'math.map': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'inMin', type: 'number', default: 0, kind: 'behavior' }, { name: 'inMax', type: 'number', default: 1, kind: 'behavior' }, { name: 'outMin', type: 'number', default: 0, kind: 'behavior' }, { name: 'outMax', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'inMin', type: 'number', default: 0 }, { name: 'inMax', type: 'number', default: 1 }, { name: 'outMin', type: 'number', default: 0 }, { name: 'outMax', type: 'number', default: 1 }, { name: 'clamp', type: 'boolean', default: false }], evaluate: (inputs, params) => { if (inputs.inMax === inputs.inMin) return { out: inputs.outMin }; let t = (inputs.value - inputs.inMin) / (inputs.inMax - inputs.inMin); if (params.clamp === true) t = Math.max(0, Math.min(1, t)); return { out: inputs.outMin + (inputs.outMax - inputs.outMin) * t }; } },
+  'math.lerp': { category: 'transform', inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 1, kind: 'behavior' }, { name: 't', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 1 }, { name: 't', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.a + (inputs.b - inputs.a) * inputs.t }) },
+  'math.smoothstep': { category: 'transform', inputs: [{ name: 'x', type: 'number', default: 0, kind: 'behavior' }, { name: 'edge0', type: 'number', default: 0, kind: 'behavior' }, { name: 'edge1', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'x', type: 'number', default: 0 }, { name: 'edge0', type: 'number', default: 0 }, { name: 'edge1', type: 'number', default: 1 }], evaluate: (inputs) => { if (inputs.edge0 === inputs.edge1) return { out: inputs.x < inputs.edge0 ? 0 : 1 }; let t = (inputs.x - inputs.edge0) / (inputs.edge1 - inputs.edge0); t = Math.max(0, Math.min(1, t)); return { out: t * t * (3 - 2 * t) }; } },
+  'math.cosine': { category: 'transform', inputs: [{ name: 't', type: 'number', default: 0, kind: 'behavior' }, { name: 'freq', type: 'number', default: 1, kind: 'behavior' }, { name: 'amplitude', type: 'number', default: 1, kind: 'behavior' }, { name: 'phase', type: 'number', default: 0, kind: 'behavior' }, { name: 'offset', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'freq', type: 'number', default: 1 }, { name: 'amplitude', type: 'number', default: 1 }, { name: 'phase', type: 'number', default: 0 }, { name: 'offset', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.cos(inputs.t * inputs.freq * 2 * Math.PI + inputs.phase) * inputs.amplitude + inputs.offset }) },
+  'math.floor': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.floor(inputs.value) }) },
+  'math.ceil': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.ceil(inputs.value) }) },
+  'math.round': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.round(inputs.value) }) },
+  'math.min': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.min(inputs.a, inputs.b) }) },
+  'math.max': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.max(inputs.a, inputs.b) }) },
+  'math.tan': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.tan(inputs.value) }) },
+  'math.sqrt': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: Math.sqrt(inputs.value) }) },
+  'math.pow': { category: 'transform', inputs: [{ name: 'value', type: 'number', default: 0, kind: 'behavior' }, { name: 'exponent', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'value', type: 'number', default: 0 }, { name: 'exponent', type: 'number', default: 1 }], evaluate: (inputs) => ({ out: Math.pow(inputs.value, inputs.exponent) }) },
+
+  'random.value': { category: 'source', inputs: [], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [], evaluate: () => ({ out: Math.random() }) },
+  'random.range': { category: 'transform', inputs: [{ name: 'min', type: 'number', default: 0, kind: 'behavior' }, { name: 'max', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'min', type: 'number', default: 0 }, { name: 'max', type: 'number', default: 1 }], evaluate: (inputs) => ({ out: inputs.min + Math.random() * (inputs.max - inputs.min) }) },
+  'random.int': { category: 'transform', inputs: [{ name: 'min', type: 'number', default: 0, kind: 'behavior' }, { name: 'max', type: 'number', default: 1, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'min', type: 'number', default: 0 }, { name: 'max', type: 'number', default: 1 }], evaluate: (inputs) => { const min = Math.ceil(Math.min(inputs.min, inputs.max)); const max = Math.floor(Math.max(inputs.min, inputs.max)); return { out: Math.floor(Math.random() * (max - min + 1)) + min }; } },
+  'random.choice': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => { const list = toArray(inputs.list); return { out: list.length ? list[Math.floor(Math.random() * list.length)] : null }; } },
+
+  'debug.inspect': { category: 'transform', inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'string', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: null }], evaluate: (inputs) => ({ out: inspectValue(inputs.value) }) },
+  'debug.trace': { category: 'transform', inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }, { name: 'label', type: 'string', default: 'trace', kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: null }, { name: 'label', type: 'string', default: 'trace' }], evaluate: (inputs, params, ctx) => { ctx.engine?._recordEffect({ type: 'debug.trace', label: inputs.label, value: inputs.value, nodeId: ctx.currentNodeId }); return { out: inputs.value }; } },
+  'debug.assert': { category: 'transform', inputs: [{ name: 'condition', type: 'any', default: false, kind: 'behavior' }, { name: 'message', type: 'string', default: 'Assertion failed', kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'condition', type: 'any', default: false }, { name: 'message', type: 'string', default: 'Assertion failed' }], evaluate: (inputs) => { if (!inputs.condition) throw new LoomError('ASSERTION_FAILED', stringifyTextValue(inputs.message) || 'Assertion failed'); return { out: true }; } },
+
+  'fs.readText': { category: 'source', inputs: [{ name: 'path', type: 'string', default: '', kind: 'behavior' }], outputs: [{ name: 'out', type: 'string', kind: 'behavior' }], params: [{ name: 'path', type: 'string', default: '' }], evaluate: (inputs) => ({ out: getNodeFs().readFileSync(String(inputs.path), 'utf8') }) },
+  'fs.writeText': { category: 'sink', inputs: [{ name: 'path', type: 'string', default: '', kind: 'behavior' }, { name: 'value', type: 'any', default: '', kind: 'behavior' }], outputs: [], params: [{ name: 'path', type: 'string', default: '' }, { name: 'value', type: 'any', default: '' }], evaluate: (inputs) => { const fs = getNodeFs(); const path = getNodePath(); fs.mkdirSync(path.dirname(String(inputs.path)), { recursive: true }); fs.writeFileSync(String(inputs.path), stringifyTextValue(inputs.value), 'utf8'); return {}; } },
+  'fs.exists': { category: 'source', inputs: [{ name: 'path', type: 'string', default: '', kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'path', type: 'string', default: '' }], evaluate: (inputs) => ({ out: getNodeFs().existsSync(String(inputs.path)) }) },
+  'fs.list': { category: 'source', inputs: [{ name: 'path', type: 'string', default: '.', kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'path', type: 'string', default: '.' }], evaluate: (inputs) => ({ out: getNodeFs().readdirSync(String(inputs.path)) }) },
 
   // Scene Sync effect nodes
   'scene.setPosition': {

--- a/src/loom.js
+++ b/src/loom.js
@@ -385,7 +385,7 @@ function collectInputs(inputs, names) {
   return names.map((name) => inputs[name]).filter((value) => value !== undefined);
 }
 
-function unsupportedFunctionValueNode(name) {
+function unsupportedFunctionValueNode(name, outputType = 'array') {
   return {
     category: 'transform',
     inputs: [
@@ -393,7 +393,7 @@ function unsupportedFunctionValueNode(name) {
       { name: 'fn', type: 'function', default: null, kind: 'behavior' },
       { name: 'initial', type: 'any', default: null, kind: 'behavior' }
     ],
-    outputs: [{ name: 'out', type: 'array', kind: 'behavior' }],
+    outputs: [{ name: 'out', type: outputType, kind: 'behavior' }],
     params: [
       { name: 'fn', type: 'function', default: null },
       { name: 'initial', type: 'any', default: null }
@@ -1010,7 +1010,6 @@ export const NODE_TYPES = {
 
   'text.concat': {
     category: 'transform',
-    commutative: true,
     inputs: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined, kind: 'behavior' })),
     outputs: [{ name: 'out', type: 'string', kind: 'behavior' }],
     params: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined })),
@@ -1157,21 +1156,21 @@ export const NODE_TYPES = {
   'logic.select': { category: 'transform', inputs: [{ name: 'condition', type: 'any', default: false, kind: 'behavior' }, { name: 'whenTrue', type: 'any', default: null, kind: 'behavior' }, { name: 'whenFalse', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'condition', type: 'any', default: false }, { name: 'whenTrue', type: 'any', default: null }, { name: 'whenFalse', type: 'any', default: null }], evaluate: (inputs) => ({ out: inputs.condition ? inputs.whenTrue : inputs.whenFalse }) },
   'logic.when': { category: 'transform', inputs: [{ name: 'condition', type: 'any', default: false, kind: 'behavior' }, { name: 'value', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'condition', type: 'any', default: false }, { name: 'value', type: 'any', default: null }], evaluate: (inputs) => ({ out: inputs.condition ? inputs.value : null }) },
 
-  'list.of': { category: 'transform', commutative: true, inputs: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined, kind: 'behavior' })), outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined })), evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 8 }, (_, i) => `value${i + 1}`)) }) },
+  'list.of': { category: 'transform', inputs: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined, kind: 'behavior' })), outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: Array.from({ length: 8 }, (_, i) => ({ name: `value${i + 1}`, type: 'any', default: undefined })), evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 8 }, (_, i) => `value${i + 1}`)) }) },
   'list.range': { category: 'transform', inputs: [{ name: 'start', type: 'number', default: 0, kind: 'behavior' }, { name: 'end', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'start', type: 'number', default: 0 }, { name: 'end', type: 'number', default: 0 }], evaluate: (inputs) => { const start = Math.trunc(inputs.start); const end = Math.trunc(inputs.end); const step = start <= end ? 1 : -1; const out = []; for (let n = start; step > 0 ? n <= end : n >= end; n += step) out.push(n); return { out }; } },
   'list.length': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => ({ out: toArray(inputs.list).length }) },
   'list.at': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'index', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'index', type: 'number', default: 0 }], evaluate: (inputs) => { const list = toArray(inputs.list); const raw = Math.trunc(inputs.index); const index = raw < 0 ? list.length + raw : raw; return { out: index >= 0 && index < list.length ? list[index] : null }; } },
   'list.first': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => ({ out: toArray(inputs.list)[0] ?? null }) },
   'list.last': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => { const list = toArray(inputs.list); return { out: list.length ? list[list.length - 1] : null }; } },
-  'list.map': unsupportedFunctionValueNode('list.map'),
-  'list.filter': unsupportedFunctionValueNode('list.filter'),
-  'list.reduce': unsupportedFunctionValueNode('list.reduce'),
+  'list.map': unsupportedFunctionValueNode('list.map', 'array'),
+  'list.filter': unsupportedFunctionValueNode('list.filter', 'array'),
+  'list.reduce': unsupportedFunctionValueNode('list.reduce', 'any'),
   'list.join': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'separator', type: 'any', default: ',', kind: 'behavior' }], outputs: [{ name: 'out', type: 'string', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'separator', type: 'any', default: ',' }], evaluate: (inputs) => ({ out: toArray(inputs.list).map((value) => stringifyTextValue(value)).join(stringifyTextValue(inputs.separator)) }) },
   'list.reverse': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => ({ out: [...toArray(inputs.list)].reverse() }) },
   'list.sort': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }], evaluate: (inputs) => { const list = [...toArray(inputs.list)]; if (list.every((value) => typeof value === 'number')) list.sort((a, b) => a - b); else list.sort((a, b) => String(a).localeCompare(String(b))); return { out: list }; } },
   'list.take': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'count', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'count', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: toArray(inputs.list).slice(0, Math.max(0, Math.trunc(inputs.count))) }) },
   'list.drop': { category: 'transform', inputs: [{ name: 'list', type: 'array', default: [], kind: 'behavior' }, { name: 'count', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: [{ name: 'list', type: 'array', default: [] }, { name: 'count', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: toArray(inputs.list).slice(Math.max(0, Math.trunc(inputs.count))) }) },
-  'list.concat': { category: 'transform', commutative: true, inputs: Array.from({ length: 4 }, (_, i) => ({ name: `list${i + 1}`, type: 'array', default: undefined, kind: 'behavior' })), outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: Array.from({ length: 4 }, (_, i) => ({ name: `list${i + 1}`, type: 'array', default: undefined })), evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 4 }, (_, i) => `list${i + 1}`)).flatMap((value) => toArray(value)) }) },
+  'list.concat': { category: 'transform', inputs: Array.from({ length: 4 }, (_, i) => ({ name: `list${i + 1}`, type: 'array', default: undefined, kind: 'behavior' })), outputs: [{ name: 'out', type: 'array', kind: 'behavior' }], params: Array.from({ length: 4 }, (_, i) => ({ name: `list${i + 1}`, type: 'array', default: undefined })), evaluate: (inputs) => ({ out: collectInputs(inputs, Array.from({ length: 4 }, (_, i) => `list${i + 1}`)).flatMap((value) => toArray(value)) }) },
 
   'math.add': { category: 'transform', commutative: true, inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.a + inputs.b }) },
   'math.subtract': { category: 'transform', inputs: [{ name: 'a', type: 'number', default: 0, kind: 'behavior' }, { name: 'b', type: 'number', default: 0, kind: 'behavior' }], outputs: [{ name: 'out', type: 'number', kind: 'behavior' }], params: [{ name: 'a', type: 'number', default: 0 }, { name: 'b', type: 'number', default: 0 }], evaluate: (inputs) => ({ out: inputs.a - inputs.b }) },

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -952,3 +952,117 @@ export const LIBRARY_METADATA = {
 export function getAllLibraries() {
   return Object.keys(LIBRARY_METADATA).sort();
 }
+
+function makeFunctionMetadata(libraryName, functionName, signature, description, returns = 'any', status = 'implemented') {
+  return {
+    name: functionName,
+    signature,
+    description,
+    args: [],
+    returns,
+    status,
+    targets: LIBRARY_COMPATIBILITY[libraryName].targets,
+    examples: [`${libraryName}.${functionName}()`]
+  };
+}
+
+Object.assign(LIBRARY_METADATA.text.functions, {
+  concat: makeFunctionMetadata('text', 'concat', 'text.concat(...values)', 'Converts values to strings and concatenates them.', 'string'),
+  split: makeFunctionMetadata('text', 'split', 'text.split(value, separator: ",")', 'Splits text into a list.', 'array'),
+  join: makeFunctionMetadata('text', 'join', 'text.join(list, separator: ",")', 'Joins a list into text.', 'string'),
+  includes: makeFunctionMetadata('text', 'includes', 'text.includes(value, search: "...")', 'Returns true when text contains the search text.', 'boolean'),
+  startsWith: makeFunctionMetadata('text', 'startsWith', 'text.startsWith(value, search: "...")', 'Returns true when text starts with the search text.', 'boolean'),
+  endsWith: makeFunctionMetadata('text', 'endsWith', 'text.endsWith(value, search: "...")', 'Returns true when text ends with the search text.', 'boolean'),
+  length: makeFunctionMetadata('text', 'length', 'text.length(value)', 'Returns string length after user-facing conversion.', 'number'),
+  isEmpty: makeFunctionMetadata('text', 'isEmpty', 'text.isEmpty(value)', 'Returns true when converted text has zero length.', 'boolean'),
+  stringify: makeFunctionMetadata('text', 'stringify', 'text.stringify(value)', 'Converts values to readable text; null and undefined become empty text.', 'string')
+});
+
+Object.assign(LIBRARY_METADATA.console.functions, {
+  table: makeFunctionMetadata('console', 'table', 'console.table(value)', 'Outputs a table-shaped value to the host console when available.', 'void')
+});
+
+Object.assign(LIBRARY_METADATA.math.functions, {
+  floor: makeFunctionMetadata('math', 'floor', 'math.floor(value)', 'Rounds down using Math.floor.', 'number'),
+  ceil: makeFunctionMetadata('math', 'ceil', 'math.ceil(value)', 'Rounds up using Math.ceil.', 'number'),
+  round: makeFunctionMetadata('math', 'round', 'math.round(value)', 'Rounds to nearest integer using Math.round.', 'number'),
+  min: makeFunctionMetadata('math', 'min', 'math.min(a, b)', 'Returns the smaller of two numbers.', 'number'),
+  max: makeFunctionMetadata('math', 'max', 'math.max(a, b)', 'Returns the larger of two numbers.', 'number'),
+  tan: makeFunctionMetadata('math', 'tan', 'math.tan(value)', 'Returns tangent using Math.tan.', 'number'),
+  sqrt: makeFunctionMetadata('math', 'sqrt', 'math.sqrt(value)', 'Returns square root using Math.sqrt.', 'number'),
+  pow: makeFunctionMetadata('math', 'pow', 'math.pow(value, exponent: 2)', 'Raises value to exponent using Math.pow.', 'number')
+});
+
+LIBRARY_METADATA.logic = {
+  name: 'logic',
+  description: LIBRARY_COMPATIBILITY.logic.description,
+  targets: LIBRARY_COMPATIBILITY.logic.targets,
+  functions: Object.fromEntries([
+    ['not', ['logic.not(value)', 'Boolean negation using JavaScript truthiness.', 'boolean']],
+    ['and', ['logic.and(a, b)', 'Boolean AND, returned as a boolean.', 'boolean']],
+    ['or', ['logic.or(a, b)', 'Boolean OR, returned as a boolean.', 'boolean']],
+    ['equals', ['logic.equals(value, other: value)', 'Strict equality using Object.is.', 'boolean']],
+    ['notEquals', ['logic.notEquals(value, other: value)', 'Inverse of logic.equals.', 'boolean']],
+    ['greaterThan', ['logic.greaterThan(value, other: 0)', 'Numeric greater-than comparison.', 'boolean']],
+    ['lessThan', ['logic.lessThan(value, other: 0)', 'Numeric less-than comparison.', 'boolean']],
+    ['greaterOrEqual', ['logic.greaterOrEqual(value, other: 0)', 'Numeric greater-or-equal comparison.', 'boolean']],
+    ['lessOrEqual', ['logic.lessOrEqual(value, other: 0)', 'Numeric less-or-equal comparison.', 'boolean']],
+    ['select', ['logic.select(condition, whenTrue: value, whenFalse: value)', 'Returns whenTrue for truthy condition, otherwise whenFalse.', 'any']],
+    ['when', ['logic.when(condition, value: value)', 'Returns value for truthy condition, otherwise null.', 'any']]
+  ].map(([name, [signature, description, returns]]) => [name, makeFunctionMetadata('logic', name, signature, description, returns)]))
+};
+
+LIBRARY_METADATA.list = {
+  name: 'list',
+  description: LIBRARY_COMPATIBILITY.list.description,
+  targets: LIBRARY_COMPATIBILITY.list.targets,
+  functions: Object.fromEntries([
+    ['of', ['list.of(...values)', 'Builds a list from up to eight positional values.', 'array', 'implemented']],
+    ['range', ['list.range(start, end: 5)', 'Builds an inclusive ascending or descending numeric range.', 'array', 'implemented']],
+    ['length', ['list.length(list)', 'Returns list length.', 'number', 'implemented']],
+    ['at', ['list.at(list, index: 0)', 'Returns an item by index; negative indexes count from the end.', 'any', 'implemented']],
+    ['first', ['list.first(list)', 'Returns first item or null.', 'any', 'implemented']],
+    ['last', ['list.last(list)', 'Returns last item or null.', 'any', 'implemented']],
+    ['map', ['list.map(list, fn: value)', 'Planned until function values are implemented; throws UNSUPPORTED_FUNCTION_VALUE at runtime.', 'array', 'planned']],
+    ['filter', ['list.filter(list, fn: value)', 'Planned until function values are implemented; throws UNSUPPORTED_FUNCTION_VALUE at runtime.', 'array', 'planned']],
+    ['reduce', ['list.reduce(list, fn: value, initial: value)', 'Planned until function values are implemented; throws UNSUPPORTED_FUNCTION_VALUE at runtime.', 'any', 'planned']],
+    ['join', ['list.join(list, separator: ",")', 'Joins list values into text.', 'string', 'implemented']],
+    ['reverse', ['list.reverse(list)', 'Returns a new reversed list.', 'array', 'implemented']],
+    ['sort', ['list.sort(list)', 'Returns a new sorted list; numbers sort numerically, otherwise by string.', 'array', 'implemented']],
+    ['take', ['list.take(list, count: 2)', 'Returns the first count items.', 'array', 'implemented']],
+    ['drop', ['list.drop(list, count: 2)', 'Drops the first count items.', 'array', 'implemented']],
+    ['concat', ['list.concat(...lists)', 'Concatenates up to four lists.', 'array', 'implemented']]
+  ].map(([name, [signature, description, returns, status]]) => [name, makeFunctionMetadata('list', name, signature, description, returns, status)]))
+};
+
+LIBRARY_METADATA.random = {
+  name: 'random',
+  description: LIBRARY_COMPATIBILITY.random.description,
+  targets: LIBRARY_COMPATIBILITY.random.targets,
+  functions: Object.fromEntries([
+    ['value', ['random.value()', 'Returns Math.random() in [0, 1).', 'number', 'implemented']],
+    ['range', ['random.range(min: 0, max: 1)', 'Returns a random float in [min, max).', 'number', 'implemented']],
+    ['int', ['random.int(min: 1, max: 6)', 'Returns a random integer in inclusive [min, max].', 'number', 'implemented']],
+    ['choice', ['random.choice(list)', 'Returns a random item or null for an empty list.', 'any', 'implemented']],
+    ['seeded', ['random.seeded(seed: 1)', 'Planned seeded random generator.', 'any', 'planned']],
+    ['noise', ['random.noise(...)', 'Planned noise generator.', 'number', 'planned']]
+  ].map(([name, [signature, description, returns, status]]) => [name, makeFunctionMetadata('random', name, signature, description, returns, status)]))
+};
+
+LIBRARY_METADATA.debug = {
+  name: 'debug',
+  description: LIBRARY_COMPATIBILITY.debug.description,
+  targets: LIBRARY_COMPATIBILITY.debug.targets,
+  functions: Object.fromEntries([
+    ['inspect', ['debug.inspect(value)', 'Returns a readable string representation.', 'string']],
+    ['trace', ['debug.trace(value, label: "trace")', 'Records a trace effect and returns the original value.', 'any']],
+    ['assert', ['debug.assert(condition, message: "Assertion failed")', 'Throws ASSERTION_FAILED when condition is false.', 'boolean']]
+  ].map(([name, [signature, description, returns]]) => [name, makeFunctionMetadata('debug', name, signature, description, returns)]))
+};
+
+LIBRARY_METADATA.fs.functions = Object.fromEntries([
+  ['readText', ['fs.readText(path: "file.txt")', 'CLI-only: reads UTF-8 text from the local filesystem.', 'string']],
+  ['writeText', ['fs.writeText(path: "file.txt", value: "text")', 'CLI-only: writes UTF-8 text to the local filesystem.', 'void']],
+  ['exists', ['fs.exists(path: "file.txt")', 'CLI-only: returns whether a local path exists.', 'boolean']],
+  ['list', ['fs.list(path: ".")', 'CLI-only: returns filenames in a local directory.', 'array']]
+].map(([name, [signature, description, returns]]) => [name, makeFunctionMetadata('fs', name, signature, description, returns)]));

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -907,8 +907,8 @@ export const LIBRARY_METADATA = {
   },
   fs: {
     name: 'fs',
-    description: LIBRARY_COMPATIBILITY.fs.description,
-    status: 'planned',
+    description: 'CLI-only file system access',
+    status: 'implemented',
     targets: LIBRARY_COMPATIBILITY.fs.targets,
     functions: {}
   },
@@ -998,17 +998,17 @@ LIBRARY_METADATA.logic = {
   description: LIBRARY_COMPATIBILITY.logic.description,
   targets: LIBRARY_COMPATIBILITY.logic.targets,
   functions: Object.fromEntries([
-    ['not', ['logic.not(value)', 'Boolean negation using JavaScript truthiness.', 'boolean']],
-    ['and', ['logic.and(a, b)', 'Boolean AND, returned as a boolean.', 'boolean']],
-    ['or', ['logic.or(a, b)', 'Boolean OR, returned as a boolean.', 'boolean']],
+    ['not', ['logic.not(value)', 'Boolean negation using JavaScript-style truthiness.', 'boolean']],
+    ['and', ['logic.and(a, b)', 'Boolean AND using JavaScript-style truthiness, returned as a boolean.', 'boolean']],
+    ['or', ['logic.or(a, b)', 'Boolean OR using JavaScript-style truthiness, returned as a boolean.', 'boolean']],
     ['equals', ['logic.equals(value, other: value)', 'Strict equality using Object.is.', 'boolean']],
     ['notEquals', ['logic.notEquals(value, other: value)', 'Inverse of logic.equals.', 'boolean']],
     ['greaterThan', ['logic.greaterThan(value, other: 0)', 'Numeric greater-than comparison.', 'boolean']],
     ['lessThan', ['logic.lessThan(value, other: 0)', 'Numeric less-than comparison.', 'boolean']],
     ['greaterOrEqual', ['logic.greaterOrEqual(value, other: 0)', 'Numeric greater-or-equal comparison.', 'boolean']],
     ['lessOrEqual', ['logic.lessOrEqual(value, other: 0)', 'Numeric less-or-equal comparison.', 'boolean']],
-    ['select', ['logic.select(condition, whenTrue: value, whenFalse: value)', 'Returns whenTrue for truthy condition, otherwise whenFalse.', 'any']],
-    ['when', ['logic.when(condition, value: value)', 'Returns value for truthy condition, otherwise null.', 'any']]
+    ['select', ['logic.select(condition, whenTrue: value, whenFalse: value)', 'Returns whenTrue when condition is truthy using JavaScript-style truthiness, otherwise whenFalse.', 'any']],
+    ['when', ['logic.when(condition, value: value)', 'Returns value when condition is truthy using JavaScript-style truthiness, otherwise null.', 'any']]
   ].map(([name, [signature, description, returns]]) => [name, makeFunctionMetadata('logic', name, signature, description, returns)]))
 };
 

--- a/src/toolchain/run.js
+++ b/src/toolchain/run.js
@@ -5,7 +5,7 @@ import { normalizeLoomError } from './errors.js';
 const CLI_SAFE_CATEGORIES = new Set(['source', 'transform', 'state']);
 
 function isCliSafeSink(nodeTypeName) {
-  return nodeTypeName === 'console.log' || nodeTypeName === 'console.warn' || nodeTypeName === 'console.error'
+  return nodeTypeName === 'console.log' || nodeTypeName === 'console.warn' || nodeTypeName === 'console.error' || nodeTypeName === 'console.table' || nodeTypeName === 'fs.writeText'
     || nodeTypeName === 'scene.setPosition' || nodeTypeName === 'scene.setRotation' || nodeTypeName === 'scene.setScale';
 }
 

--- a/src/toolchain/runtime-targets.js
+++ b/src/toolchain/runtime-targets.js
@@ -37,9 +37,9 @@ export const LIBRARY_COMPATIBILITY = {
     description: 'JSON parse/stringify utilities'
   },
   random: {
-    targets: ['cli', 'web', 'scenesync', 'unity'],
-    kind: 'pure',
-    description: 'Random value generation nodes'
+    targets: ['cli', 'web'],
+    kind: 'source',
+    description: 'Non-deterministic random value generation nodes'
   },
   debug: {
     targets: ['cli', 'web', 'unity'],

--- a/src/toolchain/runtime-targets.js
+++ b/src/toolchain/runtime-targets.js
@@ -6,6 +6,16 @@ export const LIBRARY_COMPATIBILITY = {
     kind: 'source',
     description: 'Time-based source nodes'
   },
+  logic: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'pure',
+    description: 'Boolean logic, comparison, and selection nodes'
+  },
+  list: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'pure',
+    description: 'List construction and transformation nodes'
+  },
   math: {
     targets: ['cli', 'web', 'scenesync', 'unity'],
     kind: 'pure',
@@ -25,6 +35,16 @@ export const LIBRARY_COMPATIBILITY = {
     targets: ['cli', 'web', 'scenesync', 'unity'],
     kind: 'pure',
     description: 'JSON parse/stringify utilities'
+  },
+  random: {
+    targets: ['cli', 'web', 'scenesync', 'unity'],
+    kind: 'pure',
+    description: 'Random value generation nodes'
+  },
+  debug: {
+    targets: ['cli', 'web', 'unity'],
+    kind: 'effect',
+    description: 'Debug inspection, tracing, and assertion nodes'
   },
   fs: {
     targets: ['cli'],

--- a/test/stdlib-baseline.test.mjs
+++ b/test/stdlib-baseline.test.mjs
@@ -5,8 +5,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { Loom, LoomError } from '../src/loom.js';
+import { Loom, LoomError, NODE_TYPES } from '../src/loom.js';
 import { runLoomSource } from '../src/toolchain/run.js';
+import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
 import { isLibraryAvailableInTarget } from '../src/toolchain/runtime-targets.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -42,6 +43,7 @@ test('logic baseline nodes', () => {
 });
 
 test('list baseline nodes', () => {
+  assert.deepEqual(evalNode('list.range', { start: 1, end: 3 }), [1, 2, 3]);
   assert.deepEqual(evalNode('list.range', { start: 1, end: 5 }), [1, 2, 3, 4, 5]);
   assert.deepEqual(evalNode('list.range', { start: 5, end: 1 }), [5, 4, 3, 2, 1]);
   assert.equal(evalNode('list.length', { list: [1, 2, 3] }), 3);
@@ -132,10 +134,22 @@ test('fs baseline nodes are CLI-only and access local files', () => {
   assert.equal(isLibraryAvailableInTarget('fs', 'web'), false);
 });
 
+test('stdlib metadata corrections', () => {
+  assert.equal(isLibraryAvailableInTarget('random', 'cli'), true);
+  assert.equal(isLibraryAvailableInTarget('random', 'web'), true);
+  assert.equal(isLibraryAvailableInTarget('random', 'scenesync'), false);
+  assert.equal(LIBRARY_METADATA.fs.status, 'implemented');
+  assert.equal(NODE_TYPES['list.reduce'].outputs[0].type, 'any');
+  assert.equal(NODE_TYPES['text.concat'].commutative, undefined);
+  assert.equal(NODE_TYPES['list.of'].commutative, undefined);
+  assert.equal(NODE_TYPES['list.concat'].commutative, undefined);
+});
+
 test('CLI docs and conditions smoke tests', () => {
   for (const args of [
     ['docs', 'logic'],
     ['docs', 'list'],
+    ['docs', 'fs'],
     ['docs', 'text.stringify'],
     ['docs', 'random.value'],
     ['docs', 'debug.trace'],
@@ -145,6 +159,12 @@ test('CLI docs and conditions smoke tests', () => {
     const result = spawnSync(process.execPath, [cliPath, ...args], { cwd: projectRoot, encoding: 'utf8' });
     assert.equal(result.status, 0, `${args.join(' ')}\n${result.stderr}`);
   }
+
+  const fsDocs = spawnSync(process.execPath, [cliPath, 'docs', 'fs'], { cwd: projectRoot, encoding: 'utf8' });
+  assert.match(fsDocs.stdout, /fs\.readText/);
+  assert.match(fsDocs.stdout, /fs\.writeText/);
+  assert.match(fsDocs.stdout, /fs\.exists/);
+  assert.match(fsDocs.stdout, /fs\.list/);
 
   const sample = runLoomSource('import logic\nvalue = logic.select(constant(value: true), whenTrue: "three", whenFalse: "other")', { target: 'cli', get: 'value.out' });
   assert.equal(sample.ok, true, JSON.stringify(sample.errors));

--- a/test/stdlib-baseline.test.mjs
+++ b/test/stdlib-baseline.test.mjs
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { Loom, LoomError } from '../src/loom.js';
+import { runLoomSource } from '../src/toolchain/run.js';
+import { isLibraryAvailableInTarget } from '../src/toolchain/runtime-targets.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+
+function evalNode(type, params = {}, id = 'n') {
+  const engine = new Loom({ nodes: [{ id, type, params }], edges: [] });
+  engine.evaluateOnce();
+  return engine.getValue(`${id}.out`);
+}
+
+function evalGraph(nodes, edges, ref) {
+  const engine = new Loom({ nodes, edges });
+  engine.evaluateOnce();
+  return { value: ref ? engine.getValue(ref) : undefined, effects: engine.getEffects() };
+}
+
+test('logic baseline nodes', () => {
+  assert.equal(evalNode('logic.equals', { value: 1, other: 1 }), true);
+  assert.equal(evalNode('logic.equals', { value: 1, other: 2 }), false);
+  assert.equal(evalNode('logic.notEquals', { value: 1, other: 2 }), true);
+  assert.equal(evalNode('logic.select', { condition: true, whenTrue: 'yes', whenFalse: 'no' }), 'yes');
+  assert.equal(evalNode('logic.select', { condition: false, whenTrue: 'yes', whenFalse: 'no' }), 'no');
+  assert.equal(evalNode('logic.greaterThan', { value: 3, other: 2 }), true);
+  assert.equal(evalNode('logic.lessThan', { value: 3, other: 2 }), false);
+  assert.equal(evalNode('logic.greaterOrEqual', { value: 2, other: 2 }), true);
+  assert.equal(evalNode('logic.lessOrEqual', { value: 2, other: 2 }), true);
+  assert.equal(evalNode('logic.and', { a: 1, b: 'x' }), true);
+  assert.equal(evalNode('logic.or', { a: 0, b: 'x' }), true);
+  assert.equal(evalNode('logic.not', { value: 0 }), true);
+  assert.equal(evalNode('logic.when', { condition: false, value: 'hidden' }), null);
+});
+
+test('list baseline nodes', () => {
+  assert.deepEqual(evalNode('list.range', { start: 1, end: 5 }), [1, 2, 3, 4, 5]);
+  assert.deepEqual(evalNode('list.range', { start: 5, end: 1 }), [5, 4, 3, 2, 1]);
+  assert.equal(evalNode('list.length', { list: [1, 2, 3] }), 3);
+  assert.equal(evalNode('list.first', { list: [1, 2, 3] }), 1);
+  assert.equal(evalNode('list.last', { list: [1, 2, 3] }), 3);
+  assert.equal(evalNode('list.at', { list: ['a', 'b'], index: 1 }), 'b');
+  assert.equal(evalNode('list.at', { list: ['a', 'b'], index: -1 }), 'b');
+  assert.equal(evalNode('list.join', { list: [1, 2, 3], separator: '-' }), '1-2-3');
+  const original = [3, 1, 2];
+  assert.deepEqual(evalNode('list.reverse', { list: original }), [2, 1, 3]);
+  assert.deepEqual(original, [3, 1, 2]);
+  assert.deepEqual(evalNode('list.sort', { list: original }), [1, 2, 3]);
+  assert.deepEqual(evalNode('list.take', { list: [1, 2, 3], count: 2 }), [1, 2]);
+  assert.deepEqual(evalNode('list.drop', { list: [1, 2, 3], count: 2 }), [3]);
+  assert.deepEqual(evalNode('list.concat', { list1: [1], list2: [2, 3] }), [1, 2, 3]);
+  assert.throws(() => evalNode('list.map', { list: [1], fn: null }), (error) => error instanceof LoomError && error.code === 'UNSUPPORTED_FUNCTION_VALUE');
+  assert.throws(() => evalNode('list.filter', { list: [1], fn: null }), /function values/);
+  assert.throws(() => evalNode('list.reduce', { list: [1], fn: null, initial: 0 }), /function values/);
+});
+
+test('text baseline additions', () => {
+  assert.equal(evalNode('text.concat', { value1: 'a', value2: 2, value3: true }), 'a2true');
+  assert.deepEqual(evalNode('text.split', { value: 'a,b', separator: ',' }), ['a', 'b']);
+  assert.equal(evalNode('text.join', { list: ['a', 'b'], separator: ':' }), 'a:b');
+  assert.equal(evalNode('text.includes', { value: 'loomlet', search: 'loom' }), true);
+  assert.equal(evalNode('text.startsWith', { value: 'loomlet', search: 'loom' }), true);
+  assert.equal(evalNode('text.endsWith', { value: 'loomlet', search: 'let' }), true);
+  assert.equal(evalNode('text.length', { value: 'abc' }), 3);
+  assert.equal(evalNode('text.isEmpty', { value: '' }), true);
+  assert.equal(evalNode('text.stringify', { value: 3 }), '3');
+  assert.equal(evalNode('text.stringify', { value: 'x' }), 'x');
+  assert.equal(evalNode('text.stringify', { value: [1, 2] }), '[1,2]');
+  assert.equal(evalNode('text.stringify', { value: { a: 1 } }), '{"a":1}');
+  assert.equal(evalNode('text.stringify', { value: null }), '');
+});
+
+test('math baseline additions', () => {
+  assert.equal(evalNode('math.floor', { value: 1.8 }), 1);
+  assert.equal(evalNode('math.ceil', { value: 1.2 }), 2);
+  assert.equal(evalNode('math.round', { value: 1.5 }), 2);
+  assert.equal(evalNode('math.min', { a: 1, b: 2 }), 1);
+  assert.equal(evalNode('math.max', { a: 1, b: 2 }), 2);
+  assert.equal(evalNode('math.tan', { value: 0 }), 0);
+  assert.equal(evalNode('math.sqrt', { value: 9 }), 3);
+  assert.equal(evalNode('math.pow', { value: 2, exponent: 3 }), 8);
+  assert.equal(evalNode('math.clamp', { value: 2, min: 0, max: 1 }), 1);
+  assert.equal(evalNode('math.map', { value: 5, inMin: 0, inMax: 10, outMin: 0, outMax: 1 }), 0.5);
+  assert.equal(evalNode('math.lerp', { a: 0, b: 10, t: 0.25 }), 2.5);
+  assert.equal(evalNode('math.smoothstep', { x: 0.5, edge0: 0, edge1: 1 }), 0.5);
+  assert.equal(evalNode('math.cosine', { t: 0, freq: 1, amplitude: 1, phase: 0, offset: 0 }), 1);
+});
+
+test('random baseline nodes', () => {
+  const value = evalNode('random.value');
+  assert.ok(value >= 0 && value < 1);
+  const ranged = evalNode('random.range', { min: 10, max: 11 });
+  assert.ok(ranged >= 10 && ranged < 11);
+  const int = evalNode('random.int', { min: 2, max: 4 });
+  assert.ok(Number.isInteger(int) && int >= 2 && int <= 4);
+  assert.ok(['a', 'b'].includes(evalNode('random.choice', { list: ['a', 'b'] })));
+  assert.equal(evalNode('random.choice', { list: [] }), null);
+});
+
+test('debug baseline nodes', () => {
+  assert.equal(typeof evalNode('debug.inspect', { value: { a: 1 } }), 'string');
+  const traced = evalGraph([{ id: 'trace', type: 'debug.trace', params: { value: 7, label: 'seven' } }], [], 'trace.out');
+  assert.equal(traced.value, 7);
+  assert.deepEqual(traced.effects[0], { type: 'debug.trace', label: 'seven', value: 7, nodeId: 'trace' });
+  assert.equal(evalNode('debug.assert', { condition: true, message: 'ok' }), true);
+  assert.throws(() => evalNode('debug.assert', { condition: false, message: 'bad' }), (error) => error instanceof LoomError && error.code === 'ASSERTION_FAILED' && /bad/.test(error.message));
+});
+
+test('console.table records table effect', () => {
+  const { effects } = evalGraph([{ id: 'table', type: 'console.table', params: { value: [{ a: 1 }] } }], [], null);
+  assert.equal(effects[0].type, 'console.table');
+});
+
+test('fs baseline nodes are CLI-only and access local files', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'loomlet-fs-'));
+  const file = path.join(tmpDir, 'sample.txt');
+  evalGraph([{ id: 'write', type: 'fs.writeText', params: { path: file, value: 'hello' } }], []);
+  assert.equal(fs.readFileSync(file, 'utf8'), 'hello');
+  assert.equal(evalNode('fs.readText', { path: file }), 'hello');
+  assert.equal(evalNode('fs.exists', { path: file }), true);
+  assert.equal(evalNode('fs.exists', { path: path.join(tmpDir, 'missing.txt') }), false);
+  assert.ok(evalNode('fs.list', { path: tmpDir }).includes('sample.txt'));
+  assert.equal(isLibraryAvailableInTarget('fs', 'cli'), true);
+  assert.equal(isLibraryAvailableInTarget('fs', 'web'), false);
+});
+
+test('CLI docs and conditions smoke tests', () => {
+  for (const args of [
+    ['docs', 'logic'],
+    ['docs', 'list'],
+    ['docs', 'text.stringify'],
+    ['docs', 'random.value'],
+    ['docs', 'debug.trace'],
+    ['docs', 'logic.select'],
+    ['docs', 'list.range']
+  ]) {
+    const result = spawnSync(process.execPath, [cliPath, ...args], { cwd: projectRoot, encoding: 'utf8' });
+    assert.equal(result.status, 0, `${args.join(' ')}\n${result.stderr}`);
+  }
+
+  const sample = runLoomSource('import logic\nvalue = logic.select(constant(value: true), whenTrue: "three", whenFalse: "other")', { target: 'cli', get: 'value.out' });
+  assert.equal(sample.ok, true, JSON.stringify(sample.errors));
+  assert.equal(sample.values['value.out'], 'three');
+});


### PR DESCRIPTION
### Motivation
- Provide a broad baseline of pure, CLI-safe standard library nodes so tour examples become runnable without parser changes.  
- Surface clear runtime behavior for parser-dependent features (e.g. function-value list ops) by throwing explicit errors until the language supports them.  
- Ensure documentation and runtime-target metadata reflect available libraries for `loomlet docs` and CLI validation.  

### Description
- Added runtime node implementations and small helpers in `src/loom.js` for: `logic.*` (not/and/or/equals/notEquals/greaterThan/lessThan/greaterOrEqual/lessOrEqual/select/when), `list.*` (of/range/length/at/first/last/join/reverse/sort/take/drop/concat and planned placeholders for `map/filter/reduce`), `text.*` additions (`concat/split/join/includes/startsWith/endsWith/length/isEmpty/stringify`), math additions (`floor/ceil/round/min/max/tan/sqrt/pow`), `random.*` (value/range/int/choice), `debug.*` (inspect/trace/assert), `console.table`, and minimal CLI-only `fs` nodes (`readText/writeText/exists/list`).  
- Added helper utilities `stringifyTextValue`, `inspectValue`, `toArray`, `collectInputs`, `unsupportedFunctionValueNode`, and Node-only FS helpers `getNodeFs`/`getNodePath` to support the new nodes and to surface clear `UNSUPPORTED_FUNCTION_VALUE` errors where function values are required.  
- Updated toolchain metadata and compatibility: `src/toolchain/library-metadata.js` and `src/toolchain/runtime-targets.js` now include metadata for `logic`, `list`, `random`, `debug`, and mark `fs` as CLI-only; `src/toolchain/run.js` treats `console.table` and `fs.writeText` as CLI-safe sinks.  
- Docs and examples updates: moved implemented items into `docs/STANDARD_LIBRARY_PLAN.md`, `docs/NODE_GAPS.md`, and `docs/TOUR.md` and made `examples/tour/language/06-conditions.loom` runnable; added `test/stdlib-baseline.test.mjs` and wired it into `package.json` test script.  

### Testing
- Ran the new unit smoke suite with `node test/stdlib-baseline.test.mjs`, which passed all checks.  
- Ran full project unit tests with `npm test` (includes existing CLI/repl/scenesync tests plus the new stdlib tests), and the suite passed.  
- Verified CLI smoke commands and example execution with `node bin/loomlet.mjs run examples/tour/language/06-conditions.loom` and `node bin/loomlet.mjs docs logic && node bin/loomlet.mjs docs list && node bin/loomlet.mjs docs text.stringify && node bin/loomlet.mjs docs random.value && node bin/loomlet.mjs docs debug.trace`, all of which returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc59969308324bb036eec4c2ec6bf)