### PR TITLE
Make FizzBuzz tour sample runnable and polish function-value ergonomics

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2386,3 +2386,19 @@ Loom は次の 3 つの truth を分離して扱う。
 
 - v1 では DSL への書き戻し(EditorModel → Source AST → DSL)はサポートしない。
 - 将来の Yjs 統合では `nodesById` / `edgesById` を CRDT マップとしてそのまま扱う方針。
+
+
+## Function values
+
+Loomlet supports single-expression function literals: `fn(x) => math.multiply(x, 2)`.
+
+Functions can be assigned to variables: `double = fn(x) => math.multiply(x, 2)`.
+
+Functions can capture values from outer scope: `base = 10` and `addBase = fn(x) => math.add(x, base)`.
+
+Functions can be passed to list nodes: `list.map(numbers, fn: double)`.
+
+Current limitations:
+- function bodies are single expressions
+- block bodies are not supported yet
+- recursion is not supported yet

--- a/docs/STANDARD_LIBRARY_PLAN.md
+++ b/docs/STANDARD_LIBRARY_PLAN.md
@@ -10,6 +10,7 @@ Current:
 - pipeline `|>`
 - `import`, assignment, comments
 - single-expression function values: `fn(...) => expression`
+- positional binary nodes are supported in function bodies (currently: `math.add`, `math.subtract`, `math.multiply`, `math.divide`, `math.mod`, `math.min`, `math.max`, `logic.and`, `logic.or`)
 Used by tour samples:
 - `constant`, `clock`, `|>`
 Recommended baseline:

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -50,10 +50,10 @@ Loomlet source files use the `.loom` extension.
 
 ### 07 FizzBuzz
 - Path: `examples/tour/language/07-fizzbuzz.loom`
-- Status: Draft
+- Status: Runnable
 - Run: `loomlet run examples/tour/language/07-fizzbuzz.loom`
-- Teaches: range generation, mapping, nested branching
-- Missing: block function bodies are still draft-only; single-expression `fn(...) => ...` and `list.map` are implemented
+- Teaches: function values, `list.range`, `list.map`, nested `logic.select`, `text.stringify`, `text.join`
+- Missing: none
 
 ### 08 List Map Filter
 - Path: `examples/tour/language/08-list-map-filter.loom`

--- a/examples/tour/language/07-fizzbuzz.loom
+++ b/examples/tour/language/07-fizzbuzz.loom
@@ -1,6 +1,6 @@
 # Tour: FizzBuzz
-# Goal: Draft map + branching workflow over a generated integer range.
-# Status: draft
+# Goal: Use functions, ranges, map, conditionals, and text conversion.
+# Status: runnable
 # Run:
 #   loomlet run examples/tour/language/07-fizzbuzz.loom
 # Requires:
@@ -9,14 +9,10 @@
 #   - logic.equals
 #   - logic.and
 #   - logic.select
+#   - math.mod
 #   - text.stringify
-# TODO NODE: list.range(start, end:)
-# TODO NODE: list.map(list, fn:)
-# TODO NODE: logic.equals(value, other:)
-# TODO NODE: logic.and(a, b)
-# TODO NODE: logic.select(condition, whenTrue:, whenFalse:)
-# TODO NODE: text.stringify(value)
-# TODO LANGUAGE: function definitions
+#   - text.join
+#   - console.log
 
 import list
 import logic
@@ -24,23 +20,11 @@ import math
 import text
 import console
 
+isMultipleOf = fn(n, divisor) => logic.equals(math.mod(n, divisor), other: 0)
+
+fizzbuzz = fn(n) => logic.select(logic.and(isMultipleOf(n, 3), isMultipleOf(n, 5)), whenTrue: "FizzBuzz", whenFalse: logic.select(isMultipleOf(n, 3), whenTrue: "Fizz", whenFalse: logic.select(isMultipleOf(n, 5), whenTrue: "Buzz", whenFalse: text.stringify(n))))
+
 numbers = list.range(1, end: 100)
-
-fizzbuzz = fn(n) =>
-  isFizz = logic.equals(math.mod(n, 3), other: 0)
-  isBuzz = logic.equals(math.mod(n, 5), other: 0)
-  isFizzBuzz = logic.and(isFizz, isBuzz)
-
-  logic.select(isFizzBuzz,
-    whenTrue: "FizzBuzz",
-    whenFalse: logic.select(isFizz,
-      whenTrue: "Fizz",
-      whenFalse: logic.select(isBuzz,
-        whenTrue: "Buzz",
-        whenFalse: text.stringify(n)
-      )
-    )
-  )
-
 results = list.map(numbers, fn: fizzbuzz)
-console.log(results)
+
+console.log(text.join(results, separator: "\n"))

--- a/src/loom.js
+++ b/src/loom.js
@@ -419,12 +419,12 @@ function isLoomletTruthy(value) {
   return Boolean(value);
 }
 
-// Keep existing tour/test lambda syntax working while applying stricter argument
-// validation to node calls evaluated inside function bodies.
-const FUNCTION_BODY_MULTI_POSITIONAL_COMPAT = new Set(['math.mod']);
+// Positional binary nodes are common enough to support with two positional
+// arguments in function bodies, even when they are not commutative.
+const POSITIONAL_BINARY_NODE_TYPES = new Set(['math.mod', 'math.add', 'math.subtract', 'math.multiply', 'math.divide', 'math.min', 'math.max', 'logic.and', 'logic.or']);
 
-function canUseMultiplePositionalArgsInFunctionBody(nodeName, nodeType) {
-  return Boolean(nodeType.commutative || FUNCTION_BODY_MULTI_POSITIONAL_COMPAT.has(nodeName));
+function canUsePositionalBinaryArgsInFunctionBody(nodeName, nodeType) {
+  return Boolean(nodeType.commutative || POSITIONAL_BINARY_NODE_TYPES.has(nodeName));
 }
 
 function evaluateLegacyFunctionExpr(expr, env, ctx) {
@@ -453,7 +453,7 @@ function evaluateLegacyFunctionExpr(expr, env, ctx) {
     if (nodeType.commutative && positionalArgs.length > 0 && namedArgs.length > 0) {
       throw new LoomError('MISSING_ARGUMENT_NAME', `Node '${expr.name}' is commutative: arguments must be all positional or all named`);
     }
-    if (!canUseMultiplePositionalArgsInFunctionBody(expr.name, nodeType) && positionalArgs.length > 1) {
+    if (!canUsePositionalBinaryArgsInFunctionBody(expr.name, nodeType) && positionalArgs.length > 1) {
       throw new LoomError('MISSING_ARGUMENT_NAME', `Argument at position 2 for '${expr.name}' requires a name`);
     }
 

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -29,6 +29,13 @@ function runCliWithEnv(args, env) {
   });
 }
 
+test('run fizzbuzz tour sample prints expected lines', () => {
+  const result = runCli(['run', 'examples/tour/language/07-fizzbuzz.loom', '--get', '_anon_1.out']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^1\\n2\\nFizz\\n4\\nBuzz\\nFizz/);
+  assert.match(result.stdout, /FizzBuzz/);
+});
+
 test('compile outputs GraphJSON', () => {
   const result = runCli(['compile', 'examples/cli-basic.loom']);
   assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
### Motivation
- Make the FizzBuzz tour sample actually runnable using the existing single-expression function literals, list ops, and logic nodes so the language tour feels real.
- Clarify and document the function-body argument ergonomics so common binary nodes work naturally in inline function expressions.

### Description
- Made `examples/tour/language/07-fizzbuzz.loom` runnable by replacing draft TODOs with a working single-expression `fn` implementation that uses `list.range`, `list.map`, nested `logic.select`, `math.mod`, `text.stringify`, `text.join`, and `console.log`.
- Added a CLI smoke test in `test/loom-cli.test.mjs` that runs the FizzBuzz sample with `loomlet run ... --get _anon_1.out` and asserts expected early lines and presence of `FizzBuzz`.
- Renamed and expanded the function-body positional-compat set to `POSITIONAL_BINARY_NODE_TYPES` in `src/loom.js`, added common binary nodes (`math.add`, `math.subtract`, `math.multiply`, `math.divide`, `math.min`, `math.max`, `logic.and`, `logic.or`, plus `math.mod`), and updated the helper to `canUsePositionalBinaryArgsInFunctionBody` so function bodies may accept two positional args for these nodes.
- Updated docs: `docs/TOUR.md` marks FizzBuzz as `Runnable`, `docs/STANDARD_LIBRARY_PLAN.md` documents positional-binary support, and `docs/SPEC.md` gains a concise `Function values` section describing single-expression `fn(...) => ...`, assignment, capture, higher-order usage, and current limits.

### Testing
- Ran `node bin/loomlet.mjs run examples/tour/language/07-fizzbuzz.loom` and verified expected output lines (completed successfully).
- Ran `node bin/loomlet.mjs run examples/tour/language/08-list-map-filter.loom` and `node bin/loomlet.mjs docs list.map` / `node bin/loomlet.mjs docs logic.select` to validate affected nodes (all succeeded).
- Ran the full test suite via `npm test` and observed all unit tests pass, including the new FizzBuzz smoke test (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd47531388320a3ab55f8d07fecf0)