### PR TITLE
Strengthen Scene Sync and live performance tour samples

### DIFF
--- a/docs/NODE_GAPS.md
+++ b/docs/NODE_GAPS.md
@@ -1,8 +1,15 @@
 # Node Gaps
 
+## Scene Sync status snapshot
+- Current end-to-end sinks: `scene.setPosition`, `scene.setRotation`, `scene.setScale`.
+- Planned for end-to-end Scene Sync graph target parity: `scene.setColor`, `scene.setVisible`.
+- Deferred: `scene.setText` (waiting on Scene Sync text primitive support).
+- Planned: `scene.setAsset` for GLB/image/video reassignment workflows.
+
 ## High priority
-- scene.find
-- timeline.cue
+- timeline.progress
+- timeline.between
+- audio.level
 
 ## Medium priority
 - signal.lfo
@@ -10,10 +17,22 @@
 - signal.trigger
 - state.toggle
 - state.counter
-- timeline.sequence
-- audio.level
 
-## Low priority
-- random.seeded
-- random.noise
-- fs sandboxing and target policy hardening
+## Planned scene nodes
+
+### scene.setText
+Status:
+deferred
+
+Reason:
+Scene Sync currently represents visible content primarily through GLB assets. Dynamic text requires Scene Sync text asset or textOverlay support.
+
+Proposed direction:
+Add Scene Sync `asset.type: "text"` or `textOverlay` support, then map Loomlet `scene.setText` to that.
+
+### scene.setAsset
+Status:
+planned
+
+Reason:
+Scene Sync uses GLB as the main carrier for visible objects. Assigning or replacing an asset is a natural primitive for future demos.

--- a/docs/NODE_GAPS.md
+++ b/docs/NODE_GAPS.md
@@ -2,7 +2,7 @@
 
 ## Scene Sync status snapshot
 - Current end-to-end sinks: `scene.setPosition`, `scene.setRotation`, `scene.setScale`.
-- Planned for end-to-end Scene Sync graph target parity: `scene.setColor`, `scene.setVisible`.
+- Planned for end-to-end Scene Sync graph target parity: `scene.setColor`, `scene.setVisible` (they may compile through the adapter, but runtime support is not yet confirmed).
 - Deferred: `scene.setText` (waiting on Scene Sync text primitive support).
 - Planned: `scene.setAsset` for GLB/image/video reassignment workflows.
 

--- a/docs/SCENESYNC_DEMOS.md
+++ b/docs/SCENESYNC_DEMOS.md
@@ -50,3 +50,9 @@ Loomlet demo graphs in this PR intentionally control transforms, color, and visi
 
 Loomlet graph samples control existing objects.
 They do not create objects during live graph evaluation.
+
+
+## Runtime support notes
+
+- Multi-object graph sketches (for example `05-wave-objects` and `03-grid-wave`) are marked draft because the current Scene Sync graph adapter targets a single object scope.
+- `scene.setColor` and `scene.setVisible` may compile through the Loomlet graph adapter, but samples remain draft until Scene Sync receiver/runtime support is confirmed.

--- a/docs/SCENESYNC_DEMOS.md
+++ b/docs/SCENESYNC_DEMOS.md
@@ -1,0 +1,52 @@
+# Scene Sync Demos
+
+## Setup
+
+1. Open Scene Sync.
+2. Link Loomlet:
+
+`loomlet scenesync redeem <code> --save`
+
+3. Confirm session:
+
+`loomlet scenesync session`
+
+4. Confirm objects:
+
+`loomlet scenesync objects`
+
+## Required object IDs
+
+Some samples assume objects already exist:
+
+- `sample-cube`
+- `dancer`
+- `wave-1` ... `wave-5`
+- `pulse-target`
+- `color-target`
+- `grid-1` ... `grid-9`
+
+## Adding GLB models
+
+Use the Scene Sync UI or AI command flow to import a GLB model URL.
+Then rename or assign the object ID used by the sample (for example, `dancer`).
+
+## Running live samples
+
+Use either:
+
+`loomlet scenesync dev examples/tour/scenesync/02-lissajous.loom`
+
+or:
+
+`loomlet scenesync dev examples/tour/live/01-pulse.loom`
+
+## Skybox / image / video notes
+
+Scene/environment asset import (skyboxes, images, videos, GLBs) should be done through Scene Sync UI/commands before running Loomlet graphs.
+Loomlet demo graphs in this PR intentionally control transforms, color, and visibility of existing objects.
+
+## Notes
+
+Loomlet graph samples control existing objects.
+They do not create objects during live graph evaluation.

--- a/docs/STANDARD_LIBRARY_PLAN.md
+++ b/docs/STANDARD_LIBRARY_PLAN.md
@@ -146,7 +146,7 @@ Current:
 - `scene.setPosition`, `scene.setRotation`, `scene.setScale`
 Used by tour samples:
 - runnable: `scene.setPosition`, `scene.setRotation`, `scene.setScale`
-- draft (pending end-to-end target support): `scene.setColor`, `scene.setVisible`
+- draft (pending end-to-end target/runtime confirmation): `scene.setColor`, `scene.setVisible`
 Recommended baseline:
 - extend runnable sinks with `scene.setColor`, `scene.setVisible`
 - plus `scene.find`, `scene.getPosition`, `scene.emit`, `scene.setMaterial`, `scene.setAsset`

--- a/docs/STANDARD_LIBRARY_PLAN.md
+++ b/docs/STANDARD_LIBRARY_PLAN.md
@@ -145,10 +145,13 @@ Purpose: scene graph output control.
 Current:
 - `scene.setPosition`, `scene.setRotation`, `scene.setScale`
 Used by tour samples:
-- `scene.setPosition`; drafts need `scene.find`
+- runnable: `scene.setPosition`, `scene.setRotation`, `scene.setScale`
+- draft (pending end-to-end target support): `scene.setColor`, `scene.setVisible`
 Recommended baseline:
-- `scene.setColor`, `scene.setVisible`, `scene.setText`, `scene.setMaterial`, `scene.emit`, `scene.find`, `scene.getPosition`
-Status summary: partial; discovery helpers missing
+- extend runnable sinks with `scene.setColor`, `scene.setVisible`
+- plus `scene.find`, `scene.getPosition`, `scene.emit`, `scene.setMaterial`, `scene.setAsset`
+- `scene.setText` is intentionally deferred
+Status summary: transform sinks are implemented end-to-end; color/visibility and discovery/timeline/audio-linked helpers remain planned for full Scene Sync graph parity.
 Targets: scenesync, unity, web
 
 ## input

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -133,11 +133,11 @@ Loomlet source files use the `.loom` extension.
 
 ### 05 Wave Objects
 - Path: `examples/tour/scenesync/05-wave-objects.loom`
-- Status: Runnable
+- Status: Draft
 - Required object IDs: `wave-1`, `wave-2`, `wave-3`, `wave-4`, `wave-5`
 - Run: `loomlet scenesync dev examples/tour/scenesync/05-wave-objects.loom`
 - Teaches: multi-object phase offsets without dynamic object creation
-- Missing: none
+- Missing: requires multi-object Scene Sync graph support or per-sink objectId support; current adapter targets single-object scope
 
 ### 06 Model Choreography
 - Path: `examples/tour/scenesync/06-model-choreography.loom`
@@ -167,11 +167,11 @@ Loomlet source files use the `.loom` extension.
 
 ### 03 Grid Wave
 - Path: `examples/tour/live/03-grid-wave.loom`
-- Status: Runnable
+- Status: Draft
 - Required object IDs: `grid-1` ... `grid-9`
 - Run: `loomlet scenesync dev examples/tour/live/03-grid-wave.loom`
 - Teaches: explicit multi-object wave choreography for a 3x3 layout
-- Missing: none
+- Missing: requires multi-object Scene Sync graph support or per-sink objectId support; current adapter targets single-object scope
 
 ### 04 Timeline Cues
 - Path: `examples/tour/live/04-timeline-cues.loom`

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -102,48 +102,89 @@ Loomlet source files use the `.loom` extension.
 ### 01 Move Cube
 - Path: `examples/tour/scenesync/01-move-cube.loom`
 - Status: Runnable
+- Required object IDs: `sample-cube`
 - Run: `loomlet scenesync dev examples/tour/scenesync/01-move-cube.loom`
-- Teaches: `time.serverClock` + `math.sine` + `scene.setPosition`
+- Teaches: direct `scene.setPosition` command for an existing object
 - Missing: none
 
 ### 02 Lissajous
 - Path: `examples/tour/scenesync/02-lissajous.loom`
 - Status: Runnable
+- Required object IDs: `sample-cube`
 - Run: `loomlet scenesync dev examples/tour/scenesync/02-lissajous.loom`
-- Teaches: multi-axis sine choreography
+- Teaches: time-driven X/Y choreography with `math.sine`
 - Missing: none
 
 ### 03 Orbit
 - Path: `examples/tour/scenesync/03-orbit.loom`
-- Status: Draft
+- Status: Runnable
+- Required object IDs: `sample-cube`
 - Run: `loomlet scenesync dev examples/tour/scenesync/03-orbit.loom`
-- Missing: `timeline.sequence`, `scene.find`
+- Teaches: circular motion with `math.cosine` + `math.sine`
+- Missing: none
 
 ### 04 Breathing Scale
 - Path: `examples/tour/scenesync/04-breathing-scale.loom`
-- Status: Draft
+- Status: Runnable
+- Required object IDs: `sample-cube`
 - Run: `loomlet scenesync dev examples/tour/scenesync/04-breathing-scale.loom`
-- Missing: `timeline.sequence`, `scene.find`
+- Teaches: pulse scaling with `scene.setScale`
+- Missing: none
 
 ### 05 Wave Objects
 - Path: `examples/tour/scenesync/05-wave-objects.loom`
-- Status: Draft
+- Status: Runnable
+- Required object IDs: `wave-1`, `wave-2`, `wave-3`, `wave-4`, `wave-5`
 - Run: `loomlet scenesync dev examples/tour/scenesync/05-wave-objects.loom`
-- Missing: `timeline.sequence`, `scene.find`
+- Teaches: multi-object phase offsets without dynamic object creation
+- Missing: none
 
 ### 06 Model Choreography
 - Path: `examples/tour/scenesync/06-model-choreography.loom`
-- Status: Draft
+- Status: Runnable
+- Required object IDs: `dancer`
 - Run: `loomlet scenesync dev examples/tour/scenesync/06-model-choreography.loom`
-- Missing: `timeline.sequence`, `scene.find`
+- Teaches: GLB choreography through position/scale/rotation on existing model object
+- Missing: none
 
 ## Live
 
-All live samples are Draft and use:
-`loomlet scenesync dev examples/tour/live/<file>.loom`
+### 01 Pulse
+- Path: `examples/tour/live/01-pulse.loom`
+- Status: Runnable
+- Required object IDs: `pulse-target`
+- Run: `loomlet scenesync dev examples/tour/live/01-pulse.loom`
+- Teaches: high-frequency pulse scale behavior
+- Missing: none
 
-- 01 Pulse: missing `timeline.cue`, `audio.level`
-- 02 Color Cycle: missing `timeline.cue`, `audio.level`
-- 03 Grid Wave: missing `timeline.cue`, `audio.level`
-- 04 Timeline Cues: missing `timeline.cue`, `audio.level`
-- 05 Audio Reactive Placeholder: missing `timeline.cue`, `audio.level`
+### 02 Color Cycle
+- Path: `examples/tour/live/02-color-cycle.loom`
+- Status: Draft
+- Required object IDs: `color-target`
+- Run: `loomlet scenesync dev examples/tour/live/02-color-cycle.loom`
+- Teaches: RGB color cycling via phase-shifted sine signals
+- Missing: `scene.setColor` is not yet available end-to-end for Scene Sync graph target
+
+### 03 Grid Wave
+- Path: `examples/tour/live/03-grid-wave.loom`
+- Status: Runnable
+- Required object IDs: `grid-1` ... `grid-9`
+- Run: `loomlet scenesync dev examples/tour/live/03-grid-wave.loom`
+- Teaches: explicit multi-object wave choreography for a 3x3 layout
+- Missing: none
+
+### 04 Timeline Cues
+- Path: `examples/tour/live/04-timeline-cues.loom`
+- Status: Draft
+- Required object IDs: `intro`, `main`, `outro`
+- Run: `loomlet scenesync dev examples/tour/live/04-timeline-cues.loom`
+- Teaches: intended show-control structure using timeline windows + visibility
+- Missing: `timeline.progress`, `timeline.between`
+
+### 05 Audio Reactive Placeholder
+- Path: `examples/tour/live/05-audio-reactive-placeholder.loom`
+- Status: Draft
+- Required object IDs: `audio-target`
+- Run: `loomlet scenesync dev examples/tour/live/05-audio-reactive-placeholder.loom`
+- Teaches: intended mapping from audio level to scale
+- Missing: `audio.level`

--- a/examples/tour/live/01-pulse.loom
+++ b/examples/tour/live/01-pulse.loom
@@ -1,11 +1,20 @@
 # Tour: Pulse
-# Goal: Draft live performance patch for pulse.
-# Status: draft
+# Goal: Drive scale pulsing for performance timing.
+# Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/live/01-pulse.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `pulse-target` exists in the scene.
 # Requires:
-#   - missing live/audio/timeline nodes listed below
-# TODO NODE: timeline.cue
-# TODO NODE: audio.level
-import timeline
-import audio
+#   - time.serverClock
+#   - math.sine
+#   - scene.setScale
+import time
+import math
+import scene
+
+t = time.serverClock()
+s = math.sine(t, freq: 1.0, amplitude: 0.3, offset: 1.0)
+scene.setScale(objectId: "pulse-target", x: s, y: s, z: s)

--- a/examples/tour/live/02-color-cycle.loom
+++ b/examples/tour/live/02-color-cycle.loom
@@ -1,11 +1,23 @@
 # Tour: Color Cycle
-# Goal: Draft live performance patch for color cycle.
+# Goal: Cycle RGB color values over time.
 # Status: draft
 # Run:
 #   loomlet scenesync dev examples/tour/live/02-color-cycle.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `color-target` exists in the scene.
 # Requires:
-#   - missing live/audio/timeline nodes listed below
-# TODO NODE: timeline.cue
-# TODO NODE: audio.level
-import timeline
-import audio
+#   - time.serverClock
+#   - math.sine
+#   - math.add
+#   - scene.setColor (not yet available end-to-end in Scene Sync target)
+import time
+import math
+import scene
+
+t = time.serverClock()
+r = math.sine(t, freq: 0.1, amplitude: 0.5, offset: 0.5)
+g = math.sine(math.add(t, 2.0), freq: 0.1, amplitude: 0.5, offset: 0.5)
+b = math.sine(math.add(t, 4.0), freq: 0.1, amplitude: 0.5, offset: 0.5)
+scene.setColor(objectId: "color-target", r: r, g: g, b: b)

--- a/examples/tour/live/03-grid-wave.loom
+++ b/examples/tour/live/03-grid-wave.loom
@@ -1,6 +1,6 @@
 # Tour: Grid Wave
 # Goal: Move a 3x3 object grid in phase-shifted Y waves.
-# Status: runnable
+# Status: draft
 # Run:
 #   loomlet scenesync dev examples/tour/live/03-grid-wave.loom
 # Setup:

--- a/examples/tour/live/03-grid-wave.loom
+++ b/examples/tour/live/03-grid-wave.loom
@@ -1,11 +1,37 @@
 # Tour: Grid Wave
-# Goal: Draft live performance patch for grid wave.
-# Status: draft
+# Goal: Move a 3x3 object grid in phase-shifted Y waves.
+# Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/live/03-grid-wave.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure objects `grid-1` through `grid-9` exist in the scene.
 # Requires:
-#   - missing live/audio/timeline nodes listed below
-# TODO NODE: timeline.cue
-# TODO NODE: audio.level
-import timeline
-import audio
+#   - time.serverClock
+#   - math.sine
+#   - math.add
+#   - scene.setPosition
+import time
+import math
+import scene
+
+t = time.serverClock()
+y1 = math.sine(math.add(t, 0.0), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y2 = math.sine(math.add(t, 0.3), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y3 = math.sine(math.add(t, 0.6), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y4 = math.sine(math.add(t, 0.9), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y5 = math.sine(math.add(t, 1.2), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y6 = math.sine(math.add(t, 1.5), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y7 = math.sine(math.add(t, 1.8), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y8 = math.sine(math.add(t, 2.1), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y9 = math.sine(math.add(t, 2.4), freq: 0.25, amplitude: 0.5, offset: 1.0)
+scene.setPosition(objectId: "grid-1", x: -1, y: y1, z: -1)
+scene.setPosition(objectId: "grid-2", x: 0, y: y2, z: -1)
+scene.setPosition(objectId: "grid-3", x: 1, y: y3, z: -1)
+scene.setPosition(objectId: "grid-4", x: -1, y: y4, z: 0)
+scene.setPosition(objectId: "grid-5", x: 0, y: y5, z: 0)
+scene.setPosition(objectId: "grid-6", x: 1, y: y6, z: 0)
+scene.setPosition(objectId: "grid-7", x: -1, y: y7, z: 1)
+scene.setPosition(objectId: "grid-8", x: 0, y: y8, z: 1)
+scene.setPosition(objectId: "grid-9", x: 1, y: y9, z: 1)

--- a/examples/tour/live/04-timeline-cues.loom
+++ b/examples/tour/live/04-timeline-cues.loom
@@ -1,11 +1,25 @@
 # Tour: Timeline Cues
-# Goal: Draft live performance patch for timeline cues.
+# Goal: Show desired timeline-based visibility cue workflow.
 # Status: draft
 # Run:
 #   loomlet scenesync dev examples/tour/live/04-timeline-cues.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure objects `intro`, `main`, and `outro` exist in the scene.
 # Requires:
-#   - missing live/audio/timeline nodes listed below
-# TODO NODE: timeline.cue
-# TODO NODE: audio.level
+#   - timeline.progress (planned)
+#   - timeline.between (planned)
+#   - scene.setVisible
+# TODO NODE: timeline.progress(duration:, loop:)
+# TODO NODE: timeline.between(start:, end:)
 import timeline
-import audio
+import scene
+
+p = timeline.progress(duration: 8, loop: true)
+showIntro = timeline.between(p, start: 0.0, end: 0.25)
+showMain = timeline.between(p, start: 0.25, end: 0.75)
+showOutro = timeline.between(p, start: 0.75, end: 1.0)
+scene.setVisible(objectId: "intro", visible: showIntro)
+scene.setVisible(objectId: "main", visible: showMain)
+scene.setVisible(objectId: "outro", visible: showOutro)

--- a/examples/tour/live/05-audio-reactive-placeholder.loom
+++ b/examples/tour/live/05-audio-reactive-placeholder.loom
@@ -1,11 +1,21 @@
 # Tour: Audio Reactive Placeholder
-# Goal: Draft live performance patch for audio reactive placeholder.
+# Goal: Show desired future audio-reactive scaling flow.
 # Status: draft
 # Run:
 #   loomlet scenesync dev examples/tour/live/05-audio-reactive-placeholder.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `audio-target` exists in the scene.
 # Requires:
-#   - missing live/audio/timeline nodes listed below
-# TODO NODE: timeline.cue
-# TODO NODE: audio.level
-import timeline
+#   - audio.level (planned)
+#   - math.map
+#   - scene.setScale
+# TODO NODE: audio.level()
 import audio
+import math
+import scene
+
+level = audio.level()
+s = math.map(level, inMin: 0, inMax: 1, outMin: 1, outMax: 2)
+scene.setScale(objectId: "audio-target", x: s, y: s, z: s)

--- a/examples/tour/scenesync/01-move-cube.loom
+++ b/examples/tour/scenesync/01-move-cube.loom
@@ -1,16 +1,14 @@
 # Tour: Move Cube
-# Goal: Drive Scene Sync position updates from a sine signal.
+# Goal: Send a single Scene Sync position command to an existing object.
 # Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/01-move-cube.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `sample-cube` exists in the scene.
 # Requires:
-#   - time.serverClock
-#   - math.sine
 #   - scene.setPosition
-import time
-import math
 import scene
 
-t = time.serverClock()
-x = math.sine(t, freq: 0.25, amplitude: 1.5)
-scene.setPosition(objectId: "sample-cube", x: x, y: 0, z: 0)
+scene.setPosition(objectId: "sample-cube", x: 1, y: 0.5, z: 0)

--- a/examples/tour/scenesync/02-lissajous.loom
+++ b/examples/tour/scenesync/02-lissajous.loom
@@ -1,8 +1,12 @@
 # Tour: Lissajous
-# Goal: Move one object on a Lissajous curve.
+# Goal: Animate one object with time-driven X/Y motion.
 # Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/02-lissajous.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `sample-cube` exists in the scene.
 # Requires:
 #   - time.serverClock
 #   - math.sine
@@ -13,5 +17,5 @@ import scene
 
 t = time.serverClock()
 x = math.sine(t, freq: 0.2, amplitude: 2, offset: 0)
-y = math.sine(t, freq: 0.3, amplitude: 1, offset: 1.2)
+y = math.sine(t, freq: 0.3, amplitude: 0.5, offset: 1.2)
 scene.setPosition(objectId: "sample-cube", x: x, y: y, z: 0)

--- a/examples/tour/scenesync/03-orbit.loom
+++ b/examples/tour/scenesync/03-orbit.loom
@@ -1,11 +1,22 @@
 # Tour: Orbit
-# Goal: Draft Scene Sync choreography for orbit.
-# Status: draft
+# Goal: Animate circular motion using cosine/sine on X/Z.
+# Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/03-orbit.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `sample-cube` exists in the scene.
 # Requires:
-#   - missing timeline/scene nodes listed below
-# TODO NODE: timeline.sequence
-# TODO NODE: scene.find
-import timeline
+#   - time.serverClock
+#   - math.cosine
+#   - math.sine
+#   - scene.setPosition
+import time
+import math
 import scene
+
+t = time.serverClock()
+x = math.cosine(t, freq: 0.15, amplitude: 2, offset: 0)
+z = math.sine(t, freq: 0.15, amplitude: 2, offset: 0)
+scene.setPosition(objectId: "sample-cube", x: x, y: 1.2, z: z)

--- a/examples/tour/scenesync/04-breathing-scale.loom
+++ b/examples/tour/scenesync/04-breathing-scale.loom
@@ -1,11 +1,20 @@
 # Tour: Breathing Scale
-# Goal: Draft Scene Sync choreography for breathing scale.
-# Status: draft
+# Goal: Pulse object scale for live visual emphasis.
+# Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/04-breathing-scale.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure an object named `sample-cube` exists in the scene.
 # Requires:
-#   - missing timeline/scene nodes listed below
-# TODO NODE: timeline.sequence
-# TODO NODE: scene.find
-import timeline
+#   - time.serverClock
+#   - math.sine
+#   - scene.setScale
+import time
+import math
 import scene
+
+t = time.serverClock()
+s = math.sine(t, freq: 0.4, amplitude: 0.25, offset: 1.25)
+scene.setScale(objectId: "sample-cube", x: s, y: s, z: s)

--- a/examples/tour/scenesync/05-wave-objects.loom
+++ b/examples/tour/scenesync/05-wave-objects.loom
@@ -1,11 +1,29 @@
 # Tour: Wave Objects
-# Goal: Draft Scene Sync choreography for wave objects.
-# Status: draft
+# Goal: Move multiple objects with phase-shifted Y waves.
+# Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/05-wave-objects.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Ensure objects `wave-1` through `wave-5` exist in the scene.
 # Requires:
-#   - missing timeline/scene nodes listed below
-# TODO NODE: timeline.sequence
-# TODO NODE: scene.find
-import timeline
+#   - time.serverClock
+#   - math.sine
+#   - math.add
+#   - scene.setPosition
+import time
+import math
 import scene
+
+t = time.serverClock()
+y1 = math.sine(t, freq: 0.25, amplitude: 0.5, offset: 1.0)
+y2 = math.sine(math.add(t, 0.5), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y3 = math.sine(math.add(t, 1.0), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y4 = math.sine(math.add(t, 1.5), freq: 0.25, amplitude: 0.5, offset: 1.0)
+y5 = math.sine(math.add(t, 2.0), freq: 0.25, amplitude: 0.5, offset: 1.0)
+scene.setPosition(objectId: "wave-1", x: -2, y: y1, z: 0)
+scene.setPosition(objectId: "wave-2", x: -1, y: y2, z: 0)
+scene.setPosition(objectId: "wave-3", x: 0, y: y3, z: 0)
+scene.setPosition(objectId: "wave-4", x: 1, y: y4, z: 0)
+scene.setPosition(objectId: "wave-5", x: 2, y: y5, z: 0)

--- a/examples/tour/scenesync/05-wave-objects.loom
+++ b/examples/tour/scenesync/05-wave-objects.loom
@@ -1,6 +1,6 @@
 # Tour: Wave Objects
 # Goal: Move multiple objects with phase-shifted Y waves.
-# Status: runnable
+# Status: draft
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/05-wave-objects.loom
 # Setup:

--- a/examples/tour/scenesync/06-model-choreography.loom
+++ b/examples/tour/scenesync/06-model-choreography.loom
@@ -1,11 +1,25 @@
 # Tour: Model Choreography
-# Goal: Draft Scene Sync choreography for model choreography.
-# Status: draft
+# Goal: Animate an existing GLB model with position and scale.
+# Status: runnable
 # Run:
 #   loomlet scenesync dev examples/tour/scenesync/06-model-choreography.loom
+# Setup:
+#   - Open a Scene Sync room.
+#   - Link Loomlet with `loomlet scenesync redeem <code> --save`.
+#   - Add a GLB model and ensure objectId `dancer` exists.
 # Requires:
-#   - missing timeline/scene nodes listed below
-# TODO NODE: timeline.sequence
-# TODO NODE: scene.find
-import timeline
+#   - time.serverClock
+#   - math.sine
+#   - scene.setPosition
+#   - scene.setScale
+#   - scene.setRotation
+import time
+import math
 import scene
+
+t = time.serverClock()
+x = math.sine(t, freq: 0.12, amplitude: 1.5, offset: 0)
+scale = math.sine(t, freq: 0.25, amplitude: 0.15, offset: 1.0)
+scene.setPosition(objectId: "dancer", x: x, y: 0, z: 0)
+scene.setScale(objectId: "dancer", x: scale, y: scale, z: scale)
+scene.setRotation(objectId: "dancer", x: 0, y: 0, z: 0, w: 1)

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -3,13 +3,25 @@ import { compileLoomSource } from '../toolchain/compile.js';
 const SUPPORTED_NODES = new Set([
   'time.serverClock',
   'math.sine',
-  'scene.setPosition'
+  'math.cosine',
+  'math.add',
+  'scene.setPosition',
+  'scene.setRotation',
+  'scene.setScale',
+  'scene.setColor',
+  'scene.setVisible'
 ]);
 
 const NODE_TYPE_MAPPING = {
   'time.serverClock': 'serverClock',
   'math.sine': 'sine',
-  'scene.setPosition': 'sceneSetPosition'
+  'math.cosine': 'cosine',
+  'math.add': 'add',
+  'scene.setPosition': 'sceneSetPosition',
+  'scene.setRotation': 'sceneSetRotation',
+  'scene.setScale': 'sceneSetScale',
+  'scene.setColor': 'sceneSetColor',
+  'scene.setVisible': 'sceneSetVisible'
 };
 
 const OUTPUT_PORT_MAPPING = {
@@ -17,129 +29,107 @@ const OUTPUT_PORT_MAPPING = {
   'serverClock': 't',
   'math.sine': 'out',
   'sine': 'out',
+  'math.cosine': 'out',
+  'cosine': 'out',
+  'math.add': 'out',
+  'add': 'out',
   'scene.setPosition': undefined,
-  'sceneSetPosition': undefined
+  'sceneSetPosition': undefined,
+  'scene.setRotation': undefined,
+  'sceneSetRotation': undefined,
+  'scene.setScale': undefined,
+  'sceneSetScale': undefined,
+  'scene.setColor': undefined,
+  'sceneSetColor': undefined,
+  'scene.setVisible': undefined,
+  'sceneSetVisible': undefined
 };
-
-function getDefaultOutputPort(nodeType) {
-  const mapped = NODE_TYPE_MAPPING[nodeType] || nodeType;
-  return OUTPUT_PORT_MAPPING[mapped];
-}
 
 function generateStableNodeId(originalId, nodeType) {
   const mapped = NODE_TYPE_MAPPING[nodeType] || nodeType;
   if (mapped === 'serverClock') return 'clock';
   if (originalId && !originalId.startsWith('_')) return originalId;
-  if (mapped === 'sine') {
-    const match = originalId?.match(/sine[_x_y]?(.*)$/);
-    if (match && match[1]) return `sine_${match[1]}`;
-    return 'sine';
-  }
+  if (mapped === 'sine' || mapped === 'cosine') return mapped;
   if (mapped === 'sceneSetPosition') return 'pos';
+  if (mapped === 'sceneSetRotation') return 'rot';
+  if (mapped === 'sceneSetScale') return 'scale';
+  if (mapped === 'sceneSetColor') return 'color';
+  if (mapped === 'sceneSetVisible') return 'visible';
   return originalId;
 }
 
 function normalizeScope(options = {}) {
-  if (options.scope) {
-    return options.scope;
-  }
-  if (options.objectId) {
-    return { object: options.objectId };
-  }
+  if (options.scope) return options.scope;
+  if (options.objectId) return { object: options.objectId };
   return null;
+}
+
+function pickParams(nodeType, params = {}) {
+  if (nodeType === 'scene.setPosition' || nodeType === 'scene.setScale') {
+    return { ...(params.x !== undefined ? { x: params.x } : {}), ...(params.y !== undefined ? { y: params.y } : {}), ...(params.z !== undefined ? { z: params.z } : {}) };
+  }
+  if (nodeType === 'scene.setRotation') {
+    return {
+      ...(params.x !== undefined ? { x: params.x } : {}),
+      ...(params.y !== undefined ? { y: params.y } : {}),
+      ...(params.z !== undefined ? { z: params.z } : {}),
+      ...(params.w !== undefined ? { w: params.w } : {})
+    };
+  }
+  if (nodeType === 'scene.setColor') {
+    return { ...(params.r !== undefined ? { r: params.r } : {}), ...(params.g !== undefined ? { g: params.g } : {}), ...(params.b !== undefined ? { b: params.b } : {}) };
+  }
+  if (nodeType === 'scene.setVisible') {
+    return { ...(params.visible !== undefined ? { visible: params.visible } : {}) };
+  }
+  if (nodeType === 'math.sine' || nodeType === 'math.cosine') {
+    return {
+      ...(params.freq !== undefined ? { freq: params.freq } : {}),
+      ...(params.amplitude !== undefined ? { amplitude: params.amplitude } : {}),
+      ...(params.offset !== undefined ? { offset: params.offset } : {})
+    };
+  }
+  return {};
 }
 
 export function compileLoomToSceneSyncGraph(source, options = {}) {
   const result = compileLoomSource(source, { target: 'scenesync' });
-
-  if (!result.ok) {
-    throw new Error(`Compilation failed: ${result.errors.map(e => e.message).join(', ')}`);
-  }
-
+  if (!result.ok) throw new Error(`Compilation failed: ${result.errors.map((e) => e.message).join(', ')}`);
   return loomGraphToSceneSyncGraph(result.graph, options);
 }
 
 export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
-  if (!loomGraph || !loomGraph.nodes || !loomGraph.edges) {
-    throw new Error('loomGraph must have nodes and edges arrays');
-  }
-
+  if (!loomGraph || !loomGraph.nodes || !loomGraph.edges) throw new Error('loomGraph must have nodes and edges arrays');
   const nodes = [];
   const edges = [];
   const nodeIdMap = new Map();
 
   for (const node of loomGraph.nodes) {
-    if (!SUPPORTED_NODES.has(node.type)) {
-      throw new Error(`Unsupported Scene Sync graph node: ${node.type}`);
-    }
-
+    if (!SUPPORTED_NODES.has(node.type)) throw new Error(`Unsupported Scene Sync graph node: ${node.type}`);
     const sceneSyncType = NODE_TYPE_MAPPING[node.type];
     const newId = generateStableNodeId(node.id, node.type);
     nodeIdMap.set(node.id, newId);
-
-    const sceneSyncNode = {
-      id: newId,
-      type: sceneSyncType
-    };
-
-    if (node.type === 'scene.setPosition') {
-      sceneSyncNode.params = {};
-      if (node.params?.z !== undefined) {
-        sceneSyncNode.params.z = node.params.z;
-      }
-      if (node.params?.x !== undefined) {
-        sceneSyncNode.params.x = node.params.x;
-      }
-      if (node.params?.y !== undefined) {
-        sceneSyncNode.params.y = node.params.y;
-      }
-    } else if (node.type === 'math.sine') {
-      sceneSyncNode.params = {};
-      if (node.params?.freq !== undefined) {
-        sceneSyncNode.params.freq = node.params.freq;
-      }
-      if (node.params?.amplitude !== undefined) {
-        sceneSyncNode.params.amplitude = node.params.amplitude;
-      }
-      if (node.params?.offset !== undefined) {
-        sceneSyncNode.params.offset = node.params.offset;
-      }
-    }
-
-    nodes.push(sceneSyncNode);
+    const params = pickParams(node.type, node.params);
+    nodes.push({ id: newId, type: sceneSyncType, ...(Object.keys(params).length > 0 ? { params } : {}) });
   }
 
   for (const edge of loomGraph.edges) {
     const [fromNodeId, fromPort] = edge.from.split('.');
     const [toNodeId, toPort] = edge.to.split('.');
-
     const newFromId = nodeIdMap.get(fromNodeId);
     const newToId = nodeIdMap.get(toNodeId);
-
-    if (newFromId && newToId) {
-      edges.push({
-        from: `${newFromId}.${fromPort}`,
-        to: `${newToId}.${toPort}`
-      });
-    }
+    if (newFromId && newToId) edges.push({ from: `${newFromId}.${fromPort}`, to: `${newToId}.${toPort}` });
   }
 
   let scope = normalizeScope(options);
-
   if (!scope) {
     for (const node of loomGraph.nodes) {
-      if (node.type === 'scene.setPosition' && node.params?.objectId) {
+      if (node.type.startsWith('scene.set') && node.params?.objectId) {
         scope = { object: node.params.objectId };
         break;
       }
     }
   }
 
-  return {
-    graph: {
-      nodes,
-      edges
-    },
-    scope
-  };
+  return { graph: { nodes, edges }, scope };
 }

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -45,17 +45,30 @@ const OUTPUT_PORT_MAPPING = {
   'sceneSetVisible': undefined
 };
 
-function generateStableNodeId(originalId, nodeType) {
+function generateStableNodeBase(nodeType) {
   const mapped = NODE_TYPE_MAPPING[nodeType] || nodeType;
   if (mapped === 'serverClock') return 'clock';
-  if (originalId && !originalId.startsWith('_')) return originalId;
-  if (mapped === 'sine' || mapped === 'cosine') return mapped;
+  if (mapped === 'sine') return 'sine';
+  if (mapped === 'cosine') return 'cosine';
+  if (mapped === 'add') return 'add';
   if (mapped === 'sceneSetPosition') return 'pos';
   if (mapped === 'sceneSetRotation') return 'rot';
   if (mapped === 'sceneSetScale') return 'scale';
   if (mapped === 'sceneSetColor') return 'color';
   if (mapped === 'sceneSetVisible') return 'visible';
-  return originalId;
+  return mapped;
+}
+
+function makeUniqueId(base, usedIds) {
+  if (!usedIds.has(base)) {
+    usedIds.add(base);
+    return base;
+  }
+  let index = 2;
+  while (usedIds.has(`${base}_${index}`)) index += 1;
+  const id = `${base}_${index}`;
+  usedIds.add(id);
+  return id;
 }
 
 function normalizeScope(options = {}) {
@@ -103,11 +116,13 @@ export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
   const nodes = [];
   const edges = [];
   const nodeIdMap = new Map();
+  const usedIds = new Set();
 
   for (const node of loomGraph.nodes) {
     if (!SUPPORTED_NODES.has(node.type)) throw new Error(`Unsupported Scene Sync graph node: ${node.type}`);
     const sceneSyncType = NODE_TYPE_MAPPING[node.type];
-    const newId = generateStableNodeId(node.id, node.type);
+    const baseId = (node.id && !node.id.startsWith('_')) ? node.id : generateStableNodeBase(node.type);
+    const newId = makeUniqueId(baseId, usedIds);
     nodeIdMap.set(node.id, newId);
     const params = pickParams(node.type, node.params);
     nodes.push({ id: newId, type: sceneSyncType, ...(Object.keys(params).length > 0 ? { params } : {}) });

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -157,3 +157,16 @@ test('objectId option normalizes to scope', () => {
   const result = loomGraphToSceneSyncGraph(loomGraph, { objectId: 'cube3' });
   assert.deepEqual(result.scope, { object: 'cube3' });
 });
+
+test('supports rotation/scale scene sinks', () => {
+  const source = `
+import scene
+scene.setRotation("sample-cube", x: 0, y: 0, z: 0, w: 1)
+scene.setScale("sample-cube", x: 1.2, y: 1.2, z: 1.2)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetRotation'));
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetScale'));
+  assert.deepEqual(result.scope, { object: 'sample-cube' });
+});

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -2,6 +2,14 @@ import assert from 'node:assert';
 import { test } from 'node:test';
 import { compileLoomToSceneSyncGraph, loomGraphToSceneSyncGraph } from '../src/scenesync/graph-adapter.js';
 
+function assertEdgesReferToExistingNodes(graph) {
+  const ids = new Set(graph.nodes.map((n) => n.id));
+  for (const edge of graph.edges) {
+    assert.ok(ids.has(edge.from.split('.')[0]));
+    assert.ok(ids.has(edge.to.split('.')[0]));
+  }
+}
+
 test('compiles lissajous example to Scene Sync graph', () => {
   const source = `
 import time
@@ -169,4 +177,36 @@ scene.setScale("sample-cube", x: 1.2, y: 1.2, z: 1.2)
   assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetRotation'));
   assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetScale'));
   assert.deepEqual(result.scope, { object: 'sample-cube' });
+});
+
+
+test('multiple sine nodes receive unique IDs and valid edges', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+x = math.sine(t, freq: 0.2, amplitude: 2, offset: 0)
+y = math.sine(t, freq: 0.3, amplitude: 0.5, offset: 1.2)
+scene.setPosition("sample-cube", x: x, y: y, z: 0)
+`;
+  const result = compileLoomToSceneSyncGraph(source);
+  const sineNodes = result.graph.nodes.filter((n) => n.type === 'sine');
+  assert.equal(sineNodes.length, 2);
+  assert.notEqual(sineNodes[0].id, sineNodes[1].id);
+  assertEdgesReferToExistingNodes(result.graph);
+});
+
+test('multiple scene.setPosition nodes receive unique IDs and valid edges', () => {
+  const source = `
+import scene
+scene.setPosition("sample-cube", x: 0, y: 0, z: 0)
+scene.setPosition("sample-cube", x: 1, y: 1, z: 1)
+`;
+  const result = compileLoomToSceneSyncGraph(source);
+  const posNodes = result.graph.nodes.filter((n) => n.type === 'sceneSetPosition');
+  assert.equal(posNodes.length, 2);
+  assert.notEqual(posNodes[0].id, posNodes[1].id);
+  assertEdgesReferToExistingNodes(result.graph);
 });


### PR DESCRIPTION
### Motivation
- Make Loomlet’s Scene Sync and live-performance demos more concrete and usable by exercising current Scene Sync capabilities while avoiding object creation during live graph evaluation.
- Surface missing runtime nodes and document deferred features so authors know what is runnable today and what remains planned.

### Description
- Expanded the Scene Sync graph adapter to map additional math and sink nodes used by demos (`math.cosine`, `math.add`, and scene sinks including `scene.setRotation`, `scene.setScale`, `scene.setColor`, `scene.setVisible`) and preserved literal params and scope detection in conversions (`src/scenesync/graph-adapter.js`).
- Added or updated Scene Sync tour samples to be demo-ready and explicitly control existing objects with clear headers and setup notes (`examples/tour/scenesync/01-06-*.loom`).
- Added and improved live-performance samples for pulses, grid waves, color cycling (marked draft where not yet end-to-end), timeline cues, and an audio-reactive placeholder (`examples/tour/live/*.loom`).
- Added `docs/SCENESYNC_DEMOS.md` with setup and run instructions and updated `docs/TOUR.md`, `docs/STANDARD_LIBRARY_PLAN.md`, and `docs/NODE_GAPS.md` to reflect current sink support and defer `scene.setText` while planning `scene.setAsset`.
- Added/updated unit test coverage for the graph adapter to validate rotation/scale sink conversion and adjusted tests/docs to mark color/visibility as draft where end-to-end compilation is not yet available (`test/scenesync-graph-adapter.test.mjs`).

### Testing
- Ran `node test/scenesync-graph-adapter.test.mjs` which passed locally in this environment. 
- Ran full test suite via `npm test` which completed successfully in this environment and returned all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbdb42e0488320bfdc9a61631010fd)