### PR TITLE
Drive VS Code completions from generated Loomlet library metadata

### DIFF
--- a/extensions/vscode-loomlet/README.md
+++ b/extensions/vscode-loomlet/README.md
@@ -41,3 +41,5 @@ This MVP does not include:
 - formatter
 - hover documentation from compiler metadata
 - graph preview
+
+VS Code completions are generated from Loomlet library metadata. Run `npm run generate:vscode-metadata` after changing library metadata.

--- a/extensions/vscode-loomlet/generated/library-metadata.json
+++ b/extensions/vscode-loomlet/generated/library-metadata.json
@@ -18,6 +18,7 @@
           "signature": "text.upper(value)",
           "description": "Converts text to uppercase.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -34,6 +35,7 @@
           "signature": "text.lower(value)",
           "description": "Converts text to lowercase.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -50,6 +52,7 @@
           "signature": "text.trim(value)",
           "description": "Removes whitespace from both ends of text.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -66,6 +69,7 @@
           "signature": "text.replace(value, search: \"...\", replacement: \"...\")",
           "description": "Replaces all occurrences of a substring.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -94,6 +98,7 @@
           "signature": "text.concat(...values)",
           "description": "Converts values to strings and concatenates them.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -103,6 +108,7 @@
           "signature": "text.split(value, separator: \",\")",
           "description": "Splits text into a list.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -112,6 +118,7 @@
           "signature": "text.join(list, separator: \",\")",
           "description": "Joins a list into text.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -121,6 +128,7 @@
           "signature": "text.includes(value, search: \"...\")",
           "description": "Returns true when text contains the search text.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -130,6 +138,7 @@
           "signature": "text.startsWith(value, search: \"...\")",
           "description": "Returns true when text starts with the search text.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -139,6 +148,7 @@
           "signature": "text.endsWith(value, search: \"...\")",
           "description": "Returns true when text ends with the search text.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -148,6 +158,7 @@
           "signature": "text.length(value)",
           "description": "Returns string length after user-facing conversion.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -157,6 +168,7 @@
           "signature": "text.isEmpty(value)",
           "description": "Returns true when converted text has zero length.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -166,6 +178,7 @@
           "signature": "text.stringify(value)",
           "description": "Converts values to readable text; null and undefined become empty text.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -188,6 +201,7 @@
           "signature": "json.parse(value)",
           "description": "Parses a JSON string into an object.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -204,6 +218,7 @@
           "signature": "json.stringify(value, pretty: false)",
           "description": "Converts a value to a JSON string.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -239,6 +254,7 @@
           "signature": "console.log(value)",
           "description": "Outputs a value to the console.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -255,6 +271,7 @@
           "signature": "console.warn(value)",
           "description": "Outputs a warning to the console.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -271,6 +288,7 @@
           "signature": "console.error(value)",
           "description": "Outputs an error to the console.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -287,6 +305,7 @@
           "signature": "console.table(value)",
           "description": "Outputs a table-shaped value to the host console when available.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -309,6 +328,7 @@
           "signature": "scene.setPosition(objectId: \"...\", x: 0, y: 0, z: 0)",
           "description": "Sets the position of a scene object.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "objectId",
@@ -343,6 +363,7 @@
           "signature": "scene.setRotation(objectId: \"...\", x: 0, y: 0, z: 0, w: 1)",
           "description": "Sets the rotation of a scene object (quaternion).",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "objectId",
@@ -383,6 +404,7 @@
           "signature": "scene.setScale(objectId: \"...\", x: 1, y: 1, z: 1)",
           "description": "Sets the scale of a scene object.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "objectId",
@@ -430,6 +452,7 @@
           "signature": "time.serverClock()",
           "description": "Returns the current server time.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -452,6 +475,7 @@
           "signature": "math.sine(t, freq: 1, amplitude: 1, offset: 0)",
           "description": "Computes a sine wave.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "t",
@@ -486,6 +510,7 @@
           "signature": "cosine(t, freq: 1, amplitude: 1, phase: 0, offset: 0)",
           "description": "Computes a cosine wave.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "t",
@@ -526,6 +551,7 @@
           "signature": "add(a: 0, b: 0)",
           "description": "Adds two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": [
             {
               "name": "a",
@@ -548,6 +574,7 @@
           "signature": "multiply(a: 1, b: 1)",
           "description": "Multiplies two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": [
             {
               "name": "a",
@@ -570,6 +597,7 @@
           "signature": "subtract(a: 0, b: 0)",
           "description": "Subtracts two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": [
             {
               "name": "a",
@@ -592,6 +620,7 @@
           "signature": "divide(a: 0, b: 1)",
           "description": "Divides two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": [
             {
               "name": "a",
@@ -614,6 +643,7 @@
           "signature": "mod(a: 0, b: 1)",
           "description": "Computes the modulo (remainder) of two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": [
             {
               "name": "a",
@@ -636,6 +666,7 @@
           "signature": "clamp(value: 0, min: 0, max: 1)",
           "description": "Clamps a value between min and max.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -664,6 +695,7 @@
           "signature": "map(value: 0, inMin: 0, inMax: 1, outMin: 0, outMax: 1, clamp: false)",
           "description": "Maps a value from one range to another.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -710,6 +742,7 @@
           "signature": "negate(a: 0)",
           "description": "Negates a number.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "a",
@@ -726,6 +759,7 @@
           "signature": "abs(a: 0)",
           "description": "Computes the absolute value of a number.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "a",
@@ -742,6 +776,7 @@
           "signature": "lerp(a: 0, b: 1, t: 0)",
           "description": "Linear interpolation between two values.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "a",
@@ -770,6 +805,7 @@
           "signature": "smoothstep(x: 0, edge0: 0, edge1: 1)",
           "description": "Smooth Hermite interpolation between 0 and 1.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "x",
@@ -798,6 +834,7 @@
           "signature": "greaterThan(a: 0, b: 0)",
           "description": "Compares if a > b.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "a",
@@ -820,6 +857,7 @@
           "signature": "lessThan(a: 0, b: 0)",
           "description": "Compares if a < b.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "a",
@@ -842,6 +880,7 @@
           "signature": "math.floor(value)",
           "description": "Rounds down using Math.floor.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -851,6 +890,7 @@
           "signature": "math.ceil(value)",
           "description": "Rounds up using Math.ceil.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -860,6 +900,7 @@
           "signature": "math.round(value)",
           "description": "Rounds to nearest integer using Math.round.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -869,6 +910,7 @@
           "signature": "math.min(a, b)",
           "description": "Returns the smaller of two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": []
         },
         {
@@ -878,6 +920,7 @@
           "signature": "math.max(a, b)",
           "description": "Returns the larger of two numbers.",
           "returns": "number",
+          "allowsTwoPositionalArgs": true,
           "inputs": []
         },
         {
@@ -887,6 +930,7 @@
           "signature": "math.tan(value)",
           "description": "Returns tangent using Math.tan.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -896,6 +940,7 @@
           "signature": "math.sqrt(value)",
           "description": "Returns square root using Math.sqrt.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -905,6 +950,7 @@
           "signature": "math.pow(value, exponent: 2)",
           "description": "Raises value to exponent using Math.pow.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -927,6 +973,7 @@
           "signature": "lowpass(value: 0, tau: 0.2, initial: 0)",
           "description": "Low-pass filter with exponential smoothing.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -955,6 +1002,7 @@
           "signature": "delay1(value: 0, initial: 0)",
           "description": "Delays a value by one sample.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -977,6 +1025,7 @@
           "signature": "integrate(value: 0, initial: 0, min: null, max: null)",
           "description": "Integrates a value over time.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -1011,6 +1060,7 @@
           "signature": "smoothLerp(value: 0, rate: 5, initial: 0)",
           "description": "Exponentially smooths a value with a rate parameter.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": [
             {
               "name": "value",
@@ -1049,6 +1099,7 @@
           "signature": "fs.readText(path: \"file.txt\")",
           "description": "CLI-only: reads UTF-8 text from the local filesystem.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1058,6 +1109,7 @@
           "signature": "fs.writeText(path: \"file.txt\", value: \"text\")",
           "description": "CLI-only: writes UTF-8 text to the local filesystem.",
           "returns": "void",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1067,6 +1119,7 @@
           "signature": "fs.exists(path: \"file.txt\")",
           "description": "CLI-only: returns whether a local path exists.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1076,6 +1129,7 @@
           "signature": "fs.list(path: \".\")",
           "description": "CLI-only: returns filenames in a local directory.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -1145,6 +1199,7 @@
           "signature": "logic.not(value)",
           "description": "Boolean negation using JavaScript-style truthiness.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1154,6 +1209,7 @@
           "signature": "logic.and(a, b)",
           "description": "Boolean AND using JavaScript-style truthiness, returned as a boolean.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": true,
           "inputs": []
         },
         {
@@ -1163,6 +1219,7 @@
           "signature": "logic.or(a, b)",
           "description": "Boolean OR using JavaScript-style truthiness, returned as a boolean.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": true,
           "inputs": []
         },
         {
@@ -1172,6 +1229,7 @@
           "signature": "logic.equals(value, other: value)",
           "description": "Strict equality using Object.is.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1181,6 +1239,7 @@
           "signature": "logic.notEquals(value, other: value)",
           "description": "Inverse of logic.equals.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1190,6 +1249,7 @@
           "signature": "logic.greaterThan(value, other: 0)",
           "description": "Numeric greater-than comparison.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1199,6 +1259,7 @@
           "signature": "logic.lessThan(value, other: 0)",
           "description": "Numeric less-than comparison.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1208,6 +1269,7 @@
           "signature": "logic.greaterOrEqual(value, other: 0)",
           "description": "Numeric greater-or-equal comparison.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1217,6 +1279,7 @@
           "signature": "logic.lessOrEqual(value, other: 0)",
           "description": "Numeric less-or-equal comparison.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1226,6 +1289,7 @@
           "signature": "logic.select(condition, whenTrue: value, whenFalse: value)",
           "description": "Returns whenTrue when condition is truthy using JavaScript-style truthiness, otherwise whenFalse.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1235,6 +1299,7 @@
           "signature": "logic.when(condition, value: value)",
           "description": "Returns value when condition is truthy using JavaScript-style truthiness, otherwise null.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -1257,6 +1322,7 @@
           "signature": "list.of(...values)",
           "description": "Builds a list from up to eight positional values.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1266,6 +1332,7 @@
           "signature": "list.range(start, end: 5)",
           "description": "Builds an inclusive ascending or descending numeric range.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1275,6 +1342,7 @@
           "signature": "list.length(list)",
           "description": "Returns list length.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1284,6 +1352,7 @@
           "signature": "list.at(list, index: 0)",
           "description": "Returns an item by index; negative indexes count from the end.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1293,6 +1362,7 @@
           "signature": "list.first(list)",
           "description": "Returns first item or null.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1302,6 +1372,7 @@
           "signature": "list.last(list)",
           "description": "Returns last item or null.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1311,6 +1382,7 @@
           "signature": "list.map(list, fn: fn(value) => value)",
           "description": "Returns a new list by calling fn(item) for each item.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1320,6 +1392,7 @@
           "signature": "list.filter(list, fn: fn(value) => condition)",
           "description": "Returns items where fn(item) is truthy.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1329,6 +1402,7 @@
           "signature": "list.reduce(list, fn: fn(acc, value) => next, initial: value)",
           "description": "Reduces items by calling fn(accumulator, item), starting with initial.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1338,6 +1412,7 @@
           "signature": "list.join(list, separator: \",\")",
           "description": "Joins list values into text.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1347,6 +1422,7 @@
           "signature": "list.reverse(list)",
           "description": "Returns a new reversed list.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1356,6 +1432,7 @@
           "signature": "list.sort(list)",
           "description": "Returns a new sorted list; numbers sort numerically, otherwise by string.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1365,6 +1442,7 @@
           "signature": "list.take(list, count: 2)",
           "description": "Returns the first count items.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1374,6 +1452,7 @@
           "signature": "list.drop(list, count: 2)",
           "description": "Drops the first count items.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1383,6 +1462,7 @@
           "signature": "list.concat(...lists)",
           "description": "Concatenates up to four lists.",
           "returns": "array",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -1403,6 +1483,7 @@
           "signature": "random.value()",
           "description": "Returns Math.random() in [0, 1).",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1412,6 +1493,7 @@
           "signature": "random.range(min: 0, max: 1)",
           "description": "Returns a random float in [min, max).",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1421,6 +1503,7 @@
           "signature": "random.int(min: 1, max: 6)",
           "description": "Returns a random integer in inclusive [min, max].",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1430,6 +1513,7 @@
           "signature": "random.choice(list)",
           "description": "Returns a random item or null for an empty list.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1439,6 +1523,7 @@
           "signature": "random.seeded(seed: 1)",
           "description": "Planned seeded random generator.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1448,6 +1533,7 @@
           "signature": "random.noise(...)",
           "description": "Planned noise generator.",
           "returns": "number",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]
@@ -1469,6 +1555,7 @@
           "signature": "debug.inspect(value)",
           "description": "Returns a readable string representation.",
           "returns": "string",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1478,6 +1565,7 @@
           "signature": "debug.trace(value, label: \"trace\")",
           "description": "Records a trace effect and returns the original value.",
           "returns": "any",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         },
         {
@@ -1487,6 +1575,7 @@
           "signature": "debug.assert(condition, message: \"Assertion failed\")",
           "description": "Throws ASSERTION_FAILED when condition is false.",
           "returns": "boolean",
+          "allowsTwoPositionalArgs": false,
           "inputs": []
         }
       ]

--- a/extensions/vscode-loomlet/generated/library-metadata.json
+++ b/extensions/vscode-loomlet/generated/library-metadata.json
@@ -1,0 +1,1495 @@
+{
+  "libraries": [
+    {
+      "name": "text",
+      "status": "implemented",
+      "description": "String processing utilities",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "upper",
+          "fullName": "text.upper",
+          "status": "implemented",
+          "signature": "text.upper(value)",
+          "description": "Converts text to uppercase.",
+          "returns": "string",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Input text."
+            }
+          ]
+        },
+        {
+          "name": "lower",
+          "fullName": "text.lower",
+          "status": "implemented",
+          "signature": "text.lower(value)",
+          "description": "Converts text to lowercase.",
+          "returns": "string",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Input text."
+            }
+          ]
+        },
+        {
+          "name": "trim",
+          "fullName": "text.trim",
+          "status": "implemented",
+          "signature": "text.trim(value)",
+          "description": "Removes whitespace from both ends of text.",
+          "returns": "string",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Input text."
+            }
+          ]
+        },
+        {
+          "name": "replace",
+          "fullName": "text.replace",
+          "status": "implemented",
+          "signature": "text.replace(value, search: \"...\", replacement: \"...\")",
+          "description": "Replaces all occurrences of a substring.",
+          "returns": "string",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Input text."
+            },
+            {
+              "name": "search",
+              "type": "any",
+              "positional": false,
+              "description": "Text to find and replace."
+            },
+            {
+              "name": "replacement",
+              "type": "any",
+              "positional": false,
+              "description": "Replacement text."
+            }
+          ]
+        },
+        {
+          "name": "concat",
+          "fullName": "text.concat",
+          "status": "implemented",
+          "signature": "text.concat(...values)",
+          "description": "Converts values to strings and concatenates them.",
+          "returns": "string",
+          "inputs": []
+        },
+        {
+          "name": "split",
+          "fullName": "text.split",
+          "status": "implemented",
+          "signature": "text.split(value, separator: \",\")",
+          "description": "Splits text into a list.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "join",
+          "fullName": "text.join",
+          "status": "implemented",
+          "signature": "text.join(list, separator: \",\")",
+          "description": "Joins a list into text.",
+          "returns": "string",
+          "inputs": []
+        },
+        {
+          "name": "includes",
+          "fullName": "text.includes",
+          "status": "implemented",
+          "signature": "text.includes(value, search: \"...\")",
+          "description": "Returns true when text contains the search text.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "startsWith",
+          "fullName": "text.startsWith",
+          "status": "implemented",
+          "signature": "text.startsWith(value, search: \"...\")",
+          "description": "Returns true when text starts with the search text.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "endsWith",
+          "fullName": "text.endsWith",
+          "status": "implemented",
+          "signature": "text.endsWith(value, search: \"...\")",
+          "description": "Returns true when text ends with the search text.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "length",
+          "fullName": "text.length",
+          "status": "implemented",
+          "signature": "text.length(value)",
+          "description": "Returns string length after user-facing conversion.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "isEmpty",
+          "fullName": "text.isEmpty",
+          "status": "implemented",
+          "signature": "text.isEmpty(value)",
+          "description": "Returns true when converted text has zero length.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "stringify",
+          "fullName": "text.stringify",
+          "status": "implemented",
+          "signature": "text.stringify(value)",
+          "description": "Converts values to readable text; null and undefined become empty text.",
+          "returns": "string",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "json",
+      "status": "implemented",
+      "description": "JSON parse/stringify utilities",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "parse",
+          "fullName": "json.parse",
+          "status": "implemented",
+          "signature": "json.parse(value)",
+          "description": "Parses a JSON string into an object.",
+          "returns": "any",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "JSON string to parse."
+            }
+          ]
+        },
+        {
+          "name": "stringify",
+          "fullName": "json.stringify",
+          "status": "implemented",
+          "signature": "json.stringify(value, pretty: false)",
+          "description": "Converts a value to a JSON string.",
+          "returns": "string",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Value to stringify."
+            },
+            {
+              "name": "pretty",
+              "type": "boolean",
+              "positional": false,
+              "description": "Format with indentation."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "console",
+      "status": "implemented",
+      "description": "Logging to the host environment",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "log",
+          "fullName": "console.log",
+          "status": "implemented",
+          "signature": "console.log(value)",
+          "description": "Outputs a value to the console.",
+          "returns": "void",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Value to output."
+            }
+          ]
+        },
+        {
+          "name": "warn",
+          "fullName": "console.warn",
+          "status": "implemented",
+          "signature": "console.warn(value)",
+          "description": "Outputs a warning to the console.",
+          "returns": "void",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Warning message."
+            }
+          ]
+        },
+        {
+          "name": "error",
+          "fullName": "console.error",
+          "status": "implemented",
+          "signature": "console.error(value)",
+          "description": "Outputs an error to the console.",
+          "returns": "void",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "any",
+              "positional": true,
+              "description": "Error message."
+            }
+          ]
+        },
+        {
+          "name": "table",
+          "fullName": "console.table",
+          "status": "implemented",
+          "signature": "console.table(value)",
+          "description": "Outputs a table-shaped value to the host console when available.",
+          "returns": "void",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "scene",
+      "status": "implemented",
+      "description": "Scene object control through a host adapter",
+      "targets": [
+        "cli",
+        "scenesync",
+        "unity",
+        "web"
+      ],
+      "functions": [
+        {
+          "name": "setPosition",
+          "fullName": "scene.setPosition",
+          "status": "implemented",
+          "signature": "scene.setPosition(objectId: \"...\", x: 0, y: 0, z: 0)",
+          "description": "Sets the position of a scene object.",
+          "returns": "void",
+          "inputs": [
+            {
+              "name": "objectId",
+              "type": "string",
+              "positional": true,
+              "description": "ID of the object."
+            },
+            {
+              "name": "x",
+              "type": "number",
+              "positional": false,
+              "description": "X coordinate."
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "positional": false,
+              "description": "Y coordinate."
+            },
+            {
+              "name": "z",
+              "type": "number",
+              "positional": false,
+              "description": "Z coordinate."
+            }
+          ]
+        },
+        {
+          "name": "setRotation",
+          "fullName": "scene.setRotation",
+          "status": "implemented",
+          "signature": "scene.setRotation(objectId: \"...\", x: 0, y: 0, z: 0, w: 1)",
+          "description": "Sets the rotation of a scene object (quaternion).",
+          "returns": "void",
+          "inputs": [
+            {
+              "name": "objectId",
+              "type": "string",
+              "positional": true,
+              "description": "ID of the object."
+            },
+            {
+              "name": "x",
+              "type": "number",
+              "positional": false,
+              "description": "X component of quaternion."
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "positional": false,
+              "description": "Y component of quaternion."
+            },
+            {
+              "name": "z",
+              "type": "number",
+              "positional": false,
+              "description": "Z component of quaternion."
+            },
+            {
+              "name": "w",
+              "type": "number",
+              "positional": false,
+              "description": "W component of quaternion."
+            }
+          ]
+        },
+        {
+          "name": "setScale",
+          "fullName": "scene.setScale",
+          "status": "implemented",
+          "signature": "scene.setScale(objectId: \"...\", x: 1, y: 1, z: 1)",
+          "description": "Sets the scale of a scene object.",
+          "returns": "void",
+          "inputs": [
+            {
+              "name": "objectId",
+              "type": "string",
+              "positional": true,
+              "description": "ID of the object."
+            },
+            {
+              "name": "x",
+              "type": "number",
+              "positional": false,
+              "description": "X scale."
+            },
+            {
+              "name": "y",
+              "type": "number",
+              "positional": false,
+              "description": "Y scale."
+            },
+            {
+              "name": "z",
+              "type": "number",
+              "positional": false,
+              "description": "Z scale."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time",
+      "status": "implemented",
+      "description": "Time-based source nodes",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "serverClock",
+          "fullName": "time.serverClock",
+          "status": "implemented",
+          "signature": "time.serverClock()",
+          "description": "Returns the current server time.",
+          "returns": "number",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "math",
+      "status": "implemented",
+      "description": "Pure math and numeric transform nodes",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "sine",
+          "fullName": "math.sine",
+          "status": "implemented",
+          "signature": "math.sine(t, freq: 1, amplitude: 1, offset: 0)",
+          "description": "Computes a sine wave.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "t",
+              "type": "number",
+              "positional": true,
+              "description": "Time input."
+            },
+            {
+              "name": "freq",
+              "type": "number",
+              "positional": false,
+              "description": "Frequency."
+            },
+            {
+              "name": "amplitude",
+              "type": "number",
+              "positional": false,
+              "description": "Amplitude."
+            },
+            {
+              "name": "offset",
+              "type": "number",
+              "positional": false,
+              "description": "Vertical offset."
+            }
+          ]
+        },
+        {
+          "name": "cosine",
+          "fullName": "math.cosine",
+          "status": "implemented",
+          "signature": "cosine(t, freq: 1, amplitude: 1, phase: 0, offset: 0)",
+          "description": "Computes a cosine wave.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "t",
+              "type": "number",
+              "positional": true,
+              "description": "Time input."
+            },
+            {
+              "name": "freq",
+              "type": "number",
+              "positional": false,
+              "description": "Frequency."
+            },
+            {
+              "name": "amplitude",
+              "type": "number",
+              "positional": false,
+              "description": "Amplitude."
+            },
+            {
+              "name": "phase",
+              "type": "number",
+              "positional": false,
+              "description": "Phase offset in radians."
+            },
+            {
+              "name": "offset",
+              "type": "number",
+              "positional": false,
+              "description": "Vertical offset."
+            }
+          ]
+        },
+        {
+          "name": "add",
+          "fullName": "math.add",
+          "status": "implemented",
+          "signature": "add(a: 0, b: 0)",
+          "description": "Adds two numbers.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "First number."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Second number."
+            }
+          ]
+        },
+        {
+          "name": "multiply",
+          "fullName": "math.multiply",
+          "status": "implemented",
+          "signature": "multiply(a: 1, b: 1)",
+          "description": "Multiplies two numbers.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "First number."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Second number."
+            }
+          ]
+        },
+        {
+          "name": "subtract",
+          "fullName": "math.subtract",
+          "status": "implemented",
+          "signature": "subtract(a: 0, b: 0)",
+          "description": "Subtracts two numbers.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "First number."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Second number."
+            }
+          ]
+        },
+        {
+          "name": "divide",
+          "fullName": "math.divide",
+          "status": "implemented",
+          "signature": "divide(a: 0, b: 1)",
+          "description": "Divides two numbers.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "Dividend."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Divisor."
+            }
+          ]
+        },
+        {
+          "name": "mod",
+          "fullName": "math.mod",
+          "status": "implemented",
+          "signature": "mod(a: 0, b: 1)",
+          "description": "Computes the modulo (remainder) of two numbers.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "Dividend."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Divisor."
+            }
+          ]
+        },
+        {
+          "name": "clamp",
+          "fullName": "math.clamp",
+          "status": "implemented",
+          "signature": "clamp(value: 0, min: 0, max: 1)",
+          "description": "Clamps a value between min and max.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "number",
+              "positional": false,
+              "description": "Value to clamp."
+            },
+            {
+              "name": "min",
+              "type": "number",
+              "positional": false,
+              "description": "Minimum value."
+            },
+            {
+              "name": "max",
+              "type": "number",
+              "positional": false,
+              "description": "Maximum value."
+            }
+          ]
+        },
+        {
+          "name": "map",
+          "fullName": "math.map",
+          "status": "implemented",
+          "signature": "map(value: 0, inMin: 0, inMax: 1, outMin: 0, outMax: 1, clamp: false)",
+          "description": "Maps a value from one range to another.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "number",
+              "positional": false,
+              "description": "Value to map."
+            },
+            {
+              "name": "inMin",
+              "type": "number",
+              "positional": false,
+              "description": "Input range minimum."
+            },
+            {
+              "name": "inMax",
+              "type": "number",
+              "positional": false,
+              "description": "Input range maximum."
+            },
+            {
+              "name": "outMin",
+              "type": "number",
+              "positional": false,
+              "description": "Output range minimum."
+            },
+            {
+              "name": "outMax",
+              "type": "number",
+              "positional": false,
+              "description": "Output range maximum."
+            },
+            {
+              "name": "clamp",
+              "type": "boolean",
+              "positional": false,
+              "description": "Clamp output to range."
+            }
+          ]
+        },
+        {
+          "name": "negate",
+          "fullName": "math.negate",
+          "status": "implemented",
+          "signature": "negate(a: 0)",
+          "description": "Negates a number.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "Number to negate."
+            }
+          ]
+        },
+        {
+          "name": "abs",
+          "fullName": "math.abs",
+          "status": "implemented",
+          "signature": "abs(a: 0)",
+          "description": "Computes the absolute value of a number.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "Number."
+            }
+          ]
+        },
+        {
+          "name": "lerp",
+          "fullName": "math.lerp",
+          "status": "implemented",
+          "signature": "lerp(a: 0, b: 1, t: 0)",
+          "description": "Linear interpolation between two values.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "Start value."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "End value."
+            },
+            {
+              "name": "t",
+              "type": "number",
+              "positional": false,
+              "description": "Interpolation factor (0 to 1)."
+            }
+          ]
+        },
+        {
+          "name": "smoothstep",
+          "fullName": "math.smoothstep",
+          "status": "implemented",
+          "signature": "smoothstep(x: 0, edge0: 0, edge1: 1)",
+          "description": "Smooth Hermite interpolation between 0 and 1.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "x",
+              "type": "number",
+              "positional": false,
+              "description": "Input value."
+            },
+            {
+              "name": "edge0",
+              "type": "number",
+              "positional": false,
+              "description": "Lower edge."
+            },
+            {
+              "name": "edge1",
+              "type": "number",
+              "positional": false,
+              "description": "Upper edge."
+            }
+          ]
+        },
+        {
+          "name": "greaterThan",
+          "fullName": "math.greaterThan",
+          "status": "implemented",
+          "signature": "greaterThan(a: 0, b: 0)",
+          "description": "Compares if a > b.",
+          "returns": "boolean",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "First number."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Second number."
+            }
+          ]
+        },
+        {
+          "name": "lessThan",
+          "fullName": "math.lessThan",
+          "status": "implemented",
+          "signature": "lessThan(a: 0, b: 0)",
+          "description": "Compares if a < b.",
+          "returns": "boolean",
+          "inputs": [
+            {
+              "name": "a",
+              "type": "number",
+              "positional": false,
+              "description": "First number."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Second number."
+            }
+          ]
+        },
+        {
+          "name": "floor",
+          "fullName": "math.floor",
+          "status": "implemented",
+          "signature": "math.floor(value)",
+          "description": "Rounds down using Math.floor.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "ceil",
+          "fullName": "math.ceil",
+          "status": "implemented",
+          "signature": "math.ceil(value)",
+          "description": "Rounds up using Math.ceil.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "round",
+          "fullName": "math.round",
+          "status": "implemented",
+          "signature": "math.round(value)",
+          "description": "Rounds to nearest integer using Math.round.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "min",
+          "fullName": "math.min",
+          "status": "implemented",
+          "signature": "math.min(a, b)",
+          "description": "Returns the smaller of two numbers.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "max",
+          "fullName": "math.max",
+          "status": "implemented",
+          "signature": "math.max(a, b)",
+          "description": "Returns the larger of two numbers.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "tan",
+          "fullName": "math.tan",
+          "status": "implemented",
+          "signature": "math.tan(value)",
+          "description": "Returns tangent using Math.tan.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "sqrt",
+          "fullName": "math.sqrt",
+          "status": "implemented",
+          "signature": "math.sqrt(value)",
+          "description": "Returns square root using Math.sqrt.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "pow",
+          "fullName": "math.pow",
+          "status": "implemented",
+          "signature": "math.pow(value, exponent: 2)",
+          "description": "Raises value to exponent using Math.pow.",
+          "returns": "number",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "state",
+      "status": "implemented",
+      "description": "Explicit time-based state nodes",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "lowpass",
+          "fullName": "state.lowpass",
+          "status": "implemented",
+          "signature": "lowpass(value: 0, tau: 0.2, initial: 0)",
+          "description": "Low-pass filter with exponential smoothing.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "number",
+              "positional": true,
+              "description": "Input value."
+            },
+            {
+              "name": "tau",
+              "type": "number",
+              "positional": false,
+              "description": "Time constant (larger = more smoothing)."
+            },
+            {
+              "name": "initial",
+              "type": "number",
+              "positional": false,
+              "description": "Initial state value."
+            }
+          ]
+        },
+        {
+          "name": "delay1",
+          "fullName": "state.delay1",
+          "status": "implemented",
+          "signature": "delay1(value: 0, initial: 0)",
+          "description": "Delays a value by one sample.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "number",
+              "positional": true,
+              "description": "Input value."
+            },
+            {
+              "name": "initial",
+              "type": "number",
+              "positional": false,
+              "description": "Initial state value."
+            }
+          ]
+        },
+        {
+          "name": "integrate",
+          "fullName": "state.integrate",
+          "status": "implemented",
+          "signature": "integrate(value: 0, initial: 0, min: null, max: null)",
+          "description": "Integrates a value over time.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "number",
+              "positional": true,
+              "description": "Input value to integrate."
+            },
+            {
+              "name": "initial",
+              "type": "number",
+              "positional": false,
+              "description": "Initial state value."
+            },
+            {
+              "name": "min",
+              "type": "number|null",
+              "positional": false,
+              "description": "Minimum bound (optional)."
+            },
+            {
+              "name": "max",
+              "type": "number|null",
+              "positional": false,
+              "description": "Maximum bound (optional)."
+            }
+          ]
+        },
+        {
+          "name": "smoothLerp",
+          "fullName": "state.smoothLerp",
+          "status": "implemented",
+          "signature": "smoothLerp(value: 0, rate: 5, initial: 0)",
+          "description": "Exponentially smooths a value with a rate parameter.",
+          "returns": "number",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "number",
+              "positional": true,
+              "description": "Input value."
+            },
+            {
+              "name": "rate",
+              "type": "number",
+              "positional": false,
+              "description": "Smoothing rate (higher = faster response)."
+            },
+            {
+              "name": "initial",
+              "type": "number",
+              "positional": false,
+              "description": "Initial state value."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fs",
+      "status": "implemented",
+      "description": "CLI-only file system access",
+      "targets": [
+        "cli"
+      ],
+      "functions": [
+        {
+          "name": "readText",
+          "fullName": "fs.readText",
+          "status": "implemented",
+          "signature": "fs.readText(path: \"file.txt\")",
+          "description": "CLI-only: reads UTF-8 text from the local filesystem.",
+          "returns": "string",
+          "inputs": []
+        },
+        {
+          "name": "writeText",
+          "fullName": "fs.writeText",
+          "status": "implemented",
+          "signature": "fs.writeText(path: \"file.txt\", value: \"text\")",
+          "description": "CLI-only: writes UTF-8 text to the local filesystem.",
+          "returns": "void",
+          "inputs": []
+        },
+        {
+          "name": "exists",
+          "fullName": "fs.exists",
+          "status": "implemented",
+          "signature": "fs.exists(path: \"file.txt\")",
+          "description": "CLI-only: returns whether a local path exists.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "list",
+          "fullName": "fs.list",
+          "status": "implemented",
+          "signature": "fs.list(path: \".\")",
+          "description": "CLI-only: returns filenames in a local directory.",
+          "returns": "array",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "dom",
+      "status": "planned",
+      "description": "DOM input and DOM sink nodes",
+      "targets": [
+        "web"
+      ],
+      "functions": []
+    },
+    {
+      "name": "canvas",
+      "status": "planned",
+      "description": "Canvas preview renderer",
+      "targets": [
+        "web"
+      ],
+      "functions": []
+    },
+    {
+      "name": "three",
+      "status": "planned",
+      "description": "Three.js Object3D adapter",
+      "targets": [
+        "web"
+      ],
+      "functions": []
+    },
+    {
+      "name": "unity",
+      "status": "planned",
+      "description": "Unity-specific runtime adapter",
+      "targets": [
+        "unity"
+      ],
+      "functions": []
+    },
+    {
+      "name": "scenesync",
+      "status": "planned",
+      "description": "SceneSync graph/message integration",
+      "targets": [
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": []
+    },
+    {
+      "name": "logic",
+      "status": "implemented",
+      "description": "Boolean logic, comparison, and selection nodes",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "not",
+          "fullName": "logic.not",
+          "status": "implemented",
+          "signature": "logic.not(value)",
+          "description": "Boolean negation using JavaScript-style truthiness.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "and",
+          "fullName": "logic.and",
+          "status": "implemented",
+          "signature": "logic.and(a, b)",
+          "description": "Boolean AND using JavaScript-style truthiness, returned as a boolean.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "or",
+          "fullName": "logic.or",
+          "status": "implemented",
+          "signature": "logic.or(a, b)",
+          "description": "Boolean OR using JavaScript-style truthiness, returned as a boolean.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "equals",
+          "fullName": "logic.equals",
+          "status": "implemented",
+          "signature": "logic.equals(value, other: value)",
+          "description": "Strict equality using Object.is.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "notEquals",
+          "fullName": "logic.notEquals",
+          "status": "implemented",
+          "signature": "logic.notEquals(value, other: value)",
+          "description": "Inverse of logic.equals.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "greaterThan",
+          "fullName": "logic.greaterThan",
+          "status": "implemented",
+          "signature": "logic.greaterThan(value, other: 0)",
+          "description": "Numeric greater-than comparison.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "lessThan",
+          "fullName": "logic.lessThan",
+          "status": "implemented",
+          "signature": "logic.lessThan(value, other: 0)",
+          "description": "Numeric less-than comparison.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "greaterOrEqual",
+          "fullName": "logic.greaterOrEqual",
+          "status": "implemented",
+          "signature": "logic.greaterOrEqual(value, other: 0)",
+          "description": "Numeric greater-or-equal comparison.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "lessOrEqual",
+          "fullName": "logic.lessOrEqual",
+          "status": "implemented",
+          "signature": "logic.lessOrEqual(value, other: 0)",
+          "description": "Numeric less-or-equal comparison.",
+          "returns": "boolean",
+          "inputs": []
+        },
+        {
+          "name": "select",
+          "fullName": "logic.select",
+          "status": "implemented",
+          "signature": "logic.select(condition, whenTrue: value, whenFalse: value)",
+          "description": "Returns whenTrue when condition is truthy using JavaScript-style truthiness, otherwise whenFalse.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "when",
+          "fullName": "logic.when",
+          "status": "implemented",
+          "signature": "logic.when(condition, value: value)",
+          "description": "Returns value when condition is truthy using JavaScript-style truthiness, otherwise null.",
+          "returns": "any",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "list",
+      "status": "implemented",
+      "description": "List construction and transformation nodes",
+      "targets": [
+        "cli",
+        "web",
+        "scenesync",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "of",
+          "fullName": "list.of",
+          "status": "implemented",
+          "signature": "list.of(...values)",
+          "description": "Builds a list from up to eight positional values.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "range",
+          "fullName": "list.range",
+          "status": "implemented",
+          "signature": "list.range(start, end: 5)",
+          "description": "Builds an inclusive ascending or descending numeric range.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "length",
+          "fullName": "list.length",
+          "status": "implemented",
+          "signature": "list.length(list)",
+          "description": "Returns list length.",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "at",
+          "fullName": "list.at",
+          "status": "implemented",
+          "signature": "list.at(list, index: 0)",
+          "description": "Returns an item by index; negative indexes count from the end.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "first",
+          "fullName": "list.first",
+          "status": "implemented",
+          "signature": "list.first(list)",
+          "description": "Returns first item or null.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "last",
+          "fullName": "list.last",
+          "status": "implemented",
+          "signature": "list.last(list)",
+          "description": "Returns last item or null.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "map",
+          "fullName": "list.map",
+          "status": "implemented",
+          "signature": "list.map(list, fn: fn(value) => value)",
+          "description": "Returns a new list by calling fn(item) for each item.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "filter",
+          "fullName": "list.filter",
+          "status": "implemented",
+          "signature": "list.filter(list, fn: fn(value) => condition)",
+          "description": "Returns items where fn(item) is truthy.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "reduce",
+          "fullName": "list.reduce",
+          "status": "implemented",
+          "signature": "list.reduce(list, fn: fn(acc, value) => next, initial: value)",
+          "description": "Reduces items by calling fn(accumulator, item), starting with initial.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "join",
+          "fullName": "list.join",
+          "status": "implemented",
+          "signature": "list.join(list, separator: \",\")",
+          "description": "Joins list values into text.",
+          "returns": "string",
+          "inputs": []
+        },
+        {
+          "name": "reverse",
+          "fullName": "list.reverse",
+          "status": "implemented",
+          "signature": "list.reverse(list)",
+          "description": "Returns a new reversed list.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "sort",
+          "fullName": "list.sort",
+          "status": "implemented",
+          "signature": "list.sort(list)",
+          "description": "Returns a new sorted list; numbers sort numerically, otherwise by string.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "take",
+          "fullName": "list.take",
+          "status": "implemented",
+          "signature": "list.take(list, count: 2)",
+          "description": "Returns the first count items.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "drop",
+          "fullName": "list.drop",
+          "status": "implemented",
+          "signature": "list.drop(list, count: 2)",
+          "description": "Drops the first count items.",
+          "returns": "array",
+          "inputs": []
+        },
+        {
+          "name": "concat",
+          "fullName": "list.concat",
+          "status": "implemented",
+          "signature": "list.concat(...lists)",
+          "description": "Concatenates up to four lists.",
+          "returns": "array",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "random",
+      "status": "implemented",
+      "description": "Non-deterministic random value generation nodes",
+      "targets": [
+        "cli",
+        "web"
+      ],
+      "functions": [
+        {
+          "name": "value",
+          "fullName": "random.value",
+          "status": "implemented",
+          "signature": "random.value()",
+          "description": "Returns Math.random() in [0, 1).",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "range",
+          "fullName": "random.range",
+          "status": "implemented",
+          "signature": "random.range(min: 0, max: 1)",
+          "description": "Returns a random float in [min, max).",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "int",
+          "fullName": "random.int",
+          "status": "implemented",
+          "signature": "random.int(min: 1, max: 6)",
+          "description": "Returns a random integer in inclusive [min, max].",
+          "returns": "number",
+          "inputs": []
+        },
+        {
+          "name": "choice",
+          "fullName": "random.choice",
+          "status": "implemented",
+          "signature": "random.choice(list)",
+          "description": "Returns a random item or null for an empty list.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "seeded",
+          "fullName": "random.seeded",
+          "status": "planned",
+          "signature": "random.seeded(seed: 1)",
+          "description": "Planned seeded random generator.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "noise",
+          "fullName": "random.noise",
+          "status": "planned",
+          "signature": "random.noise(...)",
+          "description": "Planned noise generator.",
+          "returns": "number",
+          "inputs": []
+        }
+      ]
+    },
+    {
+      "name": "debug",
+      "status": "implemented",
+      "description": "Debug inspection, tracing, and assertion nodes",
+      "targets": [
+        "cli",
+        "web",
+        "unity"
+      ],
+      "functions": [
+        {
+          "name": "inspect",
+          "fullName": "debug.inspect",
+          "status": "implemented",
+          "signature": "debug.inspect(value)",
+          "description": "Returns a readable string representation.",
+          "returns": "string",
+          "inputs": []
+        },
+        {
+          "name": "trace",
+          "fullName": "debug.trace",
+          "status": "implemented",
+          "signature": "debug.trace(value, label: \"trace\")",
+          "description": "Records a trace effect and returns the original value.",
+          "returns": "any",
+          "inputs": []
+        },
+        {
+          "name": "assert",
+          "fullName": "debug.assert",
+          "status": "implemented",
+          "signature": "debug.assert(condition, message: \"Assertion failed\")",
+          "description": "Throws ASSERTION_FAILED when condition is false.",
+          "returns": "boolean",
+          "inputs": []
+        }
+      ]
+    }
+  ]
+}

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -46,9 +46,19 @@
         "command": "loomlet.sceneSyncDevCurrentFile",
         "title": "Loomlet: Scene Sync Dev Current File"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Loomlet",
+      "properties": {
+        "loomlet.completion.includePlanned": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include planned Loomlet libraries/functions in completion suggestions."
+        }
+      }
+    }
   },
   "scripts": {
-    "test": "node test/completion-context.test.mjs"
+    "test": "node test/completion-context.test.mjs && node test/completion-engine.test.mjs"
   }
 }

--- a/extensions/vscode-loomlet/src/completion-engine.js
+++ b/extensions/vscode-loomlet/src/completion-engine.js
@@ -1,0 +1,89 @@
+const path = require('node:path');
+const metadata = require('../generated/library-metadata.json');
+
+function getIncludePlanned(configGetter) {
+  return Boolean(configGetter?.('loomlet.completion.includePlanned'));
+}
+
+function buildCompletionModel(includePlanned = false) {
+  const libraries = (metadata.libraries || [])
+    .filter((lib) => includePlanned || lib.status === 'implemented');
+  return libraries.map((lib) => ({
+    ...lib,
+    functions: (lib.functions || []).filter((fn) => includePlanned || fn.status === 'implemented')
+  }));
+}
+
+function inferPlaceholder(arg) {
+  if (arg.type?.includes('string')) return '"sample"';
+  if (arg.type?.includes('number')) return '0';
+  if (arg.type?.includes('boolean')) return 'false';
+  return arg.name;
+}
+
+function buildFunctionSnippet(member) {
+  const args = member.inputs || [];
+  const parts = [];
+  let index = 1;
+  args.forEach((arg, i) => {
+    const placeholder = inferPlaceholder(arg);
+    if (i === 0 || arg.positional) {
+      parts.push(`\${${index}:${placeholder}}`);
+    } else {
+      parts.push(`${arg.name}: \${${index}:${placeholder}}`);
+    }
+    index += 1;
+  });
+  return `${member.name}(${parts.join(', ')})`;
+}
+
+function toSignature(libName, member) {
+  return member.signature || `${libName}.${member.name}()`;
+}
+
+function buildCompletions(ctx, includePlanned = false) {
+  const libs = buildCompletionModel(includePlanned);
+  if (ctx.kind === 'import') {
+    return libs.map((lib) => ({
+      type: 'module',
+      label: lib.name,
+      insertText: lib.name,
+      detail: lib.targets?.length === 1 && lib.targets[0] === 'cli' ? 'CLI only' : `${lib.name} library`,
+      documentation: lib.description
+    }));
+  }
+
+  if (ctx.kind === 'member' && ctx.library) {
+    const lib = libs.find((entry) => entry.name === ctx.library);
+    if (!lib) return [];
+    return lib.functions.map((member) => ({
+      type: 'function',
+      label: member.name,
+      insertText: buildFunctionSnippet(member),
+      detail: includePlanned && member.status !== 'implemented' ? `${toSignature(lib.name, member)} (planned)` : toSignature(lib.name, member),
+      documentation: member.description,
+      namedArgs: (member.inputs || []).filter((a, i) => i > 0 || !a.positional).map((a) => a.name)
+    }));
+  }
+
+  if (ctx.kind === 'callArgs' && ctx.library && ctx.functionName) {
+    const lib = libs.find((entry) => entry.name === ctx.library);
+    const member = lib?.functions.find((fn) => fn.name === ctx.functionName);
+    if (!member) return [];
+    const used = new Set(ctx.alreadyUsedArgNames || []);
+    return (member.inputs || [])
+      .map((input) => input.name)
+      .filter((name) => !used.has(name))
+      .map((name) => ({
+        type: 'property',
+        label: `${name}:`,
+        insertText: `${name}: $0`,
+        detail: `${ctx.library}.${ctx.functionName} named argument`,
+        documentation: `Named argument for ${ctx.library}.${ctx.functionName}.`
+      }));
+  }
+
+  return [];
+}
+
+module.exports = { buildCompletions, getIncludePlanned, buildFunctionSnippet };

--- a/extensions/vscode-loomlet/src/completion-engine.js
+++ b/extensions/vscode-loomlet/src/completion-engine.js
@@ -1,4 +1,3 @@
-const path = require('node:path');
 const metadata = require('../generated/library-metadata.json');
 
 function getIncludePlanned(configGetter) {
@@ -27,7 +26,8 @@ function buildFunctionSnippet(member) {
   let index = 1;
   args.forEach((arg, i) => {
     const placeholder = inferPlaceholder(arg);
-    if (i === 0 || arg.positional) {
+    const usePositional = i === 0 || (i === 1 && member.allowsTwoPositionalArgs);
+    if (usePositional) {
       parts.push(`\${${index}:${placeholder}}`);
     } else {
       parts.push(`${arg.name}: \${${index}:${placeholder}}`);

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -2,7 +2,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vscode = require('vscode');
 const { getCompletionContext } = require('./completion-context');
-const { libraries, libraryMembers, topLevelSnippets } = require('./completion-data');
+const { buildCompletions: buildRawCompletions, getIncludePlanned } = require('./completion-engine');
 
 function activate(context) {
   const provider = {
@@ -27,74 +27,23 @@ function activate(context) {
 function deactivate() {}
 
 function buildCompletions(ctx) {
-  if (ctx.kind === 'import') {
-    return libraries.map((lib) => {
-      const item = new vscode.CompletionItem(lib.name, vscode.CompletionItemKind.Module);
-      item.insertText = lib.name;
-      item.detail = `${lib.name} library`;
-      item.documentation = lib.description;
-      return item;
-    });
-  }
-
-  if (ctx.kind === 'member' && ctx.library && libraryMembers[ctx.library]) {
-    return libraryMembers[ctx.library].map((member) => {
-      const item = new vscode.CompletionItem(member.label, vscode.CompletionItemKind.Function);
-      item.insertText = new vscode.SnippetString(member.insertText);
-      item.detail = member.detail;
-      item.documentation = member.documentation;
-      return item;
-    });
-  }
-
-  if (ctx.kind === 'callArgs' && ctx.library && ctx.functionName) {
-    const member = (libraryMembers[ctx.library] || []).find((entry) => entry.label.startsWith(ctx.functionName));
-    if (!member) return [];
-    const used = new Set(ctx.alreadyUsedArgNames || []);
-    return (member.namedArgs || [])
-      .filter((arg) => !used.has(arg))
-      .map((arg) => {
-        const item = new vscode.CompletionItem(`${arg}:`, vscode.CompletionItemKind.Property);
-        item.insertText = new vscode.SnippetString(`${arg}: $0`);
-        item.detail = `${ctx.library}.${ctx.functionName} named argument`;
-        item.documentation = `Named argument for ${ctx.library}.${ctx.functionName}.`;
-        return item;
-      });
-  }
-
-  if (ctx.kind === 'topLevel') {
-    const items = [];
-    for (const lib of ['time', 'math', 'scene', 'console']) {
-      const imp = new vscode.CompletionItem(`import ${lib}`, vscode.CompletionItemKind.Keyword);
-      imp.insertText = new vscode.SnippetString(`import ${lib}`);
-      imp.detail = 'Import library';
-      items.push(imp);
-    }
-
-    for (const lib of ['time', 'math', 'scene', 'console']) {
-      for (const member of libraryMembers[lib] || []) {
-        const fn = new vscode.CompletionItem(member.topLevelInsertText.replace(/\$\{\d+:?/g, '').replace(/\}/g, ''), vscode.CompletionItemKind.Function);
-        fn.label = member.detail;
-        fn.insertText = new vscode.SnippetString(member.topLevelInsertText);
-        fn.detail = member.detail;
-        fn.documentation = member.documentation;
-        items.push(fn);
-      }
-    }
-
-    for (const snippet of topLevelSnippets) {
-      const item = new vscode.CompletionItem(snippet.label, vscode.CompletionItemKind.Snippet);
-      item.insertText = new vscode.SnippetString(snippet.insertText);
-      item.detail = snippet.detail;
-      item.documentation = snippet.documentation;
-      items.push(item);
-    }
-
-    return items;
-  }
-
-  return [];
+  const includePlanned = getIncludePlanned((key) => vscode.workspace.getConfiguration().get(key));
+  const rawItems = buildRawCompletions(ctx, includePlanned);
+  return rawItems.map((entry) => {
+    let kind = vscode.CompletionItemKind.Text;
+    if (entry.type === "module") kind = vscode.CompletionItemKind.Module;
+    else if (entry.type === "function") kind = vscode.CompletionItemKind.Function;
+    else if (entry.type === "property") kind = vscode.CompletionItemKind.Property;
+    const item = new vscode.CompletionItem(entry.label, kind);
+    item.insertText = entry.type === "function" || entry.type === "property"
+      ? new vscode.SnippetString(entry.insertText)
+      : entry.insertText;
+    item.detail = entry.detail;
+    item.documentation = entry.documentation;
+    return item;
+  });
 }
+
 
 async function runCurrentFile(command) {
   const editor = vscode.window.activeTextEditor;
@@ -179,5 +128,6 @@ function searchUpForCli(startDir) {
 module.exports = {
   activate,
   deactivate,
-  findLoomletCli
+  findLoomletCli,
+  buildCompletions
 };

--- a/extensions/vscode-loomlet/test/completion-engine.test.mjs
+++ b/extensions/vscode-loomlet/test/completion-engine.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { getCompletionContext } = require('../src/completion-context.js');
+const { buildCompletions } = require('../src/completion-engine.js');
+
+function labels(source) {
+  const ctx = getCompletionContext(source, source.length);
+  return buildCompletions(ctx, false).map((item) => item.label);
+}
+
+test('import completion includes implemented libraries', () => {
+  const got = labels('import ');
+  for (const name of ['math', 'logic', 'list', 'scene']) {
+    assert.ok(got.includes(name));
+  }
+});
+
+test('member completion includes logic/list/scene functions', () => {
+  assert.ok(labels('logic.').includes('select'));
+  assert.ok(labels('logic.').includes('equals'));
+  assert.ok(labels('logic.').includes('and'));
+  assert.ok(labels('logic.').includes('or'));
+
+  assert.ok(labels('list.').includes('range'));
+  assert.ok(labels('list.').includes('map'));
+  assert.ok(labels('list.').includes('filter'));
+  assert.ok(labels('list.').includes('reduce'));
+
+  assert.ok(labels('scene.').includes('setPosition'));
+  assert.ok(labels('scene.').includes('setRotation'));
+  assert.ok(labels('scene.').includes('setScale'));
+});
+
+test('argument completion excludes already-used names', () => {
+  const got = labels('scene.setPosition(objectId: "sample-cube", ');
+  assert.ok(got.includes('x:'));
+  assert.ok(got.includes('y:'));
+  assert.ok(got.includes('z:'));
+  assert.ok(!got.includes('objectId:'));
+});
+
+test('planned items excluded by default and shown when enabled', () => {
+  const defaultItems = buildCompletions(getCompletionContext('random.', 'random.'.length), false).map((i) => i.label);
+  assert.ok(!defaultItems.includes('seeded'));
+
+  const plannedItems = buildCompletions(getCompletionContext('random.', 'random.'.length), true).map((i) => i.label);
+  assert.ok(plannedItems.includes('seeded'));
+});

--- a/extensions/vscode-loomlet/test/completion-engine.test.mjs
+++ b/extensions/vscode-loomlet/test/completion-engine.test.mjs
@@ -49,3 +49,23 @@ test('planned items excluded by default and shown when enabled', () => {
   const plannedItems = buildCompletions(getCompletionContext('random.', 'random.'.length), true).map((i) => i.label);
   assert.ok(plannedItems.includes('seeded'));
 });
+
+test('binary operator snippets use two positional args', () => {
+  const items = buildCompletions(getCompletionContext('math.', 'math.'.length), false);
+  const add = items.find((i) => i.label === 'add');
+  const mod = items.find((i) => i.label === 'mod');
+  assert.equal(add.insertText, 'add(${1:0}, ${2:0})');
+  assert.equal(mod.insertText, 'mod(${1:0}, ${2:0})');
+});
+
+test('multi-argument snippets keep named args after first arg', () => {
+  const items = buildCompletions(getCompletionContext('math.', 'math.'.length), false);
+  const map = items.find((i) => i.label === 'map');
+  assert.match(map.insertText, /map\(\$\{1:0\}, inMin:/);
+});
+
+test('scene snippets keep named args after first positional argument', () => {
+  const items = buildCompletions(getCompletionContext('scene.', 'scene.'.length), false);
+  const setPosition = items.find((i) => i.label === 'setPosition');
+  assert.match(setPosition.insertText, /setPosition\(\$\{1:"sample"\}, x:/);
+});

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
-    "test:browser": "node ci/run-tests.mjs"
+    "test:browser": "node ci/run-tests.mjs",
+    "generate:vscode-metadata": "node scripts/generate-vscode-metadata.mjs"
   },
   "devDependencies": {
     "http-server": "^14.1.1",

--- a/scripts/generate-vscode-metadata.mjs
+++ b/scripts/generate-vscode-metadata.mjs
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
+import { canUseTwoPositionalArgs } from '../src/loom.js';
 import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
 
 function toGenerated() {
@@ -15,6 +16,7 @@ function toGenerated() {
       signature: fn.signature ?? `${lib.name}.${fn.name}()`,
       description: fn.description ?? '',
       returns: fn.returns ?? 'any',
+      allowsTwoPositionalArgs: canUseTwoPositionalArgs(`${lib.name}.${fn.name}`, { inputs: fn.args ?? [] }),
       inputs: (fn.args ?? []).map((arg) => ({
         name: arg.name,
         type: arg.type ?? 'any',

--- a/scripts/generate-vscode-metadata.mjs
+++ b/scripts/generate-vscode-metadata.mjs
@@ -1,0 +1,33 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
+
+function toGenerated() {
+  const libraries = Object.values(LIBRARY_METADATA).map((lib) => ({
+    name: lib.name,
+    status: lib.status ?? 'implemented',
+    description: lib.description ?? '',
+    targets: lib.targets ?? [],
+    functions: Object.values(lib.functions ?? {}).map((fn) => ({
+      name: fn.name,
+      fullName: `${lib.name}.${fn.name}`,
+      status: fn.status ?? 'implemented',
+      signature: fn.signature ?? `${lib.name}.${fn.name}()`,
+      description: fn.description ?? '',
+      returns: fn.returns ?? 'any',
+      inputs: (fn.args ?? []).map((arg) => ({
+        name: arg.name,
+        type: arg.type ?? 'any',
+        positional: Boolean(arg.positional),
+        description: arg.description ?? ''
+      }))
+    }))
+  }));
+
+  return { libraries };
+}
+
+const outPath = resolve('extensions/vscode-loomlet/generated/library-metadata.json');
+await mkdir(dirname(outPath), { recursive: true });
+await writeFile(outPath, `${JSON.stringify(toGenerated(), null, 2)}\n`, 'utf8');
+console.log(`Wrote ${outPath}`);


### PR DESCRIPTION
### Motivation
- Make the VS Code extension use Loomlet's canonical library metadata as the source of truth for completions to avoid duplicated/hardcoded lists and drift as libraries grow. 
- Allow completions to reflect library `status` (implemented vs planned) and expose a setting to include planned items when desired. 

### Description
- Add a metadata generation script `scripts/generate-vscode-metadata.mjs` that imports `src/toolchain/library-metadata.js` and writes `extensions/vscode-loomlet/generated/library-metadata.json` for extension consumption. 
- Introduce a metadata-driven completion engine `extensions/vscode-loomlet/src/completion-engine.js` that provides import, member, snippet, and named-argument completions (including filtering of already-used named args) and builds function snippets from metadata. 
- Update the extension host (`extensions/vscode-loomlet/src/extension.js`) to consume the new engine and to respect the `loomlet.completion.includePlanned` configuration when building completion items. 
- Add the VS Code setting `loomlet.completion.includePlanned` (default `false`) in `extensions/vscode-loomlet/package.json` so planned items are hidden by default. 
- Commit generated metadata JSON so the extension works locally without requiring build-time generation, and add a root npm script `generate:vscode-metadata` to regenerate the JSON from source metadata. 
- Add automated tests `extensions/vscode-loomlet/test/completion-engine.test.mjs` that validate import/member/argument completions and planned-item visibility, and wire the test into the extension's `test` script. 
- Update `extensions/vscode-loomlet/README.md` with a note about regenerating completions (`npm run generate:vscode-metadata`). 

### Testing
- Ran `npm run generate:vscode-metadata` which successfully wrote `extensions/vscode-loomlet/generated/library-metadata.json` (succeeds). 
- Executed extension completion tests with `node extensions/vscode-loomlet/test/completion-engine.test.mjs` which passed (import/member/argument/planned checks OK). 
- Ran the extension test bundle `npm --prefix extensions/vscode-loomlet test` which passed. 
- Ran the repository test suite with `npm test` and observed successful completion of the automated test suites (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe03f075083208b207e2092842f63)