### PR TITLE
Improve Loomlet REPL usability for interactive library exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ loomlet> :quit
 The REPL currently recompiles the accumulated source after each snippet. Invalid snippets are rejected and do not modify the current session.
 Import snippets are hoisted into the import block automatically, so you can add imports later while exploring.
 The REPL recompiles the accumulated source after each snippet, but it only displays effects introduced by the latest snippet.
+See [docs/REPL.md](docs/REPL.md) for full command reference.
 
 ### Scene Sync probe commands
 

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -188,6 +188,11 @@ Commands:
   :libs              List all available libraries
   :help <library>    Show functions in a library
   :help <lib.func>   Show function documentation
+  :load <file>       Load and evaluate a Loom file in this session
+  :run <file>        Run a Loom file without mutating this session
+  :vars              Show current variables
+  :history           Show current session input history
+  :clear             Clear the terminal (or print blank lines)
   :source            Show accumulated source
   :inspect           Show current graph summary
   :graph             Show current GraphJSON
@@ -195,6 +200,24 @@ Commands:
   :quit              Exit the REPL
   :q                 Exit the REPL
   :exit              Exit the REPL`;
+}
+
+function formatReplVarValue(value) {
+  if (typeof value === 'function') {
+    return '<function>';
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  try {
+    const text = JSON.stringify(value);
+    if (!text) {
+      return String(value);
+    }
+    return text.length > 120 ? `${text.slice(0, 117)}...` : text;
+  } catch {
+    return String(value);
+  }
 }
 
 function getSceneSyncHelp() {
@@ -1539,7 +1562,7 @@ async function handleRepl(args) {
   return await new Promise((resolve) => {
     rl.prompt();
 
-    rl.on('line', (line) => {
+    rl.on('line', async (line) => {
       const trimmed = line.trim();
       if (trimmed === ':quit' || trimmed === ':q' || trimmed === ':exit') {
         rl.close();
@@ -1552,6 +1575,40 @@ async function handleRepl(args) {
       }
       if (trimmed === ':libs') {
         print(formatLibrariesText());
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':vars') {
+        const variables = session.getVariables();
+        if (variables.length === 0) {
+          print('Variables:\n\n<none>');
+        } else {
+          print('Variables:\n');
+          for (const variable of variables) {
+            print(`${variable.name} = ${formatReplVarValue(variable.value)}`);
+          }
+        }
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':history') {
+        const history = session.getHistory();
+        if (history.length === 0) {
+          print('<empty history>');
+        } else {
+          history.forEach((entry, index) => {
+            print(`${index + 1}: ${entry}`);
+          });
+        }
+        rl.prompt();
+        return;
+      }
+      if (trimmed === ':clear') {
+        if (process.stdout.isTTY) {
+          process.stdout.write('\x1Bc');
+        } else {
+          print('\n'.repeat(20));
+        }
         rl.prompt();
         return;
       }
@@ -1571,6 +1628,38 @@ async function handleRepl(args) {
           } else {
             printError(error.message || String(error));
           }
+        }
+        rl.prompt();
+        return;
+      }
+      if (trimmed.startsWith(':load ')) {
+        const filePath = trimmed.slice(6).trim();
+        try {
+          const source = await readFile(path.resolve(process.cwd(), filePath), 'utf8');
+          const result = session.loadSource(source);
+          if (!result.ok) {
+            printToolErrors(result.errors);
+          } else {
+            printSnippetResult(source, result);
+          }
+        } catch (error) {
+          printError(error.message || String(error));
+        }
+        rl.prompt();
+        return;
+      }
+      if (trimmed.startsWith(':run ')) {
+        const filePath = trimmed.slice(5).trim();
+        try {
+          const source = await readFile(path.resolve(process.cwd(), filePath), 'utf8');
+          const result = session.runSource(source);
+          if (!result.ok) {
+            printToolErrors(result.errors);
+          } else {
+            printSnippetResult(source, result);
+          }
+        } catch (error) {
+          printError(error.message || String(error));
         }
         rl.prompt();
         return;

--- a/docs/REPL.md
+++ b/docs/REPL.md
@@ -1,0 +1,33 @@
+# Loomlet REPL
+
+Start:
+
+`loomlet repl`
+
+Commands:
+
+- `:libs`
+- `:help <library>`
+- `:help <library.function>`
+- `:load <file>`
+- `:run <file>`
+- `:vars`
+- `:reset`
+- `:history`
+- `:clear`
+- `:exit` (also `:quit`)
+
+Notes:
+
+- Definitions persist across REPL snippets.
+- `:load` evaluates a file into the current session, so loaded definitions remain available.
+- `:run` executes a file in isolation and does not mutate the current session.
+- REPL errors do not close the session.
+
+Examples:
+
+`math.add(1, 2)`
+
+`double = fn(x) => math.multiply(x, 2)`
+
+`double(21)`

--- a/src/toolchain/repl-session.js
+++ b/src/toolchain/repl-session.js
@@ -65,11 +65,13 @@ export class LoomReplSession {
     this.graph = null;
     this.lastResult = null;
     this.seenEffectNodeIds = new Set();
+    this.history = [];
   }
 
   evaluateSnippet(source) {
     const snippet = String(source ?? '');
     const trimmed = snippet.trim();
+    this.history.push(snippet);
 
     if (!trimmed) {
       return {
@@ -143,6 +145,7 @@ export class LoomReplSession {
     this.graph = null;
     this.lastResult = null;
     this.seenEffectNodeIds = new Set();
+    this.history = [];
   }
 
   inspect() {
@@ -158,5 +161,33 @@ export class LoomReplSession {
 
   getGraph() {
     return this.graph;
+  }
+
+  getHistory() {
+    return [...this.history];
+  }
+
+  loadSource(source) {
+    return this.evaluateSnippet(source);
+  }
+
+  runSource(source) {
+    return runLoomSource(String(source ?? ''), {
+      target: this.target,
+      time: this.time,
+      dt: this.dt
+    });
+  }
+
+  getVariables() {
+    const values = this.lastResult?.values || {};
+    const variables = [];
+    for (const [key, value] of Object.entries(values)) {
+      if (key.endsWith('.out')) {
+        variables.push({ name: key.slice(0, -4), value });
+      }
+    }
+    variables.sort((a, b) => a.name.localeCompare(b.name));
+    return variables;
   }
 }

--- a/test/fixtures/repl-load.loom
+++ b/test/fixtures/repl-load.loom
@@ -1,0 +1,3 @@
+import math
+base = constant(value: 10)
+double = fn(x) => math.multiply(x, 2)

--- a/test/loom-repl-cli.test.mjs
+++ b/test/loom-repl-cli.test.mjs
@@ -58,3 +58,37 @@ test('repl does not print previous console effect again after later snippet', ()
   assert.equal(matches.length, 1);
   assert.match(result.stdout, /x\.out = 1/);
 });
+
+test('repl supports libs, help, vars, history, load, run, and reset', () => {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'repl'],
+    {
+      cwd: projectRoot,
+      input: [
+        ':libs',
+        ':help logic',
+        ':help logic.select',
+        'base = constant(value: 10)',
+        ':vars',
+        ':history',
+        ':load test/fixtures/repl-load.loom',
+        'double(base)',
+        ':run test/fixtures/repl-load.loom',
+        ':reset',
+        'math.add(base, 5)',
+        ':quit'
+      ].join('\n'),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /math/);
+  assert.match(result.stdout, /logic\.select/);
+  assert.match(result.stdout, /truthy/i);
+  assert.match(result.stdout, /base = 10/);
+  assert.match(result.stdout, /1: base = constant\(value: 10\)/);
+  assert.match(result.stdout, /session reset/);
+  assert.match(result.stderr, /UNKNOWN_IDENTIFIER|Unknown|MISSING/i);
+});

--- a/test/loom-repl-session.test.mjs
+++ b/test/loom-repl-session.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { LoomReplSession } from '../src/toolchain/repl-session.js';
 
 test('evaluates assignment snippet', () => {
@@ -146,4 +147,31 @@ test('inspect returns summary', () => {
 
   assert.equal(inspection.ok, true);
   assert.equal(inspection.summary.nodeCount >= 1, true);
+});
+
+test('vars and history are tracked', () => {
+  const session = new LoomReplSession();
+  session.evaluateSnippet('x = constant(value: 10)');
+  session.evaluateSnippet('y = fn(v) => constant(value: v)');
+  const vars = session.getVariables();
+  assert.equal(vars.some((entry) => entry.name === 'x' && entry.value === 10), true);
+  assert.equal(vars.some((entry) => entry.name === 'y'), true);
+  const history = session.getHistory();
+  assert.equal(history.length, 2);
+});
+
+test('load source persists, run source is isolated', async () => {
+  const session = new LoomReplSession();
+  const fixture = await readFile(new URL('./fixtures/repl-load.loom', import.meta.url), 'utf8');
+  const loaded = session.loadSource(fixture);
+  assert.equal(loaded.ok, true);
+  const value = session.evaluateSnippet('double(base)');
+  assert.equal(value.ok, true);
+  assert.equal(value.values['_effect1.out'], 20);
+
+  session.reset();
+  const runResult = session.runSource(fixture);
+  assert.equal(runResult.ok, true);
+  const after = session.evaluateSnippet('double(base)');
+  assert.equal(after.ok, false);
 });


### PR DESCRIPTION
### Motivation

- Make the REPL useful for exploring the language and standard library interactively with light-weight shell-like commands. 
- Provide ways to inspect available libraries, get function help, load/run files, inspect variables, view history, clear/reset session, and exit cleanly. 
- Expose session APIs to support testing and programmatic use of the REPL session (history, variables, load vs run semantics). 

### Description

- Added REPL commands and handlers in `bin/loom.mjs`: `:load`, `:run`, `:vars`, `:history`, `:clear` (in addition to existing `:libs`, `:help`, `:source`, `:inspect`, `:graph`, `:reset`, `:quit/:exit`).
- Added `formatReplVarValue` for concise variable rendering and adapted REPL output to print variables, history, and clear screen behavior. 
- Extended `LoomReplSession` (`src/toolchain/repl-session.js`) with in-memory `history`, `getHistory()`, `getVariables()`, `loadSource()` (persistent), and `runSource()` (isolated) methods, and ensured `reset()` clears history. 
- Added docs at `docs/REPL.md` and linked it from `README.md`. 
- Added a fixture `test/fixtures/repl-load.loom` and tests exercising new behaviors in `test/loom-repl-session.test.mjs` and `test/loom-repl-cli.test.mjs` to validate persistence, isolation, history, vars, and command flow. 

### Testing

- Ran the full unit suite with `npm test`; all unit tests passed. 
- Ran REPL session tests with `node test/loom-repl-session.test.mjs`; all tests passed. 
- Ran REPL CLI flow test with `node test/loom-repl-cli.test.mjs` (command-flow smoke including `:libs`, `:help`, `:vars`, `:history`, `:load`, `:run`, `:reset`); test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe05489c88320a6289f6e0e4792d1)