### PR TITLE
chore: finalize loomlet user-facing CLI naming

### DIFF
--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -1227,7 +1227,7 @@ Examples:
         } else {
           print('Stopped Scene Sync dev mode.');
           if (!dryRun) {
-            print('Graph remains active. Use `loom scenesync graph-clear ... --send` to clear it.');
+            print('Graph remains active. Use `loomlet scenesync graph-clear ... --send` to clear it.');
           }
         }
         resolve(0);
@@ -1452,7 +1452,7 @@ async function handleRun(args) {
   }
 
   if (target !== 'cli') {
-    throw new Error('loom run currently only supports --target cli');
+    throw new Error('loomlet run currently only supports --target cli');
   }
 
   const source = await readSourceFile(file);
@@ -1556,7 +1556,7 @@ async function handleRepl(args) {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
-    prompt: 'loom> '
+    prompt: 'loomlet> '
   });
 
   return await new Promise((resolve) => {
@@ -1743,7 +1743,7 @@ async function handleSceneSync(args) {
 
     if (!result.session) {
       print('No saved Scene Sync session.');
-      print('Use: loom scenesync redeem <code> --save');
+      print('Use: loomlet scenesync redeem <code> --save');
       return 0;
     }
 

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     "node": ">=20"
   },
   "bin": {
-    "loomlet": "./bin/loomlet.mjs"
+    "loomlet": "./bin/loomlet.mjs",
+    "loom": "./bin/loom.mjs"
   },
   "scripts": {
     "test": "npm run test:unit",
     "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
+    "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
-const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+const cliPath = path.join(projectRoot, 'bin', 'loomlet.mjs');
 
 function runCli(args) {
   return spawnSync(process.execPath, [cliPath, ...args], {

--- a/test/loom-repl-cli.test.mjs
+++ b/test/loom-repl-cli.test.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
-const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+const cliPath = path.join(projectRoot, 'bin', 'loomlet.mjs');
 
 test('repl smoke flow works', () => {
   const result = spawnSync(

--- a/test/stdlib-baseline.test.mjs
+++ b/test/stdlib-baseline.test.mjs
@@ -12,7 +12,7 @@ import { isLibraryAvailableInTarget } from '../src/toolchain/runtime-targets.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
-const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+const cliPath = path.join(projectRoot, 'bin', 'loomlet.mjs');
 
 function evalNode(type, params = {}, id = 'n') {
   const engine = new Loom({ nodes: [{ id, type, params }], edges: [] });


### PR DESCRIPTION
### Motivation
- Finalize the user-facing rename from `loom` to `loomlet` across CLI help, examples, tests, and package metadata while preserving the legacy `loom` entrypoint for backward compatibility.
- Avoid invasive refactors of internal runtime identifiers (e.g. `src/loom.js`) and keep runtime behavior unchanged.

### Description
- Updated CLI tests to invoke the new entrypoint `bin/loomlet.mjs` in `test/loom-cli.test.mjs`, `test/loom-repl-cli.test.mjs`, and `test/stdlib-baseline.test.mjs` so normal tests exercise the new user-facing name.
- Kept `bin/loom.mjs` as a compatibility shim but replaced remaining user-facing help/examples/prompts/messages with `loomlet` (examples, Scene Sync guidance, run error text, and REPL prompt) to avoid mixed messaging.
- Updated `package.json` to declare the package `bin` as `{ "loomlet": "./bin/loomlet.mjs", "loom": "./bin/loom.mjs" }` and added a `loomlet` npm script while preserving the existing `loom` script.
- No internal API/class/file names (e.g. `src/loom.js`, `Loom` class) were renamed or behavior changed.

### Testing
- Ran `node bin/loomlet.mjs --help` and `node bin/loomlet.mjs docs`, both of which returned expected help/output successfully.
- Executed `node bin/loomlet.mjs run examples/tour/language/07-fizzbuzz.loom` and observed expected fizzbuzz output.
- Ran the full test suite via `npm test`, which completed successfully with all tests passing.
- Verified legacy compatibility by running `node bin/loom.mjs --help`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe542411483208e70f52efe51185d)