### PR TITLE
Add CI-safe runnable Tour sample test runner

### DIFF
--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -4,6 +4,12 @@ Loomlet is a small dataflow language for weaving values, signals, and scene beha
 
 Loomlet source files use the `.loom` extension.
 
+## Sample status
+
+- `runnable`: can be executed locally and is covered by CI-safe tests.
+- `manual-runnable`: works with external setup such as a linked Scene Sync room.
+- `draft`: design sketch or requires missing features.
+
 ## Language
 
 ### 01 Hello

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     "node": ">=20"
   },
   "bin": {
-    "loomlet": "./bin/loomlet.mjs"
+    "loomlet": "./bin/loomlet.mjs",
+    "loom": "./bin/loom.mjs"
   },
   "scripts": {
     "test": "npm run test:unit",
     "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
+    "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/test/tour-runnable.test.mjs
+++ b/test/tour-runnable.test.mjs
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'bin', 'loomlet.mjs');
+const tourRoot = path.join(projectRoot, 'examples', 'tour');
+
+const BLOCKED_RUN_TOKENS = ['--send', 'redeem', 'session', 'objects', 'curl', 'https://'];
+
+function runCli(args) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: projectRoot,
+    encoding: 'utf8'
+  });
+}
+
+function walkLoomFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const nextPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkLoomFiles(nextPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.loom')) {
+      files.push(nextPath);
+    }
+  }
+  return files;
+}
+
+function extractMetadata(source) {
+  const statusMatch = source.match(/^#\s*Status\s*:\s*(.+)$/im);
+  const status = statusMatch ? statusMatch[1].trim().toLowerCase() : null;
+
+  const runLines = [];
+  const lines = source.split(/\r?\n/);
+  let inRunBlock = false;
+  for (const line of lines) {
+    if (!inRunBlock) {
+      if (/^#\s*Run\s*:\s*$/i.test(line)) {
+        inRunBlock = true;
+      }
+      continue;
+    }
+
+    if (/^#\s{2,}/.test(line)) {
+      runLines.push(line.replace(/^#\s+/, '').trim());
+      continue;
+    }
+
+    if (/^#\s*$/.test(line)) {
+      continue;
+    }
+
+    break;
+  }
+
+  return {
+    status,
+    runCommand: runLines.join(' ').trim() || null
+  };
+}
+
+function categoryFor(relativeFile) {
+  const normalized = relativeFile.replace(/\\/g, '/');
+  if (normalized.startsWith('examples/tour/language/')) return 'language';
+  if (normalized.startsWith('examples/tour/signals/')) return 'signals';
+  if (normalized.startsWith('examples/tour/scenesync/')) return 'scenesync';
+  if (normalized.startsWith('examples/tour/live/')) return 'live';
+  return 'unknown';
+}
+
+function isSafeExplicitRun(command) {
+  if (!command) return false;
+  const lowered = command.toLowerCase();
+  if (BLOCKED_RUN_TOKENS.some((token) => lowered.includes(token))) {
+    return false;
+  }
+  return lowered.startsWith('loomlet run ') || lowered.includes(' --dry-run');
+}
+
+function buildSafeCommand(sample) {
+  const { category, runCommand, relativeFile } = sample;
+
+  if (isSafeExplicitRun(runCommand)) {
+    const args = runCommand.split(/\s+/).slice(1);
+    return [process.execPath, [cliPath, ...args]];
+  }
+
+  if (category === 'language' || category === 'signals') {
+    return [process.execPath, [cliPath, 'run', relativeFile]];
+  }
+
+  if (category === 'scenesync' || category === 'live') {
+    return [process.execPath, [cliPath, 'scenesync', 'graph-compile', relativeFile]];
+  }
+
+  return null;
+}
+
+function discoverRunnableSamples() {
+  const files = walkLoomFiles(tourRoot);
+  return files
+    .map((absFile) => {
+      const source = fs.readFileSync(absFile, 'utf8');
+      const relativeFile = path.relative(projectRoot, absFile).replace(/\\/g, '/');
+      const { status, runCommand } = extractMetadata(source);
+      return {
+        absFile,
+        relativeFile,
+        status,
+        runCommand,
+        category: categoryFor(relativeFile)
+      };
+    })
+    .filter((sample) => sample.status === 'runnable');
+}
+
+test('runnable tour samples execute through a CI-safe path', () => {
+  const runnableSamples = discoverRunnableSamples();
+  assert.ok(runnableSamples.length > 0, 'Expected at least one runnable tour sample');
+
+  for (const sample of runnableSamples) {
+    const command = buildSafeCommand(sample);
+    assert.ok(command, `No CI-safe command available for runnable sample: ${sample.relativeFile}`);
+
+    const [exec, args] = command;
+    const result = spawnSync(exec, args, {
+      cwd: projectRoot,
+      encoding: 'utf8'
+    });
+
+    if (result.status !== 0) {
+      const rendered = `${exec} ${args.join(' ')}`;
+      assert.fail(`Runnable tour sample failed:\n${sample.relativeFile}\n\nCommand:\n${rendered}\n\nError:\n${result.stderr || result.stdout}`);
+    }
+  }
+});


### PR DESCRIPTION
### Motivation

- Ensure every Tour sample marked `runnable` is actually verifiable in CI without requiring a live Scene Sync server or browser tests.
- Provide a safe, automated way to execute or validate samples while skipping drafts or samples that require external setup. 

### Description

- Add `test/tour-runnable.test.mjs` which recursively discovers `examples/tour/**/*.loom`, extracts header metadata, and selects files with `# Status: runnable` for validation. 
- The test builds CI-safe commands: it runs `language` and CLI-safe `signals` samples with `loomlet run`, and validates `scenesync`/`live` samples using `loomlet scenesync graph-compile` to avoid live servers. 
- The test honors an explicit `# Run:` block only when it is considered safe (blocks commands containing tokens like `--send`, `redeem`, `session`, `objects`, `curl`, `https://`).
- Wire the new test into the unit pipeline by adding `node test/tour-runnable.test.mjs` to the `test:unit` script in `package.json`, and add sample status definitions to `docs/TOUR.md` (`runnable`, `manual-runnable`, `draft`).

### Testing

- Ran `npm test` (which includes the new `test/tour-runnable.test.mjs`) and the full unit suite; all tests passed (`0` failures). 
- Manually exercised examples with `node bin/loomlet.mjs run examples/tour/language/07-fizzbuzz.loom` and `node bin/loomlet.mjs run examples/tour/language/08-list-map-filter.loom`, both succeeded. 
- Verified `scenesync` graph validation with `node bin/loomlet.mjs scenesync graph-compile examples/tour/scenesync/01-move-cube.loom` and `node bin/loomlet.mjs scenesync graph-compile examples/tour/live/01-pulse.loom`, both produced valid GraphJSON without requiring a live server.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe52b4fa88320b71c5178fa19f087)