### PR TITLE
Add GitHub release workflow to produce CLI .tgz and VSIX artifacts

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,66 @@
+name: Release Artifacts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install root dependencies
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Generate VS Code metadata
+        run: npm run generate:vscode-metadata
+
+      - name: Build CLI npm tarball
+        run: npm pack
+
+      - name: Install VS Code extension dependencies
+        working-directory: extensions/vscode-loomlet
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Build VS Code extension VSIX
+        working-directory: extensions/vscode-loomlet
+        run: npx @vscode/vsce package
+
+      - name: Upload workflow artifacts (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            *.tgz
+            extensions/vscode-loomlet/*.vsix
+          if-no-files-found: error
+
+      - name: Upload artifacts to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" *.tgz extensions/vscode-loomlet/*.vsix --clobber

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,21 @@
+# Release artifacts
+
+GitHub Releases attach:
+
+- Loomlet npm package tarball (`*.tgz`)
+- Loomlet VS Code extension VSIX (`*.vsix`)
+
+Artifacts are built by `.github/workflows/release-artifacts.yml` on:
+
+- Release publish (`release.published`)
+- Manual run (`workflow_dispatch`)
+
+Manual test:
+
+`gh workflow run release-artifacts.yml`
+
+## Notes
+
+- The workflow runs root unit tests with `npm test`.
+- The workflow does **not** publish to npm.
+- The workflow does **not** publish to the VS Code Marketplace.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",
     "test:browser": "node ci/run-tests.mjs",
-    "generate:vscode-metadata": "node scripts/generate-vscode-metadata.mjs"
+    "generate:vscode-metadata": "node scripts/generate-vscode-metadata.mjs",
+    "pack:cli": "npm pack",
+    "pack:vscode": "cd extensions/vscode-loomlet && npx @vscode/vsce package"
   },
   "devDependencies": {
     "http-server": "^14.1.1",


### PR DESCRIPTION
### Motivation

- Provide GitHub Release artifacts for the CLI npm package and the VS Code extension so releases can attach a `.tgz` and a `.vsix` without publishing to npm or the Marketplace.
- Allow manual runs to produce the same artifacts as workflow artifacts for testing before a release is published.

### Description

- Add `.github/workflows/release-artifacts.yml` which triggers on `release.published` and `workflow_dispatch` and runs Node 20 steps to build artifacts.
- Workflow installs root dependencies (uses `npm ci` only when a lockfile exists), runs `npm test`, runs `npm run generate:vscode-metadata`, produces the CLI tarball with `npm pack`, installs extension deps in `extensions/vscode-loomlet`, and builds the VSIX with `npx @vscode/vsce package`.
- On manual dispatch the workflow uploads `*.tgz` and `extensions/vscode-loomlet/*.vsix` as a workflow artifact via `actions/upload-artifact@v4`, and on release events it runs `gh release upload "$TAG_NAME" *.tgz extensions/vscode-loomlet/*.vsix --clobber` with `GH_TOKEN: ${{ github.token }}`.
- Add helper scripts to `package.json`: `pack:cli` (`npm pack`) and `pack:vscode` (`cd extensions/vscode-loomlet && npx @vscode/vsce package`), and add `docs/RELEASE.md` documenting artifact behavior and a manual test command.

### Testing

- Ran `npm test` in the repository and all unit tests passed (multiple TAP suites; 73/73 and other subtests reported OK).
- Ran `npm pack` and confirmed a tarball `afjk-loomlet-0.1.0.tgz` was produced successfully.
- Attempted to build the VS Code extension locally with `cd extensions/vscode-loomlet && npm install && npx @vscode/vsce package`, which failed in this environment due to an external registry access error fetching `@vscode/vsce` (npm 403), not due to repository code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe5520b108320acc2ca569877b03d)