### PR TITLE
Add Scene Sync demo helper commands to Loomlet CLI

### DIFF
--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -35,6 +35,7 @@ import {
   compileLoomToSceneSyncGraph,
   loomGraphToSceneSyncGraph
 } from '../src/scenesync/index.js';
+import { SCENESYNC_DEMOS, getSceneSyncDemoByName } from '../src/scenesync/demo-registry.js';
 
 function print(message = '') {
   process.stdout.write(`${message}\n`);
@@ -235,6 +236,9 @@ Commands:
   graph-set <obj> <g>      Set a Loomlet graph behavior on a Scene Sync object
   graph-clear <obj>        Clear Loomlet graph behavior from a Scene Sync object
   dev <file>               Watch Loomlet DSL and live-send Scene Sync graph updates
+  demo list                List built-in Scene Sync demo samples
+  demo setup <name>        Check whether required demo objects exist
+  demo run <name>          Run a built-in demo through scenesync dev
   ping                     Check Scene Sync room connection
   info                     Get room information
   objects                  List scene objects
@@ -262,6 +266,9 @@ Examples:
   loomlet scenesync graph-set sample-cube examples/scene-graphs/lissajous.json
   loomlet scenesync graph-set sample-cube examples/scene-graphs/lissajous.json --send
   loomlet scenesync graph-clear sample-cube --send
+  loomlet scenesync demo list
+  loomlet scenesync demo setup lissajous
+  loomlet scenesync demo run lissajous
 
 Graph Commands:
   By default graph-set, graph-clear, and graph-run are dry-run. Pass --send to broadcast.
@@ -2164,6 +2171,95 @@ async function handleSceneSync(args) {
 
   if (subcommand === 'dev') {
     return await handleSceneSyncDev(rest);
+  }
+
+  if (subcommand === 'demo') {
+    const action = rest[0];
+    const name = rest[1];
+
+    if (!action || action === '--help') {
+      print(`Usage:
+  loomlet scenesync demo list
+  loomlet scenesync demo setup <name>
+  loomlet scenesync demo run <name>`);
+      return 0;
+    }
+
+    if (action === 'list') {
+      print('Scene Sync demos:\n');
+      for (const demo of SCENESYNC_DEMOS) {
+        print(`- ${demo.name}`);
+        print(`  file: ${demo.file}`);
+        if (demo.requiredObjects?.length) {
+          print(`  object: ${demo.requiredObjects.join(', ')}`);
+        }
+        print(`  status: ${demo.status}`);
+        print('');
+      }
+      return 0;
+    }
+
+    if (action === 'setup') {
+      if (!name) {
+        throw new Error('demo setup requires <name>');
+      }
+      const demo = getSceneSyncDemoByName(name);
+      if (!demo) {
+        throw new Error(`Unknown Scene Sync demo: ${name}`);
+      }
+      const { room, session, endpoint, json } = await parseSceneSyncArgs(rest.slice(2));
+      if (!room || !session) {
+        print('No saved Scene Sync session.');
+        print('Run:');
+        print('  loomlet scenesync redeem <code> --save');
+        return 0;
+      }
+
+      const client = new SceneSyncClient({ endpoint });
+      const result = await client.listObjects({ room, session });
+      if (!result.ok) {
+        printError(formatSceneSyncError(result.error));
+        return 1;
+      }
+
+      const objects = result.data?.objects || {};
+      const missing = (demo.requiredObjects || []).filter((objectId) => !Object.hasOwn(objects, objectId));
+      if (json) {
+        print(stringifyJson({ ok: true, demo: demo.name, missingRequiredObjects: missing }));
+        return 0;
+      }
+      if (missing.length === 0) {
+        print(`Demo setup OK: ${demo.name}`);
+        print(`Required objects found: ${(demo.requiredObjects || []).join(', ') || '(none)'}`);
+        return 0;
+      }
+      print(`Demo requires objectId: ${missing[0]}`);
+      print('');
+      print(`Create or rename an object in Scene Sync with objectId \`${missing[0]}\`.`);
+      print('Then run:');
+      print(`  loomlet scenesync demo run ${demo.name}`);
+      return 0;
+    }
+
+    if (action === 'run') {
+      if (!name) {
+        throw new Error('demo run requires <name>');
+      }
+      const demo = getSceneSyncDemoByName(name);
+      if (!demo) {
+        throw new Error(`Unknown Scene Sync demo: ${name}`);
+      }
+      const savedSession = await loadSceneSyncSession();
+      if (!(savedSession.ok && savedSession.session)) {
+        print('No saved Scene Sync session.');
+        print('Run:');
+        print('  loomlet scenesync redeem <code> --save');
+        return 0;
+      }
+      return await handleSceneSyncDev([demo.file, ...rest.slice(2)]);
+    }
+
+    throw new Error(`Unknown scenesync demo command: ${action}`);
   }
 
   const { room, session, endpoint, json } = await parseSceneSyncArgs(rest);

--- a/docs/SCENESYNC_DEMOS.md
+++ b/docs/SCENESYNC_DEMOS.md
@@ -41,6 +41,20 @@ or:
 
 `loomlet scenesync dev examples/tour/live/01-pulse.loom`
 
+## Demo helper commands
+
+List demos:
+
+`loomlet scenesync demo list`
+
+Check setup:
+
+`loomlet scenesync demo setup lissajous`
+
+Run demo:
+
+`loomlet scenesync demo run lissajous`
+
 ## Skybox / image / video notes
 
 Scene/environment asset import (skyboxes, images, videos, GLBs) should be done through Scene Sync UI/commands before running Loomlet graphs.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",
     "test:repl": "node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs",

--- a/src/scenesync/demo-registry.js
+++ b/src/scenesync/demo-registry.js
@@ -1,0 +1,30 @@
+export const SCENESYNC_DEMOS = [
+  {
+    name: 'lissajous',
+    file: 'examples/tour/scenesync/02-lissajous.loom',
+    requiredObjects: ['sample-cube'],
+    command: 'dev',
+    status: 'manual-runnable',
+    description: 'Move sample-cube in a Lissajous curve.'
+  },
+  {
+    name: 'breathing-scale',
+    file: 'examples/tour/scenesync/04-breathing-scale.loom',
+    requiredObjects: ['sample-cube'],
+    command: 'dev',
+    status: 'manual-runnable',
+    description: 'Animate sample-cube with a breathing scale pulse.'
+  },
+  {
+    name: 'orbit',
+    file: 'examples/tour/scenesync/03-orbit.loom',
+    requiredObjects: ['sample-cube'],
+    command: 'dev',
+    status: 'manual-runnable',
+    description: 'Orbit sample-cube around a center point.'
+  }
+];
+
+export function getSceneSyncDemoByName(name) {
+  return SCENESYNC_DEMOS.find((demo) => demo.name === name) || null;
+}

--- a/test/scenesync-demo-cli.test.mjs
+++ b/test/scenesync-demo-cli.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SCENESYNC_DEMOS, getSceneSyncDemoByName } from '../src/scenesync/demo-registry.js';
+
+const projectRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const cliPath = path.join(projectRoot, 'bin', 'loom.mjs');
+
+function runCli(args, env = {}) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: { ...process.env, ...env }
+  });
+}
+
+test('demo registry includes lissajous', () => {
+  assert.ok(SCENESYNC_DEMOS.some((demo) => demo.name === 'lissajous'));
+  const demo = getSceneSyncDemoByName('lissajous');
+  assert.equal(demo.file, 'examples/tour/scenesync/02-lissajous.loom');
+});
+
+test('scenesync demo list includes lissajous', () => {
+  const result = runCli(['scenesync', 'demo', 'list']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Scene Sync demos:/);
+  assert.match(result.stdout, /lissajous/);
+});
+
+test('scenesync demo unknown demo gives clear error', () => {
+  const result = runCli(['scenesync', 'demo', 'run', 'unknown-demo']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown Scene Sync demo/);
+});
+
+test('scenesync demo run without saved session prints guidance', () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'loom-demo-empty-'));
+  const result = runCli(['scenesync', 'demo', 'run', 'lissajous'], { HOME: tmpHome });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No saved Scene Sync session/);
+  assert.match(result.stdout, /redeem <code> --save/);
+});


### PR DESCRIPTION
### Motivation

- Provide a small, local CLI convenience layer to make Scene Sync demo graphs easier to try without changing the Scene Sync server or API. 
- Reuse existing Scene Sync client and `dev` flow so demos run using current saved sessions and broadcast functionality. 

### Description

- Add a hardcoded demo registry and lookup helper in `src/scenesync/demo-registry.js` with metadata for `lissajous`, `breathing-scale`, and `orbit`.
- Implement `loomlet scenesync demo` command group in `bin/loom.mjs` with `demo list`, `demo setup <name>`, and `demo run <name>` that reuse the existing `SceneSyncClient` and `handleSceneSyncDev` flow. 
- `demo list` prints the registry entries, `demo setup` verifies a saved session and checks for required objects via `listObjects`, and `demo run` forwards the demo file to the existing `dev` flow while requiring a saved session.
- Update `docs/SCENESYNC_DEMOS.md` with usage for the new demo commands and add CLI/unit tests in `test/scenesync-demo-cli.test.mjs`, plus include the new test in the `test:unit` script in `package.json`.

### Testing

- Ran the unit test suite via `npm test`, which completed successfully (all tests passed).
- Ran the new demo CLI tests with `node test/scenesync-demo-cli.test.mjs` and exercised the CLI manually with `node bin/loom.mjs scenesync demo list`, `node bin/loom.mjs scenesync demo setup lissajous`, and `node bin/loom.mjs scenesync demo run lissajous`, and these checks produced the expected outputs.
- The demo tests validate registry presence (`lissajous`), `demo list` output, unknown-demo error behavior, and guidance when no saved Scene Sync session exists, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe55fd98083209e641d5028a0a62c)