### PR TITLE
Restore scenesync-demo-cli test to test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
-    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
     "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",


### PR DESCRIPTION
## Summary
This change restores the `scenesync-demo-cli.test.mjs` test file to the test suite while keeping the previously added `tour-runnable.test.mjs` test.

## Changes
- Reordered the `test:unit` script in package.json to include both test files:
  - `tour-runnable.test.mjs` (newly added test)
  - `scenesync-demo-cli.test.mjs` (restored test)
  
The test execution order is now: loom-cli → tour-runnable → scenesync-demo-cli → remaining tests

## Details
The previous commit appears to have accidentally removed `scenesync-demo-cli.test.mjs` when adding `tour-runnable.test.mjs`. This change ensures both tests are executed as part of the unit test suite.

https://claude.ai/code/session_01EwKtaKzoZmcAXMBgySjpb4