### PR TITLE
Add node inspector with literal param editing

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -35,11 +35,12 @@
         <div id="node-editor" class="node-editor-canvas"></div>
       </div>
 
-      <!-- Bottom area: GraphJSON and Errors -->
+      <!-- Bottom area: GraphJSON, Errors, and Inspector -->
       <div class="panel graph-errors-panel">
         <div class="tabs">
           <button class="tab-btn active" data-tab="graph">GraphJSON</button>
           <button class="tab-btn" data-tab="errors">Errors</button>
+          <button class="tab-btn" data-tab="inspector">Inspector</button>
         </div>
         <div class="tab-content">
           <div id="graph-tab" class="tab-pane active">
@@ -47,6 +48,9 @@
           </div>
           <div id="errors-tab" class="tab-pane">
             <div id="errors-list" class="errors-list"></div>
+          </div>
+          <div id="inspector-tab" class="tab-pane">
+            <div id="inspector-panel" class="inspector-panel"></div>
           </div>
         </div>
       </div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -8,7 +8,6 @@ import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
 import {
   graphToEditorModel,
   editorModelToGraph,
-  applyEditorOperation,
   applyNodeEditorOperationState
 } from '../../src/node-editor-core.js';
 import { graphToCanonicalDSL } from './canonical-dsl.js';
@@ -29,6 +28,7 @@ let nodeEditor = null;
 let engine = null;
 let animationFrameId = null;
 let panelsVisible = true;
+let selectedNodeId = null;
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
@@ -36,6 +36,7 @@ const elements = {
   previewCanvas: document.getElementById('preview-canvas'),
   graphJson: document.getElementById('graph-json'),
   errorsList: document.getElementById('errors-list'),
+  inspectorPanel: document.getElementById('inspector-panel'),
   applyDslBtn: document.getElementById('applyDslBtn'),
   generateDslBtn: document.getElementById('generateDslBtn'),
   runPreviewBtn: document.getElementById('runPreviewBtn'),
@@ -103,14 +104,18 @@ async function applyDsl() {
 
   if (parseErrors.length) {
     store.setState({ errors: parseErrors });
+    selectedNodeId = null;
     renderErrors();
+    renderInspector();
     return;
   }
 
   const { graph, errors: compileErrors } = compileToGraph(ast);
   if (compileErrors.length) {
     store.setState({ errors: compileErrors });
+    selectedNodeId = null;
     renderErrors();
+    renderInspector();
     return;
   }
 
@@ -124,9 +129,11 @@ async function applyDsl() {
     errors: []
   });
 
+  selectedNodeId = null;
   await nodeEditor?.renderModel(editorModel);
   renderGraphJSON(graph);
   renderErrors();
+  renderInspector();
   runPreview(graph);
 }
 
@@ -146,6 +153,7 @@ function generateDsl() {
 
   renderGraphJSON(graph);
   renderErrors();
+  renderInspector();
   runPreview(graph);
 }
 
@@ -162,6 +170,164 @@ function renderErrors() {
     return `<div class="error-item"><strong>${err.code || 'ERROR'}${line}${col}</strong>: ${err.message}</div>`;
   }).join('');
   elements.errorsList.innerHTML = html || '<div class="error-item">No errors</div>';
+}
+
+function getSelectedEditorNode() {
+  const state = store.getState();
+  if (!selectedNodeId || !state.editorModel) return null;
+  return state.editorModel.nodesById[selectedNodeId] || null;
+}
+
+function setSelectedNodeId(nodeId) {
+  const state = store.getState();
+  if (nodeId && !state.editorModel?.nodesById[nodeId]) {
+    selectedNodeId = null;
+  } else {
+    selectedNodeId = nodeId || null;
+  }
+  renderInspector();
+}
+
+function setEditorError(message) {
+  store.setState({
+    errors: [{ code: 'EDITOR_ERROR', message }]
+  });
+  renderErrors();
+}
+
+function renderInspector() {
+  const panel = elements.inspectorPanel;
+  const node = getSelectedEditorNode();
+
+  if (!panel) return;
+
+  if (!node) {
+    panel.innerHTML = `
+      <div class="inspector-empty">
+        Select a node to edit its literal params.
+      </div>
+    `;
+    return;
+  }
+
+  let html = `
+    <div class="inspector-content">
+      <div class="inspector-section">
+        <div class="inspector-row">
+          <div class="inspector-label">ID:</div>
+          <div class="inspector-value">${escapeHtml(node.id)}</div>
+        </div>
+        <div class="inspector-row">
+          <div class="inspector-label">Type:</div>
+          <div class="inspector-value">${escapeHtml(node.type)}</div>
+        </div>
+        <div class="inspector-row">
+          <div class="inspector-label">Category:</div>
+          <div class="inspector-value">${escapeHtml(node.category)}</div>
+        </div>
+      </div>
+
+      <div class="inspector-section">
+        <div class="inspector-label" style="margin-bottom: 8px;">Params:</div>
+  `;
+
+  const params = node.params || {};
+  if (Object.keys(params).length === 0) {
+    html += '<div class="inspector-empty" style="padding: 0;">No params</div>';
+  } else {
+    for (const [key, value] of Object.entries(params)) {
+      html += renderParamInput(key, value);
+    }
+  }
+
+  html += `
+      </div>
+    </div>
+  `;
+
+  panel.innerHTML = html;
+  attachParamListeners();
+}
+
+function renderParamInput(key, value) {
+  const valueType = typeof value;
+  let input = '';
+
+  if (valueType === 'number') {
+    input = `<input type="number" class="inspector-param-input" data-param-key="${escapeHtml(key)}" value="${value}">`;
+  } else if (valueType === 'boolean') {
+    const checked = value ? 'checked' : '';
+    input = `<input type="checkbox" class="inspector-param-input" data-param-key="${escapeHtml(key)}" ${checked}>`;
+  } else if (valueType === 'string') {
+    input = `<input type="text" class="inspector-param-input" data-param-key="${escapeHtml(key)}" value="${escapeHtml(value)}">`;
+  } else {
+    const jsonStr = JSON.stringify(value, null, 2);
+    input = `<textarea class="inspector-param-input" data-param-key="${escapeHtml(key)}">${escapeHtml(jsonStr)}</textarea>`;
+  }
+
+  return `
+    <div class="inspector-row">
+      <label class="inspector-label" for="param-${escapeHtml(key)}">${escapeHtml(key)}:</label>
+      <div style="flex: 1;">${input}</div>
+    </div>
+  `;
+}
+
+function attachParamListeners() {
+  const inputs = elements.inspectorPanel.querySelectorAll('.inspector-param-input');
+  inputs.forEach(input => {
+    const key = input.getAttribute('data-param-key');
+
+    if (input.type === 'checkbox') {
+      input.addEventListener('change', () => {
+        applyParamEdit(key, input.checked);
+      });
+    } else if (input.type === 'number') {
+      input.addEventListener('change', () => {
+        const value = Number(input.value);
+        if (!Number.isFinite(value)) {
+          setEditorError(`Invalid number for param '${key}'`);
+          return;
+        }
+        applyParamEdit(key, value);
+      });
+    } else if (input.tagName === 'TEXTAREA') {
+      input.addEventListener('change', () => {
+        try {
+          const value = JSON.parse(input.value);
+          applyParamEdit(key, value);
+        } catch (err) {
+          setEditorError(`Invalid JSON for param '${key}': ${err.message}`);
+        }
+      });
+    } else {
+      input.addEventListener('change', () => {
+        applyParamEdit(key, input.value);
+      });
+    }
+  });
+}
+
+function applyParamEdit(key, value) {
+  if (!selectedNodeId) return;
+
+  handleOperation({
+    type: 'updateParam',
+    id: selectedNodeId,
+    key,
+    value
+  });
+}
+
+function escapeHtml(str) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return String(str).replace(/[&<>"']/g, char => map[char]);
 }
 
 function runPreview(graph) {
@@ -305,6 +471,7 @@ async function handleOperation(operation) {
 
     renderGraphJSON(result.state.graph);
     renderErrors();
+    renderInspector();
     runPreview(result.state.graph);
     return;
   }
@@ -327,7 +494,8 @@ function init() {
     onError: (error) => {
       store.setState({ errors: [{ message: `Editor error: ${error.message}`, code: 'EDITOR_ERROR' }] });
       renderErrors();
-    }
+    },
+    onSelectNode: setSelectedNodeId
   });
 
   setupEventListeners();

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -48,10 +48,11 @@ function createReteNode(editorNode, onControl) {
 }
 
 export class NodeEditorView {
-  constructor(container, { onOperation, onError } = {}) {
+  constructor(container, { onOperation, onError, onSelectNode } = {}) {
     this.container = container;
     this.onOperation = onOperation || (() => {});
     this.onError = onError || ((e) => console.error('NodeEditorView:', e));
+    this.onSelectNode = onSelectNode || (() => {});
     this.isRendering = false;
     this.connectionMap = new Map();
     this._renderLock = null;
@@ -87,6 +88,14 @@ export class NodeEditorView {
       if (!this.isRendering && context.type === 'nodetranslated') {
         this._onNodeTranslated(context.data);
       }
+
+      if (!this.isRendering && context.type === 'nodepicked') {
+        const nodeId = context.data?.id;
+        if (nodeId && this.editor.getNode(nodeId)) {
+          this.onSelectNode(nodeId);
+        }
+      }
+
       return context;
     });
   }

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -321,3 +321,70 @@ body.panels-hidden .editor-panels {
 .cm-selectionBackground {
   background: rgba(74, 144, 226, 0.3) !important;
 }
+
+/* Inspector Panel */
+.inspector-panel {
+  padding: 12px;
+  overflow: auto;
+  flex: 1;
+  font-size: 13px;
+}
+
+.inspector-empty {
+  color: var(--text-dim);
+  padding: 8px;
+}
+
+.inspector-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.inspector-section {
+  margin-bottom: 12px;
+}
+
+.inspector-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.inspector-label {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.inspector-value {
+  color: var(--text-color);
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.inspector-panel input[type="text"],
+.inspector-panel input[type="number"],
+.inspector-panel textarea {
+  width: 100%;
+  background: #111;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 4px 6px;
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 12px;
+}
+
+.inspector-panel input[type="checkbox"] {
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+}
+
+.inspector-panel textarea {
+  min-height: 72px;
+  resize: vertical;
+}


### PR DESCRIPTION
- Add Inspector tab to editor-studio showing node id, type, category, and params
- Implement node selection in the NodeEditorView with onSelectNode callback
- Add renderInspector() function to display selected node details
- Support editing number, boolean, string, and JSON params through Inspector panel
- Apply param edits through existing updateParam operation
- Add CSS styling for Inspector panel
- Reset node selection when new DSL is applied
- Call renderInspector after operations to keep UI in sync
- Clean up unused applyEditorOperation import

https://claude.ai/code/session_01281iN1wFqHyTHEwNeFQ5YC