### PR TITLE
Add metadata-driven node palette

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -45,6 +45,7 @@
           <button class="tab-btn active" data-tab="graph">GraphJSON</button>
           <button class="tab-btn" data-tab="errors">Errors</button>
           <button class="tab-btn" data-tab="inspector">Inspector</button>
+          <button class="tab-btn" data-tab="palette">Palette</button>
         </div>
         <div class="tab-content">
           <div id="graph-tab" class="tab-pane active">
@@ -55,6 +56,17 @@
           </div>
           <div id="inspector-tab" class="tab-pane">
             <div id="inspector-panel" class="inspector-panel"></div>
+          </div>
+          <div id="palette-tab" class="tab-pane">
+            <div class="palette-panel">
+              <div class="palette-toolbar">
+                <input id="node-palette-search" class="palette-search" type="text" placeholder="Search node types..." />
+                <select id="node-palette-category" class="palette-category">
+                  <option value="">All categories</option>
+                </select>
+              </div>
+              <div id="node-palette-list" class="node-palette-list"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -3,7 +3,7 @@ import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import { defaultKeymap } from '@codemirror/commands';
 import { json } from '@codemirror/lang-json';
 
-import { Loom } from '../../src/loom.js';
+import { Loom, NODE_TYPES } from '../../src/loom.js';
 import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
 import {
   graphToEditorModel,
@@ -13,6 +13,13 @@ import {
 import { graphToCanonicalDSL } from './canonical-dsl.js';
 import { createStore } from './studio-store.js';
 import { NodeEditorView } from './node-editor-view.js';
+import {
+  normalizeEditorCategory,
+  createDefaultParamsForNodeType,
+  createNodeIdFromType,
+  createPositionForNewNode,
+  getNodeTypeEntries
+} from './node-palette-model.js';
 
 const SAMPLE_DSL = `t = clock()
 wave = sine(t, freq: 0.35)
@@ -52,7 +59,10 @@ const elements = {
   fileStatus: document.getElementById('file-status'),
   openFileBtn: document.getElementById('openFileBtn'),
   saveFileBtn: document.getElementById('saveFileBtn'),
-  saveAsFileBtn: document.getElementById('saveAsFileBtn')
+  saveAsFileBtn: document.getElementById('saveAsFileBtn'),
+  nodePaletteSearch: document.getElementById('node-palette-search'),
+  nodePaletteCategory: document.getElementById('node-palette-category'),
+  nodePaletteList: document.getElementById('node-palette-list')
 };
 
 function setPanelsVisible(visible) {
@@ -634,6 +644,97 @@ async function resetSample() {
   setDirty(false);
 }
 
+function renderNodePaletteItem(entry) {
+  const inputs = entry.inputs.map((input) => input.name).join(', ') || 'none';
+  const outputs = entry.outputs.map((output) => output.name).join(', ') || 'none';
+  const params = entry.params.map((param) => param.name).join(', ') || 'none';
+
+  return `
+    <div class="node-palette-item">
+      <div class="node-palette-main">
+        <div class="node-palette-title">${escapeHtml(entry.typeName)}</div>
+        <div class="node-palette-category-label">${escapeHtml(entry.category)}</div>
+      </div>
+      <div class="node-palette-meta">
+        <div><strong>in</strong>: ${escapeHtml(inputs)}</div>
+        <div><strong>out</strong>: ${escapeHtml(outputs)}</div>
+        <div><strong>params</strong>: ${escapeHtml(params)}</div>
+      </div>
+      <button class="btn node-palette-add" data-add-node-type="${escapeHtml(entry.typeName)}">Add</button>
+    </div>
+  `;
+}
+
+function renderNodePalette() {
+  const list = elements.nodePaletteList;
+  if (!list) return;
+
+  const query = (elements.nodePaletteSearch?.value || '').trim().toLowerCase();
+  const selectedCategory = elements.nodePaletteCategory?.value || '';
+
+  const entries = getNodeTypeEntries(NODE_TYPES).filter((entry) => {
+    if (selectedCategory && entry.category !== selectedCategory) return false;
+    if (!query) return true;
+
+    return (
+      entry.typeName.toLowerCase().includes(query) ||
+      entry.category.toLowerCase().includes(query)
+    );
+  });
+
+  list.innerHTML = entries.map(renderNodePaletteItem).join('');
+
+  list.querySelectorAll('[data-add-node-type]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const typeName = button.getAttribute('data-add-node-type');
+      addNodeFromPalette(typeName);
+    });
+  });
+}
+
+function renderNodePaletteCategories() {
+  const select = elements.nodePaletteCategory;
+  if (!select) return;
+
+  const categories = Array.from(
+    new Set(getNodeTypeEntries(NODE_TYPES).map((entry) => entry.category))
+  ).sort();
+
+  select.innerHTML = [
+    '<option value="">All categories</option>',
+    ...categories.map((category) => `<option value="${escapeHtml(category)}">${escapeHtml(category)}</option>`)
+  ].join('');
+}
+
+async function addNodeFromPalette(typeName) {
+  const def = NODE_TYPES[typeName];
+  if (!def) {
+    setEditorError(`Unknown node type: ${typeName}`);
+    return;
+  }
+
+  const category = normalizeEditorCategory(def.category);
+  const state = store.getState();
+  const existingNodeIds = state.editorModel?.nodesById || {};
+  const id = createNodeIdFromType(typeName, existingNodeIds);
+  const nodes = Object.values(existingNodeIds || {});
+
+  const node = {
+    id,
+    type: typeName,
+    category,
+    params: createDefaultParamsForNodeType(typeName, NODE_TYPES),
+    position: createPositionForNewNode(category, nodes)
+  };
+
+  await handleOperation({
+    type: 'addNode',
+    node
+  });
+
+  setSelectedNodeId(id);
+}
+
 function setupEventListeners() {
   elements.applyDslBtn.addEventListener('click', applyDsl);
   elements.generateDslBtn.addEventListener('click', generateDsl);
@@ -659,6 +760,9 @@ function setupEventListeners() {
       document.getElementById(`${tabName}-tab`)?.classList.add('active');
     });
   });
+
+  elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
+  elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
 
   window.addEventListener('resize', resizePreviewCanvas);
 }
@@ -716,6 +820,8 @@ async function init() {
 
   setupEventListeners();
   renderFileStatus();
+  renderNodePaletteCategories();
+  renderNodePalette();
   await applyDsl({ markDirty: false });
   setDirty(false);
 }

--- a/editor-studio/src/node-palette-model.js
+++ b/editor-studio/src/node-palette-model.js
@@ -13,7 +13,8 @@ export function createDefaultParamsForNodeType(typeName, NODE_TYPES) {
   const params = {};
 
   for (const param of def?.params || []) {
-    params[param.name] = cloneDefaultValue(param.default);
+    const hasDefault = Object.prototype.hasOwnProperty.call(param, 'default');
+    params[param.name] = hasDefault ? cloneDefaultValue(param.default) : null;
   }
 
   return params;

--- a/editor-studio/src/node-palette-model.js
+++ b/editor-studio/src/node-palette-model.js
@@ -1,0 +1,66 @@
+export function normalizeEditorCategory(category) {
+  return category === 'source' ? 'input' : (category || 'transform');
+}
+
+export function cloneDefaultValue(value) {
+  if (Array.isArray(value)) return value.map(cloneDefaultValue);
+  if (value && typeof value === 'object') return JSON.parse(JSON.stringify(value));
+  return value;
+}
+
+export function createDefaultParamsForNodeType(typeName, NODE_TYPES) {
+  const def = NODE_TYPES[typeName];
+  const params = {};
+
+  for (const param of def?.params || []) {
+    params[param.name] = cloneDefaultValue(param.default);
+  }
+
+  return params;
+}
+
+export function createNodeIdFromType(typeName, existingNodeIds) {
+  const base = typeName
+    .replace(/[^a-zA-Z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'node';
+
+  if (!existingNodeIds || !existingNodeIds[base]) return base;
+
+  let index = 2;
+  while (existingNodeIds[`${base}_${index}`]) {
+    index += 1;
+  }
+
+  return `${base}_${index}`;
+}
+
+export function createPositionForNewNode(category, nodes) {
+  const categoryX = {
+    input: 0,
+    transform: 300,
+    state: 600,
+    sink: 900
+  };
+
+  const sameCategoryCount = (nodes || []).filter((node) => node.category === category).length;
+
+  return {
+    x: categoryX[category] ?? 1200,
+    y: sameCategoryCount * 120
+  };
+}
+
+export function getNodeTypeEntries(NODE_TYPES) {
+  return Object.entries(NODE_TYPES)
+    .map(([typeName, def]) => ({
+      typeName,
+      category: normalizeEditorCategory(def.category),
+      inputs: def.inputs || [],
+      outputs: def.outputs || [],
+      params: def.params || []
+    }))
+    .sort((a, b) => {
+      if (a.category !== b.category) return a.category.localeCompare(b.category);
+      return a.typeName.localeCompare(b.typeName);
+    });
+}

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -398,3 +398,106 @@ body.panels-hidden .editor-panels {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Node Palette */
+.palette-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.palette-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+
+.palette-search {
+  flex: 1;
+  padding: 6px 8px;
+  background: #111;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 12px;
+  min-width: 0;
+}
+
+.palette-search::placeholder {
+  color: var(--text-dim);
+}
+
+.palette-category {
+  padding: 6px 8px;
+  background: #111;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 12px;
+  min-width: 140px;
+}
+
+.node-palette-list {
+  flex: 1;
+  overflow: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.node-palette-item {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.node-palette-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.node-palette-title {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.node-palette-category-label {
+  color: var(--text-dim);
+  font-size: 11px;
+  background: rgba(74, 144, 226, 0.2);
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.node-palette-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1.3;
+  font-family: 'Monaco', 'Menlo', monospace;
+}
+
+.node-palette-meta > div {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.node-palette-add {
+  align-self: flex-start;
+  padding: 4px 8px;
+  font-size: 11px;
+}

--- a/test/node-palette-helpers.test.html
+++ b/test/node-palette-helpers.test.html
@@ -105,6 +105,21 @@
       }
     });
 
+    test('createDefaultParamsForNodeType should use null when param default is missing', () => {
+      const nodeTypes = {
+        custom: {
+          category: 'transform',
+          inputs: [],
+          outputs: [],
+          params: [{ name: 'value', type: 'any' }]
+        }
+      };
+      const result = createDefaultParamsForNodeType('custom', nodeTypes);
+      if (result.value !== null) {
+        throw new Error(`Expected null, got ${result.value}`);
+      }
+    });
+
     // Test createNodeIdFromType
     test('createNodeIdFromType("sine") with no existing nodes should return "sine"', () => {
       const result = createNodeIdFromType('sine', {});

--- a/test/node-palette-helpers.test.html
+++ b/test/node-palette-helpers.test.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Node Palette Helpers Tests</title>
+  <script src="./test-runner.js"></script>
+</head>
+<body>
+  <h1>Node Palette Helpers Tests</h1>
+  <div id="test-results"></div>
+
+  <script type="module">
+    import {
+      normalizeEditorCategory,
+      cloneDefaultValue,
+      createDefaultParamsForNodeType,
+      createNodeIdFromType,
+      createPositionForNewNode,
+      getNodeTypeEntries
+    } from '../editor-studio/src/node-palette-model.js';
+
+    const test = window.test || function() {};
+    const assert = window.assert || (() => {});
+
+    // Mock NODE_TYPES for testing
+    const mockNodeTypes = {
+      sine: {
+        category: 'transform',
+        inputs: [{ name: 't', type: 'number' }],
+        outputs: [{ name: 'out', type: 'number' }],
+        params: [
+          { name: 'freq', type: 'number', default: 1 },
+          { name: 'amplitude', type: 'number', default: 1 }
+        ]
+      },
+      clock: {
+        category: 'source',
+        inputs: [],
+        outputs: [{ name: 't', type: 'number' }],
+        params: []
+      },
+      add: {
+        category: 'transform',
+        inputs: [{ name: 'a', type: 'number' }, { name: 'b', type: 'number' }],
+        outputs: [{ name: 'out', type: 'number' }],
+        params: [
+          { name: 'a', type: 'number', default: 0 },
+          { name: 'b', type: 'number', default: 0 }
+        ]
+      }
+    };
+
+    // Test normalizeEditorCategory
+    test('normalizeEditorCategory("source") should return "input"', () => {
+      const result = normalizeEditorCategory('source');
+      if (result !== 'input') throw new Error(`Expected 'input', got '${result}'`);
+    });
+
+    test('normalizeEditorCategory("transform") should return "transform"', () => {
+      const result = normalizeEditorCategory('transform');
+      if (result !== 'transform') throw new Error(`Expected 'transform', got '${result}'`);
+    });
+
+    test('normalizeEditorCategory(undefined) should return "transform"', () => {
+      const result = normalizeEditorCategory(undefined);
+      if (result !== 'transform') throw new Error(`Expected 'transform', got '${result}'`);
+    });
+
+    // Test cloneDefaultValue
+    test('cloneDefaultValue(123) should return 123', () => {
+      const result = cloneDefaultValue(123);
+      if (result !== 123) throw new Error(`Expected 123, got ${result}`);
+    });
+
+    test('cloneDefaultValue([1, 2, 3]) should return deep clone', () => {
+      const original = [1, 2, 3];
+      const result = cloneDefaultValue(original);
+      if (JSON.stringify(result) !== JSON.stringify(original)) {
+        throw new Error(`Arrays do not match`);
+      }
+      if (result === original) throw new Error(`Should be a new array, not reference`);
+    });
+
+    test('cloneDefaultValue({a: 1}) should return deep clone', () => {
+      const original = { a: 1, b: { c: 2 } };
+      const result = cloneDefaultValue(original);
+      if (JSON.stringify(result) !== JSON.stringify(original)) {
+        throw new Error(`Objects do not match`);
+      }
+      if (result === original) throw new Error(`Should be a new object, not reference`);
+    });
+
+    // Test createDefaultParamsForNodeType
+    test('createDefaultParamsForNodeType("sine") should return params with defaults', () => {
+      const result = createDefaultParamsForNodeType('sine', mockNodeTypes);
+      if (result.freq !== 1 || result.amplitude !== 1) {
+        throw new Error(`Expected freq: 1, amplitude: 1, got ${JSON.stringify(result)}`);
+      }
+    });
+
+    test('createDefaultParamsForNodeType("clock") should return empty params', () => {
+      const result = createDefaultParamsForNodeType('clock', mockNodeTypes);
+      if (Object.keys(result).length !== 0) {
+        throw new Error(`Expected empty params, got ${JSON.stringify(result)}`);
+      }
+    });
+
+    // Test createNodeIdFromType
+    test('createNodeIdFromType("sine") with no existing nodes should return "sine"', () => {
+      const result = createNodeIdFromType('sine', {});
+      if (result !== 'sine') throw new Error(`Expected 'sine', got '${result}'`);
+    });
+
+    test('createNodeIdFromType("sine") with existing "sine" should return "sine_2"', () => {
+      const existing = { sine: { id: 'sine' } };
+      const result = createNodeIdFromType('sine', existing);
+      if (result !== 'sine_2') throw new Error(`Expected 'sine_2', got '${result}'`);
+    });
+
+    test('createNodeIdFromType("math.add") should normalize to "math_add"', () => {
+      const result = createNodeIdFromType('math.add', {});
+      if (result !== 'math_add') throw new Error(`Expected 'math_add', got '${result}'`);
+    });
+
+    test('createNodeIdFromType("sine") with existing "sine" and "sine_2" should return "sine_3"', () => {
+      const existing = { sine: {}, sine_2: {} };
+      const result = createNodeIdFromType('sine', existing);
+      if (result !== 'sine_3') throw new Error(`Expected 'sine_3', got '${result}'`);
+    });
+
+    // Test createPositionForNewNode
+    test('createPositionForNewNode("input") should place at x=0', () => {
+      const result = createPositionForNewNode('input', []);
+      if (result.x !== 0) throw new Error(`Expected x: 0, got x: ${result.x}`);
+    });
+
+    test('createPositionForNewNode("transform") should place at x=300', () => {
+      const result = createPositionForNewNode('transform', []);
+      if (result.x !== 300) throw new Error(`Expected x: 300, got x: ${result.x}`);
+    });
+
+    test('createPositionForNewNode("transform") with 2 existing transform nodes should increment y', () => {
+      const nodes = [
+        { id: 'add', category: 'transform', position: { x: 300, y: 0 } },
+        { id: 'mult', category: 'transform', position: { x: 300, y: 120 } }
+      ];
+      const result = createPositionForNewNode('transform', nodes);
+      if (result.y !== 240) throw new Error(`Expected y: 240, got y: ${result.y}`);
+    });
+
+    // Test getNodeTypeEntries
+    test('getNodeTypeEntries should return sorted entries', () => {
+      const result = getNodeTypeEntries(mockNodeTypes);
+      if (result.length !== 3) throw new Error(`Expected 3 entries, got ${result.length}`);
+      // Should be sorted by category first, then by typeName
+      if (result[0].category !== 'input') throw new Error(`First entry should be 'input' category`);
+      if (result[1].category !== 'transform' || result[1].typeName !== 'add') {
+        throw new Error(`Second entry should be 'add' (transform, sorted)`);
+      }
+    });
+
+    test('getNodeTypeEntries should normalize source to input', () => {
+      const result = getNodeTypeEntries(mockNodeTypes);
+      const clockEntry = result.find(e => e.typeName === 'clock');
+      if (clockEntry.category !== 'input') {
+        throw new Error(`clock should have category 'input', got '${clockEntry.category}'`);
+      }
+    });
+
+    console.log('All node palette helper tests completed');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Implements a UI-driven Node Palette that allows users to add new Loomlet nodes from the editor-studio.

Features:
- List available node types from NODE_TYPES metadata
- Search and filter by node type name and category
- Add nodes with default parameters
- Auto-select newly added nodes
- Update GraphJSON, preview, and Inspector through handleOperation

Architecture:
- Created node-palette-model.js with pure helper functions for:
  * Category normalization (source → input)
  * Default param creation from metadata
  * Unique node ID generation with numeric suffixes
  * Initial position calculation by category
- Added Palette tab to editor-studio UI (4th tab after GraphJSON, Errors, Inspector)
- Integrated with existing operation flow for graph updates

https://claude.ai/code/session_01Hjewe8ScYnsj69XKixeLXk