### PR TITLE
Add delete selected node support

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -459,11 +459,19 @@ function renderInspector() {
 
   html += `
       </div>
+
+      <div class="inspector-section inspector-danger-section">
+        <div class="inspector-label" style="margin-bottom: 8px;">Danger Zone:</div>
+        <button id="delete-selected-node-btn" class="btn btn-danger">
+          Delete Node
+        </button>
+      </div>
     </div>
   `;
 
   panel.innerHTML = html;
   attachParamListeners();
+  attachInspectorActionListeners();
 }
 
 function renderParamInput(key, value) {
@@ -523,6 +531,29 @@ function attachParamListeners() {
       });
     }
   });
+}
+
+function attachInspectorActionListeners() {
+  const deleteButton = elements.inspectorPanel.querySelector('#delete-selected-node-btn');
+  deleteButton?.addEventListener('click', deleteSelectedNode);
+}
+
+async function deleteSelectedNode() {
+  const node = getSelectedEditorNode();
+  if (!node) return;
+
+  const message = `Delete node '${node.id}'? Connected edges will also be removed.`;
+  if (!window.confirm(message)) return;
+
+  const result = await handleOperation({
+    type: 'removeNode',
+    id: node.id
+  });
+
+  if (result && !result.error) {
+    selectedNodeId = null;
+    renderInspector();
+  }
 }
 
 function applyParamEdit(key, value) {
@@ -735,6 +766,30 @@ async function addNodeFromPalette(typeName) {
   setSelectedNodeId(id);
 }
 
+function isTextEditingTarget(target) {
+  if (!target) return false;
+
+  const tagName = target.tagName;
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+    return true;
+  }
+
+  if (target.isContentEditable) return true;
+
+  if (target.closest?.('.cm-editor')) return true;
+
+  return false;
+}
+
+function handleGlobalKeyDown(event) {
+  if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+  if (!selectedNodeId) return;
+  if (isTextEditingTarget(event.target)) return;
+
+  event.preventDefault();
+  deleteSelectedNode();
+}
+
 function setupEventListeners() {
   elements.applyDslBtn.addEventListener('click', applyDsl);
   elements.generateDslBtn.addEventListener('click', generateDsl);
@@ -765,11 +820,12 @@ function setupEventListeners() {
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
 
   window.addEventListener('resize', resizePreviewCanvas);
+  window.addEventListener('keydown', handleGlobalKeyDown);
 }
 
 async function handleOperation(operation) {
   const state = store.getState();
-  if (!state.editorModel) return;
+  if (!state.editorModel) return null;
 
   const result = applyNodeEditorOperationState(
     {
@@ -787,13 +843,17 @@ async function handleOperation(operation) {
       await nodeEditor?.renderModel(result.state.editorModel);
     }
 
+    if (selectedNodeId && !result.state.editorModel.nodesById[selectedNodeId]) {
+      selectedNodeId = null;
+    }
+
     renderGraphJSON(result.state.graph);
     renderErrors();
     renderInspector();
     runPreview(result.state.graph);
     hasUnsyncedDslText = false;
     setDirty(true);
-    return;
+    return result;
   }
 
   const currentModel = state.editorModel;
@@ -802,6 +862,7 @@ async function handleOperation(operation) {
   }
 
   renderErrors();
+  return result;
 }
 
 async function init() {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -501,3 +501,19 @@ body.panels-hidden .editor-panels {
   padding: 4px 8px;
   font-size: 11px;
 }
+
+.inspector-danger-section {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 80, 80, 0.25);
+}
+
+.btn-danger {
+  background: rgba(220, 60, 60, 0.18);
+  color: #ff9b9b;
+  border: 1px solid rgba(220, 60, 60, 0.45);
+}
+
+.btn-danger:hover {
+  background: rgba(220, 60, 60, 0.28);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "bin": {
+        "loom": "bin/loom.mjs",
         "loomlet": "bin/loomlet.mjs"
       },
       "devDependencies": {

--- a/test/node-editor-session.test.html
+++ b/test/node-editor-session.test.html
@@ -135,6 +135,29 @@
       assert(resultModelStr === originalModelStr, 'editorModel should not be mutated');
     });
 
+    test('Test 5: removeNode removes the node and connected edges', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'removeNode',
+        id: 'wave'
+      });
+
+      if (result.error) throw result.error;
+      if (result.state.editorModel.nodesById.wave) {
+        throw new Error('wave node should be removed');
+      }
+
+      const remainingEdges = Object.values(result.state.editorModel.edgesById);
+      if (remainingEdges.length !== 0) {
+        throw new Error(`Expected connected edges to be removed, got ${remainingEdges.length}`);
+      }
+
+      assert(result.state.editorModel.nodesById.t, 't node should still exist');
+      assert(result.state.editorModel.nodesById.out, 'out node should still exist');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {


### PR DESCRIPTION
Implement minimal delete node functionality for editor-studio:

- Add Delete Node button in Inspector danger zone
- Delete button only shows when a node is selected
- Implement deleteSelectedNode() with confirmation dialog
- Update handleOperation() to return result and clear invalid selection
- Add Delete/Backspace keyboard shortcut (except in text inputs)
- Add isTextEditingTarget() helper to prevent accidental deletion while typing
- Style danger zone with red accents matching design
- Add removeNode test verifying node and edge removal

The removeNode operation was already implemented in node-editor-core.js
and handles removing the node and all connected edges automatically.

https://claude.ai/code/session_01NPLWxcAFB2AAetJUTXSvHu