### PR TITLE
Add rename selected node support

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -886,7 +886,8 @@ async function handleOperation(operation) {
     }
 
     if (result.change.operation.type === 'renameNode' && selectedNodeId === result.change.operation.id) {
-      selectedNodeId = result.change.operation.newId;
+      const renamedId = result.change.operation.newId.trim();
+      selectedNodeId = result.state.editorModel.nodesById[renamedId] ? renamedId : null;
     } else if (selectedNodeId && !result.state.editorModel.nodesById[selectedNodeId]) {
       selectedNodeId = null;
     }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -431,8 +431,17 @@ function renderInspector() {
     <div class="inspector-content">
       <div class="inspector-section">
         <div class="inspector-row">
-          <div class="inspector-label">ID:</div>
-          <div class="inspector-value">${escapeHtml(node.id)}</div>
+          <label class="inspector-label" for="selected-node-id-input">ID:</label>
+          <div class="inspector-inline-edit">
+            <input
+              id="selected-node-id-input"
+              class="inspector-node-id-input"
+              type="text"
+              value="${escapeHtml(node.id)}"
+              spellcheck="false"
+            />
+            <button id="rename-selected-node-btn" class="btn">Rename</button>
+          </div>
         </div>
         <div class="inspector-row">
           <div class="inspector-label">Type:</div>
@@ -533,9 +542,42 @@ function attachParamListeners() {
   });
 }
 
+async function renameSelectedNode() {
+  const node = getSelectedEditorNode();
+  if (!node) return;
+
+  const input = elements.inspectorPanel.querySelector('#selected-node-id-input');
+  const newId = input?.value?.trim();
+
+  if (!newId || newId === node.id) {
+    return;
+  }
+
+  const result = await handleOperation({
+    type: 'renameNode',
+    id: node.id,
+    newId
+  });
+
+  if (result && !result.error) {
+    selectedNodeId = newId;
+    renderInspector();
+  }
+}
+
 function attachInspectorActionListeners() {
   const deleteButton = elements.inspectorPanel.querySelector('#delete-selected-node-btn');
   deleteButton?.addEventListener('click', deleteSelectedNode);
+
+  const renameButton = elements.inspectorPanel.querySelector('#rename-selected-node-btn');
+  renameButton?.addEventListener('click', renameSelectedNode);
+
+  const idInput = elements.inspectorPanel.querySelector('#selected-node-id-input');
+  idInput?.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    renameSelectedNode();
+  });
 }
 
 async function deleteSelectedNode() {
@@ -843,7 +885,9 @@ async function handleOperation(operation) {
       await nodeEditor?.renderModel(result.state.editorModel);
     }
 
-    if (selectedNodeId && !result.state.editorModel.nodesById[selectedNodeId]) {
+    if (result.change.operation.type === 'renameNode' && selectedNodeId === result.change.operation.id) {
+      selectedNodeId = result.change.operation.newId;
+    } else if (selectedNodeId && !result.state.editorModel.nodesById[selectedNodeId]) {
       selectedNodeId = null;
     }
 

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -389,6 +389,16 @@ body.panels-hidden .editor-panels {
   resize: vertical;
 }
 
+.inspector-inline-edit {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.inspector-node-id-input {
+  flex: 1;
+}
+
 .file-status {
   color: var(--text-dim);
   font-size: 12px;

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -33,11 +33,32 @@ import { NODE_TYPES } from './loom.js';
  *   | { type: 'moveNode',    id: string, position: { x: number, y: number } }
  *   | { type: 'addEdge',     edge: EditorEdge }
  *   | { type: 'removeEdge',  edgeId: string }
+ *   | { type: 'renameNode',  id: string, newId: string }
  * } EditorOperation
  */
 
 function edgeId(fromNodeId, fromPort, toNodeId, toPort) {
   return `${fromNodeId}.${fromPort}->${toNodeId}.${toPort}`;
+}
+
+function validateNodeId(id) {
+  if (typeof id !== 'string') {
+    throw new Error('Node id must be a string');
+  }
+
+  const trimmed = id.trim();
+
+  if (!trimmed) {
+    throw new Error('Node id cannot be empty');
+  }
+
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) {
+    throw new Error(
+      `Invalid node id '${id}'. Use letters, numbers, and underscores, and do not start with a number.`
+    );
+  }
+
+  return trimmed;
 }
 
 export function layoutFallback(nodes) {
@@ -201,6 +222,43 @@ export function applyEditorOperation(em, op) {
   if (op.type === 'removeEdge') {
     if (!next.edgesById[op.edgeId]) return next;
     delete next.edgesById[op.edgeId];
+    return next;
+  }
+
+  if (op.type === 'renameNode') {
+    if (!next.nodesById[op.id]) throw new Error(`Node '${op.id}' does not exist`);
+    const newId = validateNodeId(op.newId);
+    if (newId === op.id) return next;
+    if (next.nodesById[newId]) throw new Error(`Node '${newId}' already exists`);
+
+    const node = next.nodesById[op.id];
+    delete next.nodesById[op.id];
+    next.nodesById[newId] = { ...node, id: newId };
+
+    next.order = next.order.map((id) => (id === op.id ? newId : id));
+
+    const renamedEdgesById = {};
+    for (const edge of Object.values(next.edgesById)) {
+      const renamedEdge = {
+        ...edge,
+        fromNodeId: edge.fromNodeId === op.id ? newId : edge.fromNodeId,
+        toNodeId: edge.toNodeId === op.id ? newId : edge.toNodeId
+      };
+
+      const renamedEdgeId = edgeId(
+        renamedEdge.fromNodeId,
+        renamedEdge.fromPort,
+        renamedEdge.toNodeId,
+        renamedEdge.toPort
+      );
+
+      renamedEdgesById[renamedEdgeId] = {
+        ...renamedEdge,
+        id: renamedEdgeId
+      };
+    }
+    next.edgesById = renamedEdgesById;
+
     return next;
   }
 

--- a/src/node-editor-session.js
+++ b/src/node-editor-session.js
@@ -13,10 +13,45 @@ export function createNodeEditorState(graph) {
   };
 }
 
+function rewriteReferenceValue(value, oldId, newId) {
+  if (typeof value === 'string') {
+    if (value === oldId) return newId;
+    if (value.startsWith(`${oldId}.`)) {
+      return `${newId}${value.slice(oldId.length)}`;
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => rewriteReferenceValue(item, oldId, newId));
+  }
+
+  if (value && typeof value === 'object') {
+    const next = {};
+    for (const [key, child] of Object.entries(value)) {
+      next[key] = rewriteReferenceValue(child, oldId, newId);
+    }
+    return next;
+  }
+
+  return value;
+}
+
+function rewriteGraphReferencesForRename(graph, oldId, newId) {
+  return {
+    ...graph,
+    render: rewriteReferenceValue(graph.render, oldId, newId)
+  };
+}
+
 export function applyNodeEditorOperationState(state, operation) {
   try {
     const editorModel = applyEditorOperation(state.editorModel, operation);
-    const graph = editorModelToGraph(editorModel, state.graph);
+    let graph = editorModelToGraph(editorModel, state.graph);
+
+    if (operation.type === 'renameNode') {
+      graph = rewriteGraphReferencesForRename(graph, operation.id, operation.newId);
+    }
 
     return {
       state: {

--- a/test/node-editor-session.test.html
+++ b/test/node-editor-session.test.html
@@ -158,6 +158,95 @@
       assert(result.state.editorModel.nodesById.out, 'out node should still exist');
     });
 
+    test('Test 6: renameNode updates node ID and order', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'renameNode',
+        id: 'wave',
+        newId: 'wave2'
+      });
+
+      assert(!result.error, 'renameNode should not error');
+      assert(!result.state.editorModel.nodesById.wave, 'wave node should not exist');
+      assert(result.state.editorModel.nodesById.wave2, 'wave2 node should exist');
+      assert(result.state.editorModel.order.includes('wave2'), 'order should contain wave2');
+      assert(!result.state.editorModel.order.includes('wave'), 'order should not contain wave');
+      assert(result.state.editorModel.nodesById.wave2.id === 'wave2', 'node id should be wave2');
+    });
+
+    test('Test 7: renameNode updates connected edges', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'renameNode',
+        id: 'wave',
+        newId: 'wave2'
+      });
+
+      assert(!result.error, 'renameNode should not error');
+
+      const edges = Object.values(result.state.editorModel.edgesById);
+      let foundFromEdge = false;
+      let foundToEdge = false;
+
+      for (const edge of edges) {
+        if (edge.fromNodeId === 'wave2' && edge.toNodeId === 'out') {
+          foundFromEdge = true;
+          assert(edge.id === 'wave2.out->out.value', 'edge id should be recalculated with new node id');
+        }
+        if (edge.fromNodeId === 't' && edge.toNodeId === 'wave2') {
+          foundToEdge = true;
+          assert(edge.id === 't.t->wave2.t', 'edge id should be recalculated with new node id');
+        }
+      }
+
+      assert(foundFromEdge, 'should have from edge with wave2');
+      assert(foundToEdge, 'should have to edge with wave2');
+
+      for (const edge of edges) {
+        if (edge.fromNodeId === 'wave' || edge.toNodeId === 'wave') {
+          throw new Error('edges should not reference old node id');
+        }
+      }
+    });
+
+    test('Test 8: renameNode rejects duplicate ID', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'renameNode',
+        id: 'wave',
+        newId: 'out'
+      });
+
+      assert(result.error, 'renameNode should error on duplicate id');
+      assert(result.state.errors.length > 0, 'errors should contain error message');
+
+      const originalModelStr = JSON.stringify(sampleGraph());
+      const resultModelStr = JSON.stringify(result.state.graph);
+      assert(resultModelStr === originalModelStr, 'graph should not be mutated on error');
+    });
+
+    test('Test 9: renameNode rejects invalid ID', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'renameNode',
+        id: 'wave',
+        newId: '123bad'
+      });
+
+      assert(result.error, 'renameNode should error on invalid id');
+      assert(result.state.errors.length > 0, 'errors should contain error message');
+      assert(result.state.editorModel.nodesById.wave, 'original node should still exist');
+      assert(!result.state.editorModel.nodesById['123bad'], 'invalid node should not exist');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {

--- a/test/node-editor-session.test.html
+++ b/test/node-editor-session.test.html
@@ -247,6 +247,23 @@
       assert(!result.state.editorModel.nodesById['123bad'], 'invalid node should not exist');
     });
 
+    test('Test 10: renameNode updates render references', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'renameNode',
+        id: 'wave',
+        newId: 'wave2'
+      });
+
+      if (result.error) throw result.error;
+
+      assert(result.state.graph.render.x === 'wave2.out', 'render.x should reference wave2.out');
+      assert(result.state.graph.render.y === 'wave2.out', 'render.y should reference wave2.out');
+      assert(graph.render.x === 'wave.out', 'original graph render.x should not be mutated');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {


### PR DESCRIPTION
- Add renameNode to EditorOperation typedef
- Implement validateNodeId helper with proper ID validation
- Implement renameNode in applyEditorOperation with:
  - Validation of new ID
  - Update of nodesById, order, and all connected edges
  - Recalculation of edge IDs with new node reference
- Add 4 test cases for renameNode:
  - Updates node ID and order
  - Updates connected edges
  - Rejects duplicate ID
  - Rejects invalid ID
- Add ID edit UI to Inspector with:
  - Editable input field
  - Rename button
  - Enter key support
- Implement renameSelectedNode function
- Update handleOperation to preserve selection on rename
- Add styling for inline edit UI
- Mark file as dirty on successful rename

https://claude.ai/code/session_01Cctt31Hkt5bhTmCS243Mk8