### PR TITLE
Show and remove node connections in Inspector

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -395,6 +395,29 @@ function getSelectedEditorNode() {
   return state.editorModel.nodesById[selectedNodeId] || null;
 }
 
+function getSelectedNodeConnections() {
+  const state = store.getState();
+  const node = getSelectedEditorNode();
+
+  if (!node || !state.editorModel?.edgesById) {
+    return {
+      incoming: [],
+      outgoing: []
+    };
+  }
+
+  const edges = Object.values(state.editorModel.edgesById);
+
+  return {
+    incoming: edges.filter((edge) => edge.toNodeId === node.id),
+    outgoing: edges.filter((edge) => edge.fromNodeId === node.id)
+  };
+}
+
+function formatEdgeEndpoint(nodeId, port) {
+  return `${nodeId}.${port}`;
+}
+
 function setSelectedNodeId(nodeId) {
   const state = store.getState();
   if (nodeId && !state.editorModel?.nodesById[nodeId]) {
@@ -410,6 +433,60 @@ function setEditorError(message) {
     errors: [{ code: 'EDITOR_ERROR', message }]
   });
   renderErrors();
+}
+
+function renderConnectionItem(edge) {
+  const from = formatEdgeEndpoint(edge.fromNodeId, edge.fromPort);
+  const to = formatEdgeEndpoint(edge.toNodeId, edge.toPort);
+
+  return `
+    <div class="connection-item">
+      <div class="connection-label">
+        <span class="connection-endpoint">${escapeHtml(from)}</span>
+        <span class="connection-arrow">→</span>
+        <span class="connection-endpoint">${escapeHtml(to)}</span>
+      </div>
+      <button
+        class="btn connection-remove-btn"
+        data-remove-edge-id="${escapeHtml(edge.id)}"
+        title="Remove connection"
+      >
+        Remove
+      </button>
+    </div>
+  `;
+}
+
+function renderConnectionGroup(title, edges) {
+  if (!edges.length) {
+    return `
+      <div class="connection-group">
+        <div class="connection-group-title">${escapeHtml(title)}</div>
+        <div class="connection-empty">No ${escapeHtml(title.toLowerCase())} connections.</div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="connection-group">
+      <div class="connection-group-title">${escapeHtml(title)}</div>
+      <div class="connection-list">
+        ${edges.map(renderConnectionItem).join('')}
+      </div>
+    </div>
+  `;
+}
+
+function renderConnectionsSection() {
+  const { incoming, outgoing } = getSelectedNodeConnections();
+
+  return `
+    <div class="inspector-section">
+      <div class="inspector-section-title">Connections</div>
+      ${renderConnectionGroup('Incoming', incoming)}
+      ${renderConnectionGroup('Outgoing', outgoing)}
+    </div>
+  `;
 }
 
 function renderInspector() {
@@ -468,6 +545,8 @@ function renderInspector() {
 
   html += `
       </div>
+
+      ${renderConnectionsSection()}
 
       <div class="inspector-section inspector-danger-section">
         <div class="inspector-label" style="margin-bottom: 8px;">Danger Zone:</div>
@@ -578,6 +657,15 @@ function attachInspectorActionListeners() {
     event.preventDefault();
     renameSelectedNode();
   });
+
+  elements.inspectorPanel
+    .querySelectorAll('[data-remove-edge-id]')
+    .forEach((button) => {
+      button.addEventListener('click', () => {
+        const edgeId = button.getAttribute('data-remove-edge-id');
+        removeConnection(edgeId);
+      });
+    });
 }
 
 async function deleteSelectedNode() {
@@ -596,6 +684,21 @@ async function deleteSelectedNode() {
     selectedNodeId = null;
     renderInspector();
   }
+}
+
+async function removeConnection(edgeId) {
+  if (!edgeId) return;
+
+  const state = store.getState();
+  if (!state.editorModel?.edgesById?.[edgeId]) {
+    setEditorError(`Connection '${edgeId}' does not exist`);
+    return;
+  }
+
+  await handleOperation({
+    type: 'removeEdge',
+    edgeId
+  });
 }
 
 function applyParamEdit(key, value) {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -527,3 +527,61 @@ body.panels-hidden .editor-panels {
 .btn-danger:hover {
   background: rgba(220, 60, 60, 0.28);
 }
+
+.inspector-section-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--text-color);
+}
+
+.connection-group {
+  margin-bottom: 12px;
+}
+
+.connection-group-title {
+  color: var(--text-dim);
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.connection-empty {
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 4px 0;
+}
+
+.connection-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.connection-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.connection-label {
+  min-width: 0;
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-arrow {
+  color: var(--text-dim);
+  margin: 0 4px;
+}
+
+.connection-remove-btn {
+  font-size: 12px;
+  padding: 3px 6px;
+}

--- a/test/node-editor-session.test.html
+++ b/test/node-editor-session.test.html
@@ -264,6 +264,35 @@
       assert(graph.render.x === 'wave.out', 'original graph render.x should not be mutated');
     });
 
+    test('Test 11: removeEdge removes a connection without removing nodes', () => {
+      const graph = sampleGraph();
+      const state = createNodeEditorState(graph);
+
+      const edgeId = Object.keys(state.editorModel.edgesById).find((id) => {
+        const edge = state.editorModel.edgesById[id];
+        return edge.fromNodeId === 'wave' && edge.toNodeId === 'out';
+      });
+
+      assert(edgeId, 'expected edge from wave to out to exist');
+
+      const result = applyNodeEditorOperationState(state, {
+        type: 'removeEdge',
+        edgeId
+      });
+
+      if (result.error) throw result.error;
+
+      assert(!result.state.editorModel.edgesById[edgeId], 'edge should be removed');
+      assert(result.state.editorModel.nodesById.wave, 'wave node should remain');
+      assert(result.state.editorModel.nodesById.out, 'out node should remain');
+
+      const graphHasRemovedEdge = result.state.graph.edges.some((edge) => {
+        return edge.from === 'wave.out' && edge.to === 'out.value';
+      });
+
+      assert(!graphHasRemovedEdge, 'graph should not contain removed edge');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {


### PR DESCRIPTION
Add connections section to Inspector displaying:
- Inbound connections for selected node
- Outbound connections for selected node
- Remove button for each connection

Implements removeConnection() to handle edge removal via operation flow,
ensuring GraphJSON, preview, and dirty state update correctly.

Added CSS styling for connection items and groups.
Added test for removeEdge operation.

https://claude.ai/code/session_01RVp7qqK4ENfSxc7AUFvUDj