### PR TITLE
Add debounced Auto Apply DSL to Node Graph

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -20,6 +20,11 @@
       <button id="resetSampleBtn" class="btn">Reset Sample</button>
       <button id="applyDslBtn" class="btn btn-primary">Apply DSL → Node</button>
       <button id="generateDslBtn" class="btn btn-primary">Generate DSL ← Node</button>
+      <label class="toolbar-toggle">
+        <input id="autoApplyDslToggle" type="checkbox" />
+        <span>Auto Apply DSL</span>
+      </label>
+      <span id="auto-apply-status" class="auto-apply-status">Manual</span>
     </div>
 
     <div id="editor-panels" class="editor-panels">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -198,6 +198,19 @@ function scheduleAutoApplyDsl() {
   }, autoApplyDelayMs);
 }
 
+function cancelPendingAutoApplyDsl() {
+  if (autoApplyTimer) {
+    clearTimeout(autoApplyTimer);
+    autoApplyTimer = null;
+  }
+
+  autoApplyRequestId += 1;
+
+  if (autoApplyDslEnabled) {
+    renderAutoApplyStatus('ok');
+  }
+}
+
 function isAbortError(error) {
   return error && (error.name === 'AbortError' || error.code === 20);
 }
@@ -366,7 +379,7 @@ async function openLoomFile() {
   }
 }
 
-async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraphOnError = false } = {}) {
+async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraphOnError = false, shouldCommit = null } = {}) {
   const { ast, errors: parseErrors } = parseDSLToAST(sourceText);
 
   if (parseErrors.length) {
@@ -407,6 +420,14 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
 
   const editorModel = graphToEditorModel(graph);
 
+  if (shouldCommit && !shouldCommit()) {
+    return { ok: false, stale: true, errors: [] };
+  }
+
+  if (shouldCommit && !shouldCommit()) {
+    return { ok: false, stale: true, errors: [] };
+  }
+
   store.setState({
     sourceText,
     sourceAst: ast,
@@ -417,6 +438,11 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
 
   selectedNodeId = null;
   await nodeEditor?.renderModel(editorModel);
+
+  if (shouldCommit && !shouldCommit()) {
+    return { ok: false, stale: true, errors: [] };
+  }
+
   renderGraphJSON(graph);
   renderErrors();
   renderInspector();
@@ -435,10 +461,16 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
 }
 
 async function applyDsl({ markDirty = true } = {}) {
-  return applyDslTextToGraph(getDslText(), {
+  const result = await applyDslTextToGraph(getDslText(), {
     markDirty,
     preserveGraphOnError: false
   });
+
+  if (result.ok) {
+    cancelPendingAutoApplyDsl();
+  }
+
+  return result;
 }
 
 function generateDsl() {
@@ -461,6 +493,7 @@ function generateDsl() {
   runPreview(graph);
   hasUnsyncedDslText = false;
   latestSuccessfulDslText = dsl;
+  cancelPendingAutoApplyDsl();
   setDirty(true);
 }
 
@@ -477,9 +510,11 @@ async function autoApplyDslFromEditor(requestId) {
 
   const result = await applyDslTextToGraph(sourceText, {
     markDirty: true,
-    preserveGraphOnError: true
+    preserveGraphOnError: true,
+    shouldCommit: () => autoApplyDslEnabled && requestId === autoApplyRequestId
   });
 
+  if (result.stale) return;
   if (requestId !== autoApplyRequestId) return;
 
   if (result.ok) {
@@ -1134,6 +1169,7 @@ async function handleOperation(operation) {
     renderInspector();
     runPreview(result.state.graph);
     hasUnsyncedDslText = false;
+    cancelPendingAutoApplyDsl();
     setDirty(true);
     return result;
   }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -424,10 +424,6 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
     return { ok: false, stale: true, errors: [] };
   }
 
-  if (shouldCommit && !shouldCommit()) {
-    return { ok: false, stale: true, errors: [] };
-  }
-
   store.setState({
     sourceText,
     sourceAst: ast,
@@ -438,10 +434,6 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
 
   selectedNodeId = null;
   await nodeEditor?.renderModel(editorModel);
-
-  if (shouldCommit && !shouldCommit()) {
-    return { ok: false, stale: true, errors: [] };
-  }
 
   renderGraphJSON(graph);
   renderErrors();

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -41,6 +41,11 @@ let currentFileName = '';
 let isDirty = false;
 let isApplyingProgrammaticDslChange = false;
 let hasUnsyncedDslText = false;
+let autoApplyDslEnabled = false;
+let autoApplyTimer = null;
+let autoApplyDelayMs = 500;
+let autoApplyRequestId = 0;
+let latestSuccessfulDslText = '';
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
@@ -62,7 +67,9 @@ const elements = {
   saveAsFileBtn: document.getElementById('saveAsFileBtn'),
   nodePaletteSearch: document.getElementById('node-palette-search'),
   nodePaletteCategory: document.getElementById('node-palette-category'),
-  nodePaletteList: document.getElementById('node-palette-list')
+  nodePaletteList: document.getElementById('node-palette-list'),
+  autoApplyDslToggle: document.getElementById('autoApplyDslToggle'),
+  autoApplyStatus: document.getElementById('auto-apply-status')
 };
 
 function setPanelsVisible(visible) {
@@ -101,6 +108,7 @@ function initDslEditor() {
 
         hasUnsyncedDslText = true;
         setDirty(true);
+        scheduleAutoApplyDsl();
       })
     ]
   });
@@ -139,6 +147,55 @@ function renderFileStatus() {
   const label = currentFileName || 'No file';
   const dirtyMark = isDirty ? ' *' : '';
   elements.fileStatus.textContent = `${label}${dirtyMark}`;
+}
+
+function renderAutoApplyStatus(status = null) {
+  if (!elements.autoApplyStatus) return;
+
+  if (!autoApplyDslEnabled) {
+    elements.autoApplyStatus.textContent = 'Manual';
+    elements.autoApplyStatus.className = 'auto-apply-status';
+    return;
+  }
+
+  if (status === 'pending') {
+    elements.autoApplyStatus.textContent = 'Auto: pending';
+    elements.autoApplyStatus.className = 'auto-apply-status pending';
+    return;
+  }
+
+  if (status === 'ok') {
+    elements.autoApplyStatus.textContent = 'Auto: synced';
+    elements.autoApplyStatus.className = 'auto-apply-status ok';
+    return;
+  }
+
+  if (status === 'error') {
+    elements.autoApplyStatus.textContent = 'Auto: error';
+    elements.autoApplyStatus.className = 'auto-apply-status error';
+    return;
+  }
+
+  elements.autoApplyStatus.textContent = 'Auto: on';
+  elements.autoApplyStatus.className = 'auto-apply-status';
+}
+
+function scheduleAutoApplyDsl() {
+  if (!autoApplyDslEnabled) return;
+  if (isApplyingProgrammaticDslChange) return;
+
+  if (autoApplyTimer) {
+    clearTimeout(autoApplyTimer);
+  }
+
+  renderAutoApplyStatus('pending');
+
+  const requestId = ++autoApplyRequestId;
+
+  autoApplyTimer = window.setTimeout(() => {
+    autoApplyTimer = null;
+    autoApplyDslFromEditor(requestId);
+  }, autoApplyDelayMs);
 }
 
 function isAbortError(error) {
@@ -309,27 +366,43 @@ async function openLoomFile() {
   }
 }
 
-async function applyDsl({ markDirty = true } = {}) {
-  const sourceText = getDslText();
+async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraphOnError = false } = {}) {
   const { ast, errors: parseErrors } = parseDSLToAST(sourceText);
 
   if (parseErrors.length) {
     store.setState({ errors: parseErrors });
-    selectedNodeId = null;
+
+    if (!preserveGraphOnError) {
+      selectedNodeId = null;
+      renderInspector();
+    }
+
     renderErrors();
-    renderInspector();
     if (markDirty) setDirty(true);
-    return;
+
+    return {
+      ok: false,
+      errors: parseErrors
+    };
   }
 
   const { graph, errors: compileErrors } = compileToGraph(ast);
+
   if (compileErrors.length) {
     store.setState({ errors: compileErrors });
-    selectedNodeId = null;
+
+    if (!preserveGraphOnError) {
+      selectedNodeId = null;
+      renderInspector();
+    }
+
     renderErrors();
-    renderInspector();
     if (markDirty) setDirty(true);
-    return;
+
+    return {
+      ok: false,
+      errors: compileErrors
+    };
   }
 
   const editorModel = graphToEditorModel(graph);
@@ -348,8 +421,24 @@ async function applyDsl({ markDirty = true } = {}) {
   renderErrors();
   renderInspector();
   runPreview(graph);
+
   hasUnsyncedDslText = false;
+  latestSuccessfulDslText = sourceText;
+
   if (markDirty) setDirty(true);
+
+  return {
+    ok: true,
+    graph,
+    editorModel
+  };
+}
+
+async function applyDsl({ markDirty = true } = {}) {
+  return applyDslTextToGraph(getDslText(), {
+    markDirty,
+    preserveGraphOnError: false
+  });
 }
 
 function generateDsl() {
@@ -371,7 +460,33 @@ function generateDsl() {
   renderInspector();
   runPreview(graph);
   hasUnsyncedDslText = false;
+  latestSuccessfulDslText = dsl;
   setDirty(true);
+}
+
+async function autoApplyDslFromEditor(requestId) {
+  if (!autoApplyDslEnabled) return;
+  if (requestId !== autoApplyRequestId) return;
+
+  const sourceText = getDslText();
+
+  if (sourceText === latestSuccessfulDslText) {
+    renderAutoApplyStatus('ok');
+    return;
+  }
+
+  const result = await applyDslTextToGraph(sourceText, {
+    markDirty: true,
+    preserveGraphOnError: true
+  });
+
+  if (requestId !== autoApplyRequestId) return;
+
+  if (result.ok) {
+    renderAutoApplyStatus('ok');
+  } else {
+    renderAutoApplyStatus('error');
+  }
 }
 
 function renderGraphJSON(graph) {
@@ -951,6 +1066,25 @@ function setupEventListeners() {
   elements.saveFileBtn.addEventListener('click', saveDslFile);
   elements.saveAsFileBtn.addEventListener('click', saveDslAsFile);
 
+  elements.autoApplyDslToggle?.addEventListener('change', () => {
+    autoApplyDslEnabled = Boolean(elements.autoApplyDslToggle.checked);
+
+    if (!autoApplyDslEnabled) {
+      if (autoApplyTimer) {
+        clearTimeout(autoApplyTimer);
+        autoApplyTimer = null;
+      }
+      renderAutoApplyStatus();
+      return;
+    }
+
+    renderAutoApplyStatus();
+
+    if (hasUnsyncedDslText) {
+      scheduleAutoApplyDsl();
+    }
+  });
+
   elements.tabBtns.forEach(btn => {
     btn.addEventListener('click', () => {
       const tabName = btn.getAttribute('data-tab');
@@ -1029,6 +1163,7 @@ async function init() {
 
   setupEventListeners();
   renderFileStatus();
+  renderAutoApplyStatus();
   renderNodePaletteCategories();
   renderNodePalette();
   await applyDsl({ markDirty: false });

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -585,3 +585,35 @@ body.panels-hidden .editor-panels {
   font-size: 12px;
   padding: 3px 6px;
 }
+
+.toolbar-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-dim);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.toolbar-toggle input {
+  margin: 0;
+  cursor: pointer;
+}
+
+.auto-apply-status {
+  color: var(--text-dim);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.auto-apply-status.pending {
+  color: #e7c66b;
+}
+
+.auto-apply-status.ok {
+  color: #80ed99;
+}
+
+.auto-apply-status.error {
+  color: #ff9b9b;
+}


### PR DESCRIPTION
Implement optional Auto Apply mode for the DSL editor with the following features:

- Auto Apply toggle in toolbar (OFF by default)
- Debounced DSL parsing/compilation (500ms delay)
- Status indicator showing Manual/Auto: pending/synced/error states
- Safe graph state preservation on parse/compile errors
- Prevents feedback loops by respecting isApplyingProgrammaticDslChange flag
- Extracted applyDslTextToGraph helper for reusable parse/compile logic
- Refactored applyDsl() to use the helper
- Auto Apply only triggers on real user edits via CodeMirror listener
- latestSuccessfulDslText tracks most recent valid DSL for the current graph
- Graph operations remain source of truth (hasUnsyncedDslText=false on graph edit)
- Manual Apply behavior unchanged (clears selected node on error)
- Auto Apply failure preserves current graph/editorModel/selected node

UI Changes:
- Added checkbox toggle and status label near Apply/Generate buttons
- CSS classes for pending/ok/error status states with distinct colors

https://claude.ai/code/session_01DB3vov7ZDi8x2zwywaPYpT