### PR TITLE
Auto sync node graph changes to DSL

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -24,6 +24,10 @@
         <input id="autoApplyDslToggle" type="checkbox" />
         <span>Auto Apply DSL</span>
       </label>
+      <label class="toolbar-toggle">
+        <input id="autoSyncGraphToDslToggle" type="checkbox" checked />
+        <span>Auto Sync DSL</span>
+      </label>
       <span id="auto-apply-status" class="auto-apply-status">Manual</span>
     </div>
 

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -42,6 +42,7 @@ let isDirty = false;
 let isApplyingProgrammaticDslChange = false;
 let hasUnsyncedDslText = false;
 let autoApplyDslEnabled = false;
+let autoSyncGraphToDslEnabled = true;
 let autoApplyTimer = null;
 let autoApplyDelayMs = 500;
 let autoApplyRequestId = 0;
@@ -69,7 +70,8 @@ const elements = {
   nodePaletteCategory: document.getElementById('node-palette-category'),
   nodePaletteList: document.getElementById('node-palette-list'),
   autoApplyDslToggle: document.getElementById('autoApplyDslToggle'),
-  autoApplyStatus: document.getElementById('auto-apply-status')
+  autoApplyStatus: document.getElementById('auto-apply-status'),
+  autoSyncGraphToDslToggle: document.getElementById('autoSyncGraphToDslToggle')
 };
 
 function setPanelsVisible(visible) {
@@ -465,28 +467,39 @@ async function applyDsl({ markDirty = true } = {}) {
   return result;
 }
 
-function generateDsl() {
+function generateCanonicalDslFromState() {
   const state = store.getState();
-  if (!state.editorModel) return;
+
+  if (!state.editorModel) {
+    return getDslText();
+  }
 
   const graph = editorModelToGraph(state.editorModel, state.graph);
-  const dsl = graphToCanonicalDSL(graph);
+  return graphToCanonicalDSL(graph);
+}
+
+function syncGraphToDslEditor({ markDirty = true, force = false } = {}) {
+  if (!force && !autoSyncGraphToDslEnabled) return null;
+
+  const dsl = generateCanonicalDslFromState();
 
   setDslText(dsl);
-  store.setState({
-    sourceText: dsl,
-    graph,
-    errors: []
-  });
 
-  renderGraphJSON(graph);
-  renderErrors();
-  renderInspector();
-  runPreview(graph);
   hasUnsyncedDslText = false;
   latestSuccessfulDslText = dsl;
+
+  if (markDirty) {
+    setDirty(true);
+  }
+
+  return dsl;
+}
+
+function generateDsl() {
   cancelPendingAutoApplyDsl();
-  setDirty(true);
+  const dsl = syncGraphToDslEditor({ markDirty: true, force: true });
+  if (!dsl) return;
+  renderAutoApplyStatus(autoApplyDslEnabled ? 'ok' : null);
 }
 
 async function autoApplyDslFromEditor(requestId) {
@@ -1112,6 +1125,14 @@ function setupEventListeners() {
     }
   });
 
+  elements.autoSyncGraphToDslToggle?.addEventListener('change', () => {
+    autoSyncGraphToDslEnabled = Boolean(elements.autoSyncGraphToDslToggle.checked);
+
+    if (autoSyncGraphToDslEnabled && !hasUnsyncedDslText) {
+      syncGraphToDslEditor({ markDirty: false });
+    }
+  });
+
   elements.tabBtns.forEach(btn => {
     btn.addEventListener('click', () => {
       const tabName = btn.getAttribute('data-tab');
@@ -1162,6 +1183,7 @@ async function handleOperation(operation) {
     runPreview(result.state.graph);
     hasUnsyncedDslText = false;
     cancelPendingAutoApplyDsl();
+    syncGraphToDslEditor({ markDirty: true });
     setDirty(true);
     return result;
   }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -485,6 +485,13 @@ function syncGraphToDslEditor({ markDirty = true, force = false } = {}) {
 
   setDslText(dsl);
 
+  store.setState({
+    sourceText: dsl,
+    errors: []
+  });
+
+  renderErrors();
+
   hasUnsyncedDslText = false;
   latestSuccessfulDslText = dsl;
 


### PR DESCRIPTION
After a successful graph operation (updateParam, addNode, removeNode, renameNode, moveNode, addEdge, removeEdge), the DSL Editor now automatically updates to the canonical DSL generated from the current graph state, completing bidirectional sync.

- Add `autoSyncGraphToDslEnabled` state (default ON)
- Add `Auto Sync DSL` checkbox toggle to toolbar (checked by default)
- Add `generateCanonicalDslFromState()` helper for graph→DSL conversion
- Add `syncGraphToDslEditor({ markDirty, force })` helper that is guarded by `isApplyingProgrammaticDslChange` via `setDslText`, preventing Auto Apply feedback loops
- Refactor `generateDsl()` to call `syncGraphToDslEditor({ force: true })` so manual Generate DSL ← Node always works regardless of toggle state
- Call `syncGraphToDslEditor()` in the success path of `handleOperation()`, after `cancelPendingAutoApplyDsl()`, so graph operations drive DSL Editor updates
- Toggle listener immediately syncs once when turned ON (if graph is source of truth)

https://claude.ai/code/session_01AAKKzrTRaLHHYKAhFMygiT