### PR TITLE
Add resizable and collapsible bottom panel with persistent state

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -49,12 +49,17 @@
       </div>
 
       <!-- Bottom area: GraphJSON, Errors, and Inspector -->
-      <div class="panel graph-errors-panel">
-        <div class="tabs">
-          <button class="tab-btn active" data-tab="graph">GraphJSON</button>
-          <button class="tab-btn" data-tab="errors">Errors</button>
-          <button class="tab-btn" data-tab="inspector">Inspector</button>
-          <button class="tab-btn" data-tab="palette">Palette</button>
+      <div id="bottom-panel-resize-handle" class="bottom-panel-resize-handle" title="Drag to resize bottom panel"></div>
+
+      <div class="panel graph-errors-panel" id="bottom-panel">
+        <div class="tab-header">
+          <div class="tab-buttons">
+            <button class="tab-btn active" data-tab="graph">GraphJSON</button>
+            <button class="tab-btn" data-tab="errors">Errors</button>
+            <button class="tab-btn" data-tab="inspector">Inspector</button>
+            <button class="tab-btn" data-tab="palette">Palette</button>
+          </div>
+          <button id="bottom-panel-collapse-btn" class="bottom-panel-collapse-btn" title="Collapse bottom panel">Collapse</button>
         </div>
         <div class="tab-content">
           <div id="graph-tab" class="tab-pane active">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -29,6 +29,13 @@ width = map(smooth, inMin: -1, inMax: 1, outMin: 80, outMax: 680, clamp: true)
 render bar(width: width, color: "#80ed99", height: 48)
 `;
 
+const BOTTOM_PANEL_HEIGHT_KEY = 'loomlet.editorStudio.bottomPanelHeight';
+const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
+
+const DEFAULT_BOTTOM_PANEL_HEIGHT = 260;
+const MIN_BOTTOM_PANEL_HEIGHT = 120;
+const MAX_BOTTOM_PANEL_RATIO = 0.6;
+
 const store = createStore();
 let dslEditor = null;
 let nodeEditor = null;
@@ -47,6 +54,9 @@ let autoApplyTimer = null;
 let autoApplyDelayMs = 500;
 let autoApplyRequestId = 0;
 let latestSuccessfulDslText = '';
+let bottomPanelHeight = DEFAULT_BOTTOM_PANEL_HEIGHT;
+let isBottomPanelCollapsed = false;
+let isResizingBottomPanel = false;
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
@@ -71,7 +81,10 @@ const elements = {
   nodePaletteList: document.getElementById('node-palette-list'),
   autoApplyDslToggle: document.getElementById('autoApplyDslToggle'),
   autoApplyStatus: document.getElementById('auto-apply-status'),
-  autoSyncGraphToDslToggle: document.getElementById('autoSyncGraphToDslToggle')
+  autoSyncGraphToDslToggle: document.getElementById('autoSyncGraphToDslToggle'),
+  bottomPanel: document.getElementById('bottom-panel'),
+  bottomPanelResizeHandle: document.getElementById('bottom-panel-resize-handle'),
+  bottomPanelCollapseBtn: document.getElementById('bottom-panel-collapse-btn')
 };
 
 function setPanelsVisible(visible) {
@@ -82,6 +95,107 @@ function setPanelsVisible(visible) {
   if (button) {
     button.textContent = visible ? 'Hide Editors' : 'Show Editors';
   }
+}
+
+function getMaxBottomPanelHeight() {
+  return Math.max(
+    MIN_BOTTOM_PANEL_HEIGHT,
+    Math.floor(window.innerHeight * MAX_BOTTOM_PANEL_RATIO)
+  );
+}
+
+function clampBottomPanelHeight(height) {
+  return Math.min(
+    Math.max(height, MIN_BOTTOM_PANEL_HEIGHT),
+    getMaxBottomPanelHeight()
+  );
+}
+
+function applyBottomPanelLayout() {
+  const panel = elements.bottomPanel;
+  const handle = elements.bottomPanelResizeHandle;
+  const button = elements.bottomPanelCollapseBtn;
+
+  if (!panel) return;
+
+  if (isBottomPanelCollapsed) {
+    panel.style.height = '0px';
+    panel.classList.add('collapsed');
+    handle?.classList.add('collapsed');
+    if (button) {
+      button.textContent = 'Expand';
+      button.title = 'Expand bottom panel';
+    }
+    return;
+  }
+
+  const height = clampBottomPanelHeight(bottomPanelHeight);
+  bottomPanelHeight = height;
+  panel.style.height = `${height}px`;
+  panel.classList.remove('collapsed');
+  handle?.classList.remove('collapsed');
+
+  if (button) {
+    button.textContent = 'Collapse';
+    button.title = 'Collapse bottom panel';
+  }
+}
+
+function loadBottomPanelLayout() {
+  const savedHeight = Number(localStorage.getItem(BOTTOM_PANEL_HEIGHT_KEY));
+  if (Number.isFinite(savedHeight)) {
+    bottomPanelHeight = clampBottomPanelHeight(savedHeight);
+  }
+
+  isBottomPanelCollapsed =
+    localStorage.getItem(BOTTOM_PANEL_COLLAPSED_KEY) === 'true';
+
+  applyBottomPanelLayout();
+}
+
+function saveBottomPanelLayout() {
+  localStorage.setItem(BOTTOM_PANEL_HEIGHT_KEY, String(bottomPanelHeight));
+  localStorage.setItem(BOTTOM_PANEL_COLLAPSED_KEY, String(isBottomPanelCollapsed));
+}
+
+function startBottomPanelResize(event) {
+  if (isBottomPanelCollapsed) {
+    isBottomPanelCollapsed = false;
+  }
+
+  isResizingBottomPanel = true;
+  document.body.classList.add('resizing-bottom-panel');
+  event.preventDefault();
+}
+
+function resizeBottomPanel(event) {
+  if (!isResizingBottomPanel) return;
+
+  const viewportHeight = window.innerHeight;
+  const newHeight = viewportHeight - event.clientY;
+
+  bottomPanelHeight = clampBottomPanelHeight(newHeight);
+  applyBottomPanelLayout();
+}
+
+function stopBottomPanelResize() {
+  if (!isResizingBottomPanel) return;
+
+  isResizingBottomPanel = false;
+  document.body.classList.remove('resizing-bottom-panel');
+  saveBottomPanelLayout();
+}
+
+function handleWindowResizeForBottomPanel() {
+  bottomPanelHeight = clampBottomPanelHeight(bottomPanelHeight);
+  applyBottomPanelLayout();
+  saveBottomPanelLayout();
+}
+
+function toggleBottomPanelCollapsed() {
+  isBottomPanelCollapsed = !isBottomPanelCollapsed;
+  applyBottomPanelLayout();
+  saveBottomPanelLayout();
 }
 
 function resizePreviewCanvas() {
@@ -1153,6 +1267,12 @@ function setupEventListeners() {
   elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
 
+  elements.bottomPanelResizeHandle?.addEventListener('pointerdown', startBottomPanelResize);
+  window.addEventListener('pointermove', resizeBottomPanel);
+  window.addEventListener('pointerup', stopBottomPanelResize);
+  window.addEventListener('resize', handleWindowResizeForBottomPanel);
+  elements.bottomPanelCollapseBtn?.addEventListener('click', toggleBottomPanelCollapsed);
+
   window.addEventListener('resize', resizePreviewCanvas);
   window.addEventListener('keydown', handleGlobalKeyDown);
 }
@@ -1219,6 +1339,7 @@ async function init() {
   });
 
   setupEventListeners();
+  loadBottomPanelLayout();
   renderFileStatus();
   renderAutoApplyStatus();
   renderNodePaletteCategories();

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -65,6 +65,7 @@ html, body {
   bottom: 12px;
   display: grid;
   grid-template-columns: minmax(360px, 1fr) minmax(420px, 1fr);
+  grid-template-rows: 1fr auto auto;
   gap: 12px;
   z-index: 15;
   pointer-events: auto;
@@ -73,6 +74,26 @@ html, body {
 /* Hide editor panels */
 body.panels-hidden .editor-panels {
   display: none;
+}
+
+.dsl-pane {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.node-pane {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.bottom-panel-resize-handle {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+
+.graph-errors-panel {
+  grid-column: 1 / -1;
+  grid-row: 3;
 }
 
 /* Panel styling */
@@ -170,14 +191,59 @@ body.panels-hidden .editor-panels {
 /* Graph/Errors panel */
 .graph-errors-panel {
   grid-column: 1 / -1;
+  flex: 0 0 auto;
+  height: 260px;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.graph-errors-panel.collapsed {
+  height: 0 !important;
+  border-top: none;
+  overflow: hidden;
+}
+
+.bottom-panel-resize-handle {
+  flex: 0 0 6px;
+  height: 6px;
+  cursor: row-resize;
+  background: transparent;
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.bottom-panel-resize-handle:hover,
+body.resizing-bottom-panel .bottom-panel-resize-handle {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bottom-panel-resize-handle.collapsed {
+  border-bottom: none;
 }
 
 /* Tabs */
 .tabs {
+  display: none;
+}
+
+.tab-header {
+  flex: 0 0 auto;
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(0, 0, 0, 0.3);
-  flex-shrink: 0;
+}
+
+.tab-buttons {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow-x: auto;
 }
 
 .tab-btn {
@@ -202,10 +268,18 @@ body.panels-hidden .editor-panels {
   border-bottom-color: var(--primary-color);
 }
 
+.bottom-panel-collapse-btn {
+  flex: 0 0 auto;
+  font-size: 12px;
+  padding: 3px 8px;
+  margin-right: 4px;
+}
+
 .tab-content {
   flex: 1;
   overflow: hidden;
   display: flex;
+  min-height: 0;
 }
 
 .tab-pane {
@@ -213,6 +287,7 @@ body.panels-hidden .editor-panels {
   overflow: auto;
   display: none;
   flex-direction: column;
+  min-height: 0;
 }
 
 .tab-pane.active {


### PR DESCRIPTION
## Summary
This PR adds functionality to make the bottom panel (containing GraphJSON, Errors, Inspector, and Palette tabs) resizable and collapsible, with the ability to persist the user's layout preferences to localStorage.

## Key Changes
- **Resizable bottom panel**: Users can drag the resize handle between the editor panels and bottom panel to adjust its height
- **Collapsible bottom panel**: Added a collapse/expand button to toggle the bottom panel visibility
- **Persistent layout**: Panel height and collapsed state are saved to localStorage and restored on page load
- **Responsive constraints**: Panel height is constrained between a minimum (120px) and maximum (60% of viewport height)
- **Window resize handling**: Panel layout automatically adjusts when the window is resized to maintain valid constraints
- **Visual feedback**: Added hover states and cursor changes for the resize handle; body class added during resize for styling

## Implementation Details
- Added state variables: `bottomPanelHeight`, `isBottomPanelCollapsed`, `isResizingBottomPanel`
- Implemented pointer event handlers for smooth drag-to-resize functionality
- Grid layout updated to accommodate the resize handle and bottom panel as separate rows
- CSS updated with flexbox for proper overflow handling and visual styling of the resize handle
- HTML restructured to separate tab buttons from the collapse button in a new `tab-header` container
- localStorage keys namespaced under `loomlet.editorStudio.*` for organization

https://claude.ai/code/session_0157r9K1c6F2zzGepcs8davJ