### PR TITLE
Add resizable editor split between DSL and node panes

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -40,6 +40,13 @@
         <div id="dsl-editor-host" class="dsl-editor-host"></div>
       </div>
 
+      <!-- Vertical splitter -->
+      <div
+        id="editor-split-resize-handle"
+        class="editor-split-resize-handle"
+        title="Drag to resize editor split"
+      ></div>
+
       <!-- Right pane: Node Editor -->
       <div class="panel node-pane">
         <div class="pane-header">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -31,10 +31,16 @@ render bar(width: width, color: "#80ed99", height: 48)
 
 const BOTTOM_PANEL_HEIGHT_KEY = 'loomlet.editorStudio.bottomPanelHeight';
 const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
+const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';
 
 const DEFAULT_BOTTOM_PANEL_HEIGHT = 260;
 const MIN_BOTTOM_PANEL_HEIGHT = 120;
 const MAX_BOTTOM_PANEL_RATIO = 0.6;
+
+const DEFAULT_DSL_PANE_WIDTH = 520;
+const MIN_DSL_PANE_WIDTH = 280;
+const MIN_NODE_PANE_WIDTH = 320;
+const EDITOR_SPLIT_HANDLE_WIDTH = 8;
 
 const store = createStore();
 let dslEditor = null;
@@ -57,6 +63,8 @@ let latestSuccessfulDslText = '';
 let bottomPanelHeight = DEFAULT_BOTTOM_PANEL_HEIGHT;
 let isBottomPanelCollapsed = false;
 let isResizingBottomPanel = false;
+let dslPaneWidth = DEFAULT_DSL_PANE_WIDTH;
+let isResizingEditorSplit = false;
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
@@ -84,7 +92,9 @@ const elements = {
   autoSyncGraphToDslToggle: document.getElementById('autoSyncGraphToDslToggle'),
   bottomPanel: document.getElementById('bottom-panel'),
   bottomPanelResizeHandle: document.getElementById('bottom-panel-resize-handle'),
-  bottomPanelCollapseBtn: document.getElementById('bottom-panel-collapse-btn')
+  bottomPanelCollapseBtn: document.getElementById('bottom-panel-collapse-btn'),
+  editorPanels: document.querySelector('.editor-panels'),
+  editorSplitResizeHandle: document.getElementById('editor-split-resize-handle')
 };
 
 function setPanelsVisible(visible) {
@@ -189,13 +199,84 @@ function stopBottomPanelResize() {
 function handleWindowResizeForBottomPanel() {
   bottomPanelHeight = clampBottomPanelHeight(bottomPanelHeight);
   applyBottomPanelLayout();
+
+  dslPaneWidth = clampDslPaneWidth(dslPaneWidth);
+  applyEditorSplitLayout();
+
   saveBottomPanelLayout();
+  saveEditorSplitLayout();
 }
 
 function toggleBottomPanelCollapsed() {
   isBottomPanelCollapsed = !isBottomPanelCollapsed;
   applyBottomPanelLayout();
   saveBottomPanelLayout();
+}
+
+function getMaxDslPaneWidth() {
+  const panels = elements.editorPanels;
+  if (!panels) return DEFAULT_DSL_PANE_WIDTH;
+
+  const rect = panels.getBoundingClientRect();
+  return Math.max(
+    MIN_DSL_PANE_WIDTH,
+    Math.floor(rect.width - MIN_NODE_PANE_WIDTH - EDITOR_SPLIT_HANDLE_WIDTH)
+  );
+}
+
+function clampDslPaneWidth(width) {
+  return Math.min(
+    Math.max(width, MIN_DSL_PANE_WIDTH),
+    getMaxDslPaneWidth()
+  );
+}
+
+function applyEditorSplitLayout() {
+  const panels = elements.editorPanels;
+  if (!panels) return;
+
+  dslPaneWidth = clampDslPaneWidth(dslPaneWidth);
+  panels.style.setProperty('--dsl-pane-width-px', `${dslPaneWidth}px`);
+}
+
+function loadEditorSplitLayout() {
+  const savedWidth = Number(localStorage.getItem(EDITOR_SPLIT_WIDTH_KEY));
+  if (Number.isFinite(savedWidth)) {
+    dslPaneWidth = savedWidth;
+  }
+
+  applyEditorSplitLayout();
+}
+
+function saveEditorSplitLayout() {
+  localStorage.setItem(EDITOR_SPLIT_WIDTH_KEY, String(dslPaneWidth));
+}
+
+function startEditorSplitResize(event) {
+  isResizingEditorSplit = true;
+  document.body.classList.add('resizing-editor-split');
+  event.preventDefault();
+}
+
+function resizeEditorSplit(event) {
+  if (!isResizingEditorSplit) return;
+
+  const panels = elements.editorPanels;
+  if (!panels) return;
+
+  const rect = panels.getBoundingClientRect();
+  const nextWidth = event.clientX - rect.left;
+
+  dslPaneWidth = clampDslPaneWidth(nextWidth);
+  applyEditorSplitLayout();
+}
+
+function stopEditorSplitResize() {
+  if (!isResizingEditorSplit) return;
+
+  isResizingEditorSplit = false;
+  document.body.classList.remove('resizing-editor-split');
+  saveEditorSplitLayout();
 }
 
 function resizePreviewCanvas() {
@@ -1273,6 +1354,10 @@ function setupEventListeners() {
   window.addEventListener('resize', handleWindowResizeForBottomPanel);
   elements.bottomPanelCollapseBtn?.addEventListener('click', toggleBottomPanelCollapsed);
 
+  elements.editorSplitResizeHandle?.addEventListener('pointerdown', startEditorSplitResize);
+  window.addEventListener('pointermove', resizeEditorSplit);
+  window.addEventListener('pointerup', stopEditorSplitResize);
+
   window.addEventListener('resize', resizePreviewCanvas);
   window.addEventListener('keydown', handleGlobalKeyDown);
 }
@@ -1340,6 +1425,7 @@ async function init() {
 
   setupEventListeners();
   loadBottomPanelLayout();
+  loadEditorSplitLayout();
   renderFileStatus();
   renderAutoApplyStatus();
   renderNodePaletteCategories();

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -41,6 +41,8 @@ const DEFAULT_DSL_PANE_WIDTH = 520;
 const MIN_DSL_PANE_WIDTH = 280;
 const MIN_NODE_PANE_WIDTH = 320;
 const EDITOR_SPLIT_HANDLE_WIDTH = 8;
+const EDITOR_SPLIT_GRID_GAP = 12;
+const EDITOR_SPLIT_GRID_GAP_COUNT = 2;
 
 const store = createStore();
 let dslEditor = null;
@@ -218,10 +220,15 @@ function getMaxDslPaneWidth() {
   if (!panels) return DEFAULT_DSL_PANE_WIDTH;
 
   const rect = panels.getBoundingClientRect();
-  return Math.max(
-    MIN_DSL_PANE_WIDTH,
-    Math.floor(rect.width - MIN_NODE_PANE_WIDTH - EDITOR_SPLIT_HANDLE_WIDTH)
-  );
+  // editor-panels has three columns with two horizontal grid gaps:
+  // DSL pane | gap | splitter | gap | Node pane
+  const maxWidth =
+    rect.width
+    - MIN_NODE_PANE_WIDTH
+    - EDITOR_SPLIT_HANDLE_WIDTH
+    - EDITOR_SPLIT_GRID_GAP * EDITOR_SPLIT_GRID_GAP_COUNT;
+
+  return Math.max(MIN_DSL_PANE_WIDTH, Math.floor(maxWidth));
 }
 
 function clampDslPaneWidth(width) {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -7,6 +7,11 @@
   --primary-color: #4a90e2;
   --success-color: #4caf50;
   --error-color: #f44336;
+  --panel-bg: rgba(20, 20, 20, 0.42);
+  --panel-bg-strong: rgba(20, 20, 20, 0.58);
+  --panel-header-bg: rgba(0, 0, 0, 0.26);
+  --editor-bg: rgba(20, 20, 20, 0.32);
+  --editor-bg-subtle: rgba(20, 20, 20, 0.18);
 }
 
 * {
@@ -64,7 +69,11 @@ html, body {
   top: 64px;
   bottom: 12px;
   display: grid;
-  grid-template-columns: minmax(360px, 1fr) minmax(420px, 1fr);
+  --dsl-pane-width-px: 520px;
+  grid-template-columns:
+    minmax(280px, var(--dsl-pane-width-px))
+    8px
+    minmax(320px, 1fr);
   grid-template-rows: 1fr auto auto;
   gap: 12px;
   z-index: 15;
@@ -81,8 +90,13 @@ body.panels-hidden .editor-panels {
   grid-row: 1;
 }
 
-.node-pane {
+.editor-split-resize-handle {
   grid-column: 2;
+  grid-row: 1;
+}
+
+.node-pane {
+  grid-column: 3;
   grid-row: 1;
 }
 
@@ -98,7 +112,7 @@ body.panels-hidden .editor-panels {
 
 /* Panel styling */
 .panel {
-  background: rgba(20, 20, 20, 0.9);
+  background: var(--panel-bg);
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 12px;
   overflow: hidden;
@@ -110,7 +124,7 @@ body.panels-hidden .editor-panels {
 .pane {
   display: flex;
   flex-direction: column;
-  background: rgba(20, 20, 20, 0.9);
+  background: var(--panel-bg);
   min-height: 0;
 }
 
@@ -120,7 +134,7 @@ body.panels-hidden .editor-panels {
   align-items: center;
   padding: 12px 16px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--panel-header-bg);
   flex-shrink: 0;
 }
 
@@ -133,16 +147,21 @@ body.panels-hidden .editor-panels {
 .dsl-editor-host {
   flex: 1;
   overflow: hidden;
+  background: var(--editor-bg-subtle);
 }
 
 .dsl-editor-host .cm-editor {
   height: 100%;
-  background: rgba(20, 20, 20, 0.9) !important;
+  background: transparent !important;
+}
+
+.dsl-editor-host .cm-scroller {
+  background: transparent !important;
 }
 
 .node-editor-canvas {
   flex: 1;
-  background: rgba(20, 20, 20, 0.9);
+  background: var(--editor-bg-subtle);
   border: none;
   overflow: hidden;
   position: relative;
@@ -152,18 +171,24 @@ body.panels-hidden .editor-panels {
 .node-editor-canvas .rete-area {
   width: 100%;
   height: 100%;
+  background: transparent !important;
+}
+
+.node-editor-canvas [data-testid="area"],
+.node-editor-canvas .area {
+  background: transparent !important;
 }
 
 /* Node title bar */
 .node-editor-canvas .title {
-  background: #2a2a2a !important;
+  background: rgba(42, 42, 42, 0.88) !important;
   color: var(--text-color) !important;
   border-bottom: 1px solid var(--border-color) !important;
 }
 
 /* Node body */
 .node-editor-canvas .node {
-  background: #222 !important;
+  background: rgba(28, 28, 28, 0.86) !important;
   border-color: var(--border-color) !important;
   color: var(--text-color) !important;
 }
@@ -221,6 +246,27 @@ body.resizing-bottom-panel .bottom-panel-resize-handle {
 
 .bottom-panel-resize-handle.collapsed {
   border-bottom: none;
+}
+
+.editor-split-resize-handle {
+  grid-column: 2;
+  grid-row: 1;
+  cursor: col-resize;
+  background: transparent;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  min-width: 8px;
+}
+
+.editor-split-resize-handle:hover,
+body.resizing-editor-split .editor-split-resize-handle {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+body.resizing-editor-split,
+body.resizing-editor-split * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 
 /* Tabs */
@@ -376,13 +422,17 @@ body.resizing-bottom-panel .bottom-panel-resize-handle {
 
 /* CodeMirror theme adjustments */
 .cm-editor {
-  --cm-bg: rgba(20, 20, 20, 0.9);
+  --cm-bg: transparent;
   --cm-text: var(--text-color);
 }
 
 .cm-gutters {
-  background: rgba(0, 0, 0, 0.4) !important;
-  border-right: 1px solid rgba(255, 255, 255, 0.12) !important;
+  background: rgba(0, 0, 0, 0.18) !important;
+  border-right: 1px solid rgba(255, 255, 255, 0.10) !important;
+}
+
+.cm-content {
+  background: transparent !important;
 }
 
 .cm-activeLineGutter {


### PR DESCRIPTION
## Summary
This PR adds a resizable vertical splitter between the DSL editor and node editor panes, allowing users to adjust the width of each editor independently. The split position is persisted to localStorage.

## Key Changes
- **New resize handle**: Added a vertical splitter element between the DSL and node editor panes with drag-to-resize functionality
- **Layout system**: Updated grid layout to use CSS custom properties (`--dsl-pane-width-px`) for dynamic pane sizing instead of fixed proportions
- **Resize logic**: Implemented `startEditorSplitResize()`, `resizeEditorSplit()`, and `stopEditorSplitResize()` functions to handle pointer events during resizing
- **Constraints**: Added width constraints with `MIN_DSL_PANE_WIDTH` (280px), `MIN_NODE_PANE_WIDTH` (320px), and `EDITOR_SPLIT_HANDLE_WIDTH` (8px)
- **Persistence**: Added localStorage support to save and restore the editor split width across sessions
- **Styling**: 
  - Added new CSS variables for consistent panel backgrounds
  - Styled the resize handle with hover effects and cursor feedback
  - Made editor backgrounds transparent to layer properly with new color scheme
  - Updated CodeMirror and node editor styling for better visual hierarchy

## Implementation Details
- The resize handle uses pointer events (pointerdown/pointermove/pointerup) for better cross-device support
- Width clamping ensures both panes maintain minimum viable widths even when the window is resized
- The `resizing-editor-split` class is applied to the body during resize to provide visual feedback and prevent text selection
- Grid layout now uses 3 columns: DSL pane, resize handle, and node pane (previously 2 columns)

https://claude.ai/code/session_0139dNYQoNzFvoC9Vmd3QeKo