### PR TITLE
Preserve node positions when updating editor model from graph

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -8,7 +8,8 @@ import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
 import {
   graphToEditorModel,
   editorModelToGraph,
-  applyNodeEditorOperationState
+  applyNodeEditorOperationState,
+  preserveEditorModelLayout
 } from '../../src/node-editor-core.js';
 import { graphToCanonicalDSL } from './canonical-dsl.js';
 import { createStore } from './studio-store.js';
@@ -622,7 +623,11 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
     };
   }
 
-  const editorModel = graphToEditorModel(graph);
+  const previousEditorModel = store.getState().editorModel;
+  const editorModel = preserveEditorModelLayout(
+    graphToEditorModel(graph),
+    previousEditorModel
+  );
 
   if (shouldCommit && !shouldCommit()) {
     return { ok: false, stale: true, errors: [] };
@@ -636,7 +641,9 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
     errors: []
   });
 
-  selectedNodeId = null;
+  if (selectedNodeId && !editorModel.nodesById[selectedNodeId]) {
+    selectedNodeId = null;
+  }
   await nodeEditor?.renderModel(editorModel);
 
   renderGraphJSON(graph);

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -162,6 +162,33 @@ export function editorModelToGraph(em, originalGraph = null) {
   return graph;
 }
 
+export function preserveEditorModelLayout(nextEditorModel, previousEditorModel) {
+  if (!previousEditorModel) return nextEditorModel;
+
+  const nodesById = {};
+  for (const [id, node] of Object.entries(nextEditorModel.nodesById || {})) {
+    const previousNode = previousEditorModel.nodesById?.[id];
+
+    if (
+      previousNode?.position &&
+      Number.isFinite(previousNode.position.x) &&
+      Number.isFinite(previousNode.position.y)
+    ) {
+      nodesById[id] = {
+        ...node,
+        position: { ...previousNode.position }
+      };
+    } else {
+      nodesById[id] = node;
+    }
+  }
+
+  return {
+    ...nextEditorModel,
+    nodesById
+  };
+}
+
 export function applyEditorOperation(em, op) {
   const next = {
     nodesById: { ...em.nodesById },

--- a/src/node-editor-core.js
+++ b/src/node-editor-core.js
@@ -2,7 +2,8 @@ export {
   layoutFallback,
   graphToEditorModel,
   editorModelToGraph,
-  applyEditorOperation
+  applyEditorOperation,
+  preserveEditorModelLayout
 } from './loom-editor-model.js';
 
 export {

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -8,7 +8,7 @@
   <h1>Loom Editor Model テスト</h1>
   <div id="results"></div>
   <script type="module">
-    import { graphToEditorModel, editorModelToGraph, applyEditorOperation, layoutFallback } from "../src/loom-editor-model.js";
+    import { graphToEditorModel, editorModelToGraph, applyEditorOperation, layoutFallback, preserveEditorModelLayout } from "../src/loom-editor-model.js";
 
     const results = [];
     function test(name, fn) { results.push({ name, fn }); }
@@ -170,6 +170,95 @@
       const next = applyEditorOperation(em, { type: 'moveNode', id: 'wave', position: { x: 1, y: 1 } });
       assert(JSON.stringify(em) === before, 'input unchanged');
       assert(next !== em, 'new object');
+    });
+
+    test('15. preserveEditorModelLayout preserves positions for existing nodes', () => {
+      const previous = {
+        nodesById: {
+          wave: {
+            id: 'wave',
+            type: 'sine',
+            category: 'transform',
+            params: { freq: 0.35 },
+            position: { x: 123, y: 456 }
+          }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const next = {
+        nodesById: {
+          wave: {
+            id: 'wave',
+            type: 'sine',
+            category: 'transform',
+            params: { freq: 0.8 },
+            position: { x: 300, y: 0 }
+          }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const merged = preserveEditorModelLayout(next, previous);
+
+      assert(merged.nodesById.wave.position.x === 123, 'x should be preserved');
+      assert(merged.nodesById.wave.position.y === 456, 'y should be preserved');
+      assert(merged.nodesById.wave.params.freq === 0.8, 'params should come from next model');
+    });
+
+    test('16. preserveEditorModelLayout keeps next position for new nodes', () => {
+      const previous = {
+        nodesById: {},
+        edgesById: {},
+        order: []
+      };
+
+      const next = {
+        nodesById: {
+          wave: {
+            id: 'wave',
+            type: 'sine',
+            category: 'transform',
+            params: {},
+            position: { x: 300, y: 0 }
+          }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const merged = preserveEditorModelLayout(next, previous);
+
+      assert(merged.nodesById.wave.position.x === 300, 'new node should keep next x');
+      assert(merged.nodesById.wave.position.y === 0, 'new node should keep next y');
+    });
+
+    test('17. preserveEditorModelLayout does not re-add removed nodes', () => {
+      const previous = {
+        nodesById: {
+          old: {
+            id: 'old',
+            type: 'sine',
+            category: 'transform',
+            params: {},
+            position: { x: 1, y: 2 }
+          }
+        },
+        edgesById: {},
+        order: ['old']
+      };
+
+      const next = {
+        nodesById: {},
+        edgesById: {},
+        order: []
+      };
+
+      const merged = preserveEditorModelLayout(next, previous);
+
+      assert(!merged.nodesById.old, 'removed node should not be restored');
     });
 
     async function run() {


### PR DESCRIPTION
## Summary
This PR adds functionality to preserve node positions in the editor when the graph is updated, preventing nodes from jumping to default positions during operations like DSL recompilation.

## Key Changes
- **New function `preserveEditorModelLayout`**: Merges a new editor model with a previous one, preserving node positions from the previous model while keeping all other properties (params, type, etc.) from the new model
  - Only preserves positions for nodes that exist in both models
  - Uses new node positions for newly added nodes
  - Does not restore deleted nodes
  - Validates that preserved positions have finite x and y coordinates

- **Updated `applyDslTextToGraph` in editor-studio**: Now calls `preserveEditorModelLayout` when converting a graph to an editor model, maintaining user-arranged node positions across DSL updates

- **Improved node selection handling**: Only clears the selected node ID if it no longer exists in the updated model, rather than unconditionally clearing it

- **Export updates**: Added `preserveEditorModelLayout` to public exports in both `loom-editor-model.js` and `node-editor-core.js`

## Implementation Details
The function creates a new editor model by iterating through nodes in the next model and checking if they existed in the previous model with valid positions. If so, it preserves those positions; otherwise, it uses the positions from the next model. This approach ensures that:
- Node layout is stable across graph updates
- New nodes get appropriate default positions
- Removed nodes don't reappear
- All other node properties are updated from the latest model

https://claude.ai/code/session_01EM8HVxzpkneLjv45Fh2eaF