### PR TITLE
Add undo/redo functionality for graph edits

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -18,6 +18,12 @@
       <span id="file-status" class="file-status">No file</span>
       <button id="runPreviewBtn" class="btn btn-success">Run Preview</button>
       <button id="resetSampleBtn" class="btn">Reset Sample</button>
+      <button id="undo-btn" class="btn" title="Undo graph edit (Ctrl/Cmd+Z)" disabled>
+        Undo
+      </button>
+      <button id="redo-btn" class="btn" title="Redo graph edit (Ctrl/Cmd+Shift+Z)" disabled>
+        Redo
+      </button>
       <button id="applyDslBtn" class="btn btn-primary">Apply DSL → Node</button>
       <button id="generateDslBtn" class="btn btn-primary">Generate DSL ← Node</button>
       <label class="toolbar-toggle">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -34,6 +34,8 @@ const BOTTOM_PANEL_HEIGHT_KEY = 'loomlet.editorStudio.bottomPanelHeight';
 const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
 const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';
 
+const MAX_HISTORY_ENTRIES = 100;
+
 const DEFAULT_BOTTOM_PANEL_HEIGHT = 260;
 const MIN_BOTTOM_PANEL_HEIGHT = 120;
 const MAX_BOTTOM_PANEL_RATIO = 0.6;
@@ -69,6 +71,10 @@ let isResizingBottomPanel = false;
 let dslPaneWidth = DEFAULT_DSL_PANE_WIDTH;
 let isResizingEditorSplit = false;
 
+let undoStack = [];
+let redoStack = [];
+let isApplyingHistory = false;
+
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
   nodeEditorHost: document.getElementById('node-editor'),
@@ -97,7 +103,9 @@ const elements = {
   bottomPanelResizeHandle: document.getElementById('bottom-panel-resize-handle'),
   bottomPanelCollapseBtn: document.getElementById('bottom-panel-collapse-btn'),
   editorPanels: document.querySelector('.editor-panels'),
-  editorSplitResizeHandle: document.getElementById('editor-split-resize-handle')
+  editorSplitResizeHandle: document.getElementById('editor-split-resize-handle'),
+  undoBtn: document.getElementById('undo-btn'),
+  redoBtn: document.getElementById('redo-btn')
 };
 
 function setPanelsVisible(visible) {
@@ -559,6 +567,7 @@ async function openLoomFile() {
       await applyDsl({ markDirty: false });
       hasUnsyncedDslText = false;
       setDirty(false);
+      clearEditorHistory();
       return;
     }
 
@@ -576,6 +585,7 @@ async function openLoomFile() {
       await applyDsl({ markDirty: false });
       hasUnsyncedDslText = false;
       setDirty(false);
+      clearEditorHistory();
     });
     input.click();
   } catch (error) {
@@ -671,6 +681,7 @@ async function applyDsl({ markDirty = true } = {}) {
 
   if (result.ok) {
     cancelPendingAutoApplyDsl();
+    clearEditorHistory();
   }
 
   return result;
@@ -740,6 +751,7 @@ async function autoApplyDslFromEditor(requestId) {
 
   if (result.ok) {
     renderAutoApplyStatus('ok');
+    clearEditorHistory();
   } else {
     renderAutoApplyStatus('error');
   }
@@ -1189,6 +1201,7 @@ async function resetSample() {
   await applyDsl({ markDirty: false });
   hasUnsyncedDslText = false;
   setDirty(false);
+  clearEditorHistory();
 }
 
 function renderNodePaletteItem(entry) {
@@ -1306,6 +1319,145 @@ function handleGlobalKeyDown(event) {
   deleteSelectedNode();
 }
 
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function createEditorHistorySnapshot() {
+  const state = store.getState();
+
+  return {
+    graph: cloneJson(state.graph),
+    editorModel: cloneJson(state.editorModel),
+    sourceText: state.sourceText,
+    sourceAst: cloneJson(state.sourceAst),
+    errors: cloneJson(state.errors || []),
+    selectedNodeId,
+    dslText: getDslText(),
+    hasUnsyncedDslText,
+    latestSuccessfulDslText
+  };
+}
+
+function pushUndoSnapshot(snapshot) {
+  if (!snapshot?.editorModel || !snapshot?.graph) return;
+
+  undoStack.push(snapshot);
+
+  if (undoStack.length > MAX_HISTORY_ENTRIES) {
+    undoStack.shift();
+  }
+
+  redoStack = [];
+  renderUndoRedoState();
+}
+
+function renderUndoRedoState() {
+  if (elements.undoBtn) {
+    elements.undoBtn.disabled = undoStack.length === 0;
+  }
+
+  if (elements.redoBtn) {
+    elements.redoBtn.disabled = redoStack.length === 0;
+  }
+}
+
+async function restoreEditorHistorySnapshot(snapshot, { pushRedo = false, pushUndo = false } = {}) {
+  if (!snapshot) return;
+
+  const currentSnapshot = createEditorHistorySnapshot();
+
+  if (pushRedo) {
+    redoStack.push(currentSnapshot);
+  }
+
+  if (pushUndo) {
+    undoStack.push(currentSnapshot);
+  }
+
+  store.setState({
+    graph: cloneJson(snapshot.graph),
+    editorModel: cloneJson(snapshot.editorModel),
+    sourceText: snapshot.sourceText,
+    sourceAst: cloneJson(snapshot.sourceAst),
+    errors: cloneJson(snapshot.errors || [])
+  });
+
+  selectedNodeId = snapshot.selectedNodeId;
+  hasUnsyncedDslText = snapshot.hasUnsyncedDslText;
+  latestSuccessfulDslText = snapshot.latestSuccessfulDslText;
+
+  setDslText(snapshot.dslText || snapshot.sourceText || '');
+
+  await nodeEditor?.renderModel(snapshot.editorModel, { force: true });
+
+  renderGraphJSON(snapshot.graph);
+  renderErrors();
+  renderInspector();
+  runPreview(snapshot.graph);
+
+  setDirty(true);
+  renderUndoRedoState();
+
+  if (autoApplyDslEnabled) {
+    renderAutoApplyStatus('ok');
+  }
+}
+
+async function undoGraphEdit() {
+  if (!undoStack.length) return;
+
+  cancelPendingAutoApplyDsl();
+
+  isApplyingHistory = true;
+  try {
+    const snapshot = undoStack.pop();
+    await restoreEditorHistorySnapshot(snapshot, { pushRedo: true });
+  } finally {
+    isApplyingHistory = false;
+    renderUndoRedoState();
+  }
+}
+
+async function redoGraphEdit() {
+  if (!redoStack.length) return;
+
+  cancelPendingAutoApplyDsl();
+
+  isApplyingHistory = true;
+  try {
+    const snapshot = redoStack.pop();
+    await restoreEditorHistorySnapshot(snapshot, { pushUndo: true });
+  } finally {
+    isApplyingHistory = false;
+    renderUndoRedoState();
+  }
+}
+
+function handleUndoRedoKeyDown(event) {
+  const isUndoRedoKey = event.key.toLowerCase() === 'z';
+  if (!isUndoRedoKey) return;
+  if (!(event.metaKey || event.ctrlKey)) return;
+
+  if (isTextEditingTarget(event.target)) {
+    return;
+  }
+
+  event.preventDefault();
+
+  if (event.shiftKey) {
+    redoGraphEdit();
+  } else {
+    undoGraphEdit();
+  }
+}
+
+function clearEditorHistory() {
+  undoStack = [];
+  redoStack = [];
+  renderUndoRedoState();
+}
+
 function setupEventListeners() {
   elements.applyDslBtn.addEventListener('click', applyDsl);
   elements.generateDslBtn.addEventListener('click', generateDsl);
@@ -1374,11 +1526,17 @@ function setupEventListeners() {
 
   window.addEventListener('resize', resizePreviewCanvas);
   window.addEventListener('keydown', handleGlobalKeyDown);
+
+  elements.undoBtn?.addEventListener('click', undoGraphEdit);
+  elements.redoBtn?.addEventListener('click', redoGraphEdit);
+  window.addEventListener('keydown', handleUndoRedoKeyDown);
 }
 
 async function handleOperation(operation) {
   const state = store.getState();
   if (!state.editorModel) return null;
+
+  const beforeSnapshot = createEditorHistorySnapshot();
 
   const result = applyNodeEditorOperationState(
     {
@@ -1411,6 +1569,11 @@ async function handleOperation(operation) {
     cancelPendingAutoApplyDsl();
     syncGraphToDslEditor({ markDirty: true });
     setDirty(true);
+
+    if (!isApplyingHistory) {
+      pushUndoSnapshot(beforeSnapshot);
+    }
+
     return result;
   }
 
@@ -1442,6 +1605,7 @@ async function init() {
   loadEditorSplitLayout();
   renderFileStatus();
   renderAutoApplyStatus();
+  renderUndoRedoState();
   renderNodePaletteCategories();
   renderNodePalette();
   await applyDsl({ markDirty: false });

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -439,12 +439,17 @@ body.resizing-editor-split * {
   background: rgba(255, 255, 255, 0.06) !important;
 }
 
-.cm-cursor {
-  border-left-color: var(--text-color) !important;
+.dsl-editor-host .cm-cursor {
+  border-left-color: #ffffff !important;
 }
 
-.cm-selectionBackground {
-  background: rgba(74, 144, 226, 0.3) !important;
+.dsl-editor-host .cm-dropCursor {
+  border-left-color: #ffffff !important;
+}
+
+.dsl-editor-host .cm-selectionBackground,
+.dsl-editor-host .cm-focused .cm-selectionBackground {
+  background: rgba(120, 170, 255, 0.35) !important;
 }
 
 /* Inspector Panel */


### PR DESCRIPTION
## Summary
This PR implements undo/redo functionality for graph editing operations in the editor studio. Users can now undo and redo changes to the node graph using keyboard shortcuts (Ctrl/Cmd+Z for undo, Ctrl/Cmd+Shift+Z for redo) or toolbar buttons.

## Key Changes
- **History Management**: Added undo and redo stacks with a maximum of 100 history entries to track editor state snapshots
- **Snapshot System**: Implemented `createEditorHistorySnapshot()` to capture the complete editor state (graph, editorModel, sourceText, sourceAst, errors, selectedNodeId, and DSL text)
- **Undo/Redo Operations**: Added `undoGraphEdit()` and `redoGraphEdit()` functions that restore previous/next states from the history stacks
- **Keyboard Shortcuts**: Implemented `handleUndoRedoKeyDown()` to handle Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z shortcuts, with proper handling to avoid interfering with text editing
- **UI Controls**: Added Undo and Redo buttons to the toolbar with disabled states when no history is available
- **History Clearing**: Clear history when opening files, applying DSL, resetting samples, or auto-applying changes to prevent stale snapshots
- **State Tracking**: Added `isApplyingHistory` flag to prevent creating duplicate snapshots when restoring from history
- **CodeMirror Styling**: Improved cursor and selection styling in the DSL editor for better visibility

## Implementation Details
- History snapshots are created before operations are applied and pushed to the undo stack only if the operation succeeds and wasn't triggered by a history restoration
- The `restoreEditorHistorySnapshot()` function handles state restoration and can optionally push the current state to redo or undo stacks
- History is automatically cleared when external changes occur (file open, DSL apply, sample reset) to maintain consistency
- Undo/redo operations cancel any pending auto-apply DSL requests to prevent conflicts

https://claude.ai/code/session_01L6bG4eTL5idrUUqXJc6R6Y