### PR TITLE
Coalesce consecutive node move operations in undo/redo history

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1650,16 +1650,20 @@ async function handleOperation(operation) {
     return result;
   }
 
-  const currentModel = state.editorModel;
-  if (currentModel && result.change.shouldRerenderView) {
-    await nodeEditor?.renderModel(currentModel);
+  if (result.error) {
+    if (operation?.type === 'moveNode') {
+      finishMoveHistoryGroup();
+    }
+
+    const currentModel = state.editorModel;
+    if (currentModel && result.change.shouldRerenderView) {
+      await nodeEditor?.renderModel(currentModel);
+    }
+
+    renderErrors();
+    return result;
   }
 
-  if (operation?.type === 'moveNode') {
-    finishMoveHistoryGroup();
-  }
-
-  renderErrors();
   return result;
 }
 

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -35,6 +35,7 @@ const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
 const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';
 
 const MAX_HISTORY_ENTRIES = 100;
+const MOVE_HISTORY_COALESCE_MS = 250;
 
 const DEFAULT_BOTTOM_PANEL_HEIGHT = 260;
 const MIN_BOTTOM_PANEL_HEIGHT = 120;
@@ -74,6 +75,8 @@ let isResizingEditorSplit = false;
 let undoStack = [];
 let redoStack = [];
 let isApplyingHistory = false;
+let activeMoveHistoryNodeId = null;
+let moveHistoryCoalesceTimer = null;
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
@@ -723,6 +726,7 @@ function syncGraphToDslEditor({ markDirty = true, force = false } = {}) {
 }
 
 function generateDsl() {
+  finishMoveHistoryGroup();
   cancelPendingAutoApplyDsl();
   const dsl = syncGraphToDslEditor({ markDirty: true, force: true });
   if (!dsl) return;
@@ -1323,6 +1327,69 @@ function cloneJson(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
 }
 
+function clearMoveHistoryCoalesceTimer() {
+  if (moveHistoryCoalesceTimer) {
+    clearTimeout(moveHistoryCoalesceTimer);
+    moveHistoryCoalesceTimer = null;
+  }
+}
+
+function finishMoveHistoryGroup() {
+  clearMoveHistoryCoalesceTimer();
+  activeMoveHistoryNodeId = null;
+}
+
+function scheduleMoveHistoryGroupFinish() {
+  clearMoveHistoryCoalesceTimer();
+
+  moveHistoryCoalesceTimer = window.setTimeout(() => {
+    finishMoveHistoryGroup();
+  }, MOVE_HISTORY_COALESCE_MS);
+}
+
+function isNoopMoveOperation(operation) {
+  if (operation?.type !== 'moveNode') return false;
+
+  const state = store.getState();
+  const node = state.editorModel?.nodesById?.[operation.id];
+  if (!node) return false;
+
+  return (
+    node.position?.x === operation.position?.x &&
+    node.position?.y === operation.position?.y
+  );
+}
+
+function shouldPushHistoryForOperation(operation) {
+  if (isApplyingHistory) return false;
+
+  if (operation?.type !== 'moveNode') {
+    finishMoveHistoryGroup();
+    return true;
+  }
+
+  const nodeId = operation.id;
+
+  if (!nodeId) {
+    finishMoveHistoryGroup();
+    return true;
+  }
+
+  if (isNoopMoveOperation(operation)) {
+    return false;
+  }
+
+  if (activeMoveHistoryNodeId === nodeId) {
+    scheduleMoveHistoryGroupFinish();
+    return false;
+  }
+
+  finishMoveHistoryGroup();
+  activeMoveHistoryNodeId = nodeId;
+  scheduleMoveHistoryGroupFinish();
+  return true;
+}
+
 function createEditorHistorySnapshot() {
   const state = store.getState();
 
@@ -1364,6 +1431,8 @@ function renderUndoRedoState() {
 
 async function restoreEditorHistorySnapshot(snapshot, { pushRedo = false, pushUndo = false } = {}) {
   if (!snapshot) return;
+
+  finishMoveHistoryGroup();
 
   const currentSnapshot = createEditorHistorySnapshot();
 
@@ -1407,6 +1476,7 @@ async function restoreEditorHistorySnapshot(snapshot, { pushRedo = false, pushUn
 async function undoGraphEdit() {
   if (!undoStack.length) return;
 
+  finishMoveHistoryGroup();
   cancelPendingAutoApplyDsl();
 
   isApplyingHistory = true;
@@ -1422,6 +1492,7 @@ async function undoGraphEdit() {
 async function redoGraphEdit() {
   if (!redoStack.length) return;
 
+  finishMoveHistoryGroup();
   cancelPendingAutoApplyDsl();
 
   isApplyingHistory = true;
@@ -1453,6 +1524,7 @@ function handleUndoRedoKeyDown(event) {
 }
 
 function clearEditorHistory() {
+  finishMoveHistoryGroup();
   undoStack = [];
   redoStack = [];
   renderUndoRedoState();
@@ -1537,6 +1609,7 @@ async function handleOperation(operation) {
   if (!state.editorModel) return null;
 
   const beforeSnapshot = createEditorHistorySnapshot();
+  const shouldPushHistory = shouldPushHistoryForOperation(operation);
 
   const result = applyNodeEditorOperationState(
     {
@@ -1570,7 +1643,7 @@ async function handleOperation(operation) {
     syncGraphToDslEditor({ markDirty: true });
     setDirty(true);
 
-    if (!isApplyingHistory) {
+    if (shouldPushHistory) {
       pushUndoSnapshot(beforeSnapshot);
     }
 
@@ -1580,6 +1653,10 @@ async function handleOperation(operation) {
   const currentModel = state.editorModel;
   if (currentModel && result.change.shouldRerenderView) {
     await nodeEditor?.renderModel(currentModel);
+  }
+
+  if (operation?.type === 'moveNode') {
+    finishMoveHistoryGroup();
   }
 
   renderErrors();


### PR DESCRIPTION
## Summary
This change implements history coalescing for node move operations in the editor. Instead of creating a new undo/redo history entry for every single move event, consecutive moves of the same node are grouped together and only the final position is recorded in the history.

## Key Changes
- Added `MOVE_HISTORY_COALESCE_MS` constant (250ms) to define the coalescing window
- Introduced move history tracking state variables:
  - `activeMoveHistoryNodeId`: tracks which node is currently being moved
  - `moveHistoryCoalesceTimer`: manages the timeout for finishing a move group
- Added helper functions for move history management:
  - `clearMoveHistoryCoalesceTimer()`: clears pending timeout
  - `finishMoveHistoryGroup()`: completes the current move operation group
  - `scheduleMoveHistoryGroupFinish()`: schedules automatic group completion
  - `isNoopMoveOperation()`: detects moves that don't change position
  - `shouldPushHistoryForOperation()`: determines whether to record an operation in history
- Integrated move history logic into the operation handling pipeline:
  - Calls `shouldPushHistoryForOperation()` to gate history pushes
  - Finalizes move groups when non-move operations occur or after move completion
  - Ensures move groups are finished during undo/redo/clear operations

## Implementation Details
- Move operations for the same node within the coalescing window are skipped in history (only the first one is recorded)
- A timer automatically finalizes the move group after 250ms of inactivity
- Non-move operations immediately finalize any active move group
- No-op moves (where position hasn't actually changed) are filtered out entirely
- History finalization is called at key points: undo, redo, DSL generation, and history clearing

https://claude.ai/code/session_0163qqfZ7darzHuoMQ9z6mTm