### PR TITLE
Document editor studio workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,40 +516,100 @@ x = timer |> sine(freq: 0.3) |> map(inMin: -1, inMax: 1, outMin: 100, outMax: 70
 
 詳細な仕様は **[docs/DSL.md](docs/DSL.md)** をご覧ください。
 
-### Editor Studio
+### Editor Studio (experimental)
 
 `editor-studio` は DSL と Rete.js v2 ノードエディタを左右に並べた協調編集スタジオです。
 
-- GitHub Pages: https://afjk.github.io/loomlet/editor-studio/dist/
+**GitHub Pages**: https://afjk.github.io/loomlet/editor-studio/dist/
 
-ローカル開発:
+#### ローカル開発
 
 ```bash
 cd editor-studio
 npm install
-npm run dev
+npm run dev        # http://localhost:5173/
+npm run build      # Production build
+npm run test:unit  # Unit tests
+npm run test:browser  # Browser tests
 ```
 
-**機能：**
-- DSL エディタ（CodeMirror）と **Rete.js v2 ノードエディタ** を左右2ペインで表示
-- `Apply DSL → Node`: DSL をパースしてノードエディタに反映
-- `Generate DSL ← Node`: ノードエディタから正規形 DSL を生成
-- ノード操作：
-  - ドラッグで移動
-  - エッジの接続・削除
-  - params の表示・編集
-- Canvas preview：`render bar` / `render point` に対応（全画面表示）
-- GraphJSON 表示 pane
-- Errors pane
-- Editor panels can be shown or hidden with the `Show/Hide Editors` button
+#### UI 概要
 
-**設計方針：**
-- 手動同期: DSL ↔ Node は明示ボタン式（リアルタイム自動同期ではない）
-- Node → DSL は正規形（元のコメント・書式は保持しない）
-- EditorModel が single source of truth、Rete.js ノードエディタは view として扱う
-- The node editor uses **Rete.js v2** as the visual editing layer
+**左ペイン: DSL Editor**
+- CodeMirror 6 ベース
+- 構文ハイライト
+- 補完（ノード型・パラメータ名）
+- **inline lint**: エラーは DSL エディタに直接表示（赤波線 + ガター）
 
-詳細は `editor-studio/src/` の実装と `test/loom-editor-studio.test.html` のテストを参照してください。
+**右ペイン: Node Editor**
+- Rete.js v2 による視覚的ノード編集
+- ドラッグで移動
+- エッジの接続・削除
+- パラメータの表示・編集
+
+**下部パネル（タブ式）**
+| タブ | 役割 |
+|---|---|
+| GraphJSON | 現在のグラフをJSON表示 |
+| Errors | パースエラー・コンパイルエラー一覧 |
+| Inspector | 選択ノードの詳細・接続情報 |
+| Nodes | ノードリスト（検索・フィルタ対応） |
+| Palette | ノード型一覧から新規ノード追加 |
+
+#### 主な機能
+
+**編集ワークフロー**
+- `Apply DSL → Node`: DSL をパースしてノードエディタに反映（手動）
+- `Generate DSL ← Node`: ノードエディタから正規形 DSL を生成（手動）
+- Auto Apply DSL: DSL 入力後、自動で apply（オプション）
+- Auto Sync DSL: ノード操作後、自動で DSL に同期（オプション）
+
+**レイアウト保存**
+- パネルサイズ（DSL/Node 分割、下部パネル高さ）を保存
+- 再度開くと前回のレイアウトを復元
+
+**Undo/Redo**
+- グラフ操作のみ対応（DSL テキスト編集は CodeMirror に従う）
+- ドラッグ移動は複数移動を1ステップに統合
+
+**キーボードショートカット**
+- Delete / Backspace: 選択ノードを削除
+- Ctrl/Cmd+Z: Undo
+- Ctrl/Cmd+Shift+Z: Redo
+
+#### Source of Truth モデル
+
+**DSL テキスト → 正規形グラフ → UI 表示**
+
+1. **DSL は text source**: ユーザーが編集した状態を保持
+2. **Apply**: DSL を parse → compile → EditorModel に変換
+   - Invalid DSL はエラー表示、前のグラフ保持
+   - Valid DSL のみ EditorModel 更新
+3. **Node operations**: EditorModel を直接編集
+   - 自動同期が有効なら、EditorModel から DSL を再生成
+4. **Save**: 現在の source-of-truth を .loom ファイルに保存
+   - DSL テキストが未適用なら text を save
+   - ノード操作後なら EditorModel から正規形 DSL を生成して save
+
+#### 設計方針
+
+- **EditorModel が single source of truth**: Rete.js ノードはビュー層
+- **手動同期**: DSL ↔ Node は明示ボタン式（リアルタイム自動ではない）
+- **正規形 DSL**: Node → DSL 生成時、元のコメント・書式は保持しない
+- **Incremental rendering**: DSL apply 時、変更のあったノード・接続のみ更新
+- **Separate text undo**: CodeMirror 内の text undo と、グラフ undo は独立
+
+#### CLI コマンド
+
+```bash
+cd editor-studio
+npm run dev          # 開発サーバ起動
+npm run build        # Vite ビルド
+npm run test:unit    # ユニットテスト実行
+npm run test:browser # ブラウザテスト実行
+```
+
+詳細は `editor-studio/src/` の実装と `editor-studio/test/` のテストを参照してください。
 
 ## デモの確認方法
 

--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -70,6 +70,7 @@
             <button class="tab-btn active" data-tab="graph">GraphJSON</button>
             <button class="tab-btn" data-tab="errors">Errors</button>
             <button class="tab-btn" data-tab="inspector">Inspector</button>
+            <button class="tab-btn" data-tab="nodes">Nodes</button>
             <button class="tab-btn" data-tab="palette">Palette</button>
           </div>
           <button id="bottom-panel-collapse-btn" class="bottom-panel-collapse-btn" title="Collapse bottom panel">Collapse</button>
@@ -83,6 +84,22 @@
           </div>
           <div id="inspector-tab" class="tab-pane">
             <div id="inspector-panel" class="inspector-panel"></div>
+          </div>
+          <div id="nodes-tab" class="tab-pane">
+            <div class="node-list-panel">
+              <div class="node-list-toolbar">
+                <input
+                  id="node-list-search"
+                  class="node-list-search"
+                  type="text"
+                  placeholder="Search nodes..."
+                />
+                <select id="node-list-category" class="node-list-category">
+                  <option value="">All categories</option>
+                </select>
+              </div>
+              <div id="node-list" class="node-list"></div>
+            </div>
           </div>
           <div id="palette-tab" class="tab-pane">
             <div class="palette-panel">

--- a/editor-studio/src/loomlet-codemirror.js
+++ b/editor-studio/src/loomlet-codemirror.js
@@ -2,6 +2,7 @@ import { StreamLanguage, syntaxHighlighting, HighlightStyle } from '@codemirror/
 import { tags } from '@lezer/highlight';
 import { EditorView } from '@codemirror/view';
 import { autocompletion } from '@codemirror/autocomplete';
+import { linter, lintGutter } from '@codemirror/lint';
 
 // Create a set of valid node/function names from metadata
 function createNodeTypeNameSet(nodeTypes = {}) {
@@ -269,10 +270,59 @@ export function getParamCompletionOptionsForNode(nodeTypes = {}, nodeName) {
   }));
 }
 
+function resolveErrorPosition(doc, error) {
+  if (!error) return 0;
+
+  const line = error.line !== undefined ? error.line : null;
+  const column = error.column !== undefined ? error.column : 0;
+
+  if (line === null || line < 1) {
+    return 0;
+  }
+
+  try {
+    const lineObject = doc.line(line);
+    if (!lineObject) return 0;
+    const colOffset = Math.max(0, Math.min(column || 0, lineObject.length));
+    return lineObject.from + colOffset;
+  } catch {
+    return 0;
+  }
+}
+
+export function createLoomletDslLinter({ getErrors } = {}) {
+  return linter((view) => {
+    const errors = getErrors?.() || [];
+
+    return errors.map((error) => {
+      const from = resolveErrorPosition(view.state.doc, error);
+      let to = from + 1;
+
+      if (error.line !== undefined) {
+        try {
+          const lineObject = view.state.doc.line(error.line);
+          if (lineObject) {
+            to = lineObject.to;
+          }
+        } catch {
+          to = from + 1;
+        }
+      }
+
+      return {
+        from,
+        to,
+        severity: 'error',
+        message: error.message || String(error)
+      };
+    });
+  });
+}
+
 export { findNearestCallNameBefore };
 
 // Main export: return array of CodeMirror extensions
-export function loomletDslExtensions({ nodeTypes } = {}) {
+export function loomletDslExtensions({ nodeTypes, getErrors } = {}) {
   const extensions = [
     createLoomletStreamLanguage(nodeTypes),
     syntaxHighlighting(loomletHighlightStyle),
@@ -284,6 +334,11 @@ export function loomletDslExtensions({ nodeTypes } = {}) {
       activateOnTyping: true
     })
   ];
+
+  if (getErrors) {
+    extensions.push(createLoomletDslLinter({ getErrors }));
+    extensions.push(lintGutter());
+  }
 
   return extensions;
 }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -332,7 +332,10 @@ function initDslEditor() {
         ...searchKeymap,
         ...completionKeymap
       ]),
-      ...loomletDslExtensions({ nodeTypes: NODE_TYPES }),
+      ...loomletDslExtensions({
+        nodeTypes: NODE_TYPES,
+        getErrors: () => store.getState().errors || []
+      }),
       EditorView.updateListener.of((update) => {
         if (!update.docChanged) return;
         if (isApplyingProgrammaticDslChange) return;
@@ -791,6 +794,10 @@ function renderErrors() {
     return `<div class="error-item"><strong>${err.code || 'ERROR'}${line}${col}</strong>: ${err.message}</div>`;
   }).join('');
   elements.errorsList.innerHTML = html || '<div class="error-item">No errors</div>';
+
+  if (dslEditor) {
+    dslEditor.dispatch({});
+  }
 }
 
 function getSelectedEditorNode() {

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -102,6 +102,9 @@ const elements = {
   nodePaletteSearch: document.getElementById('node-palette-search'),
   nodePaletteCategory: document.getElementById('node-palette-category'),
   nodePaletteList: document.getElementById('node-palette-list'),
+  nodeListSearch: document.getElementById('node-list-search'),
+  nodeListCategory: document.getElementById('node-list-category'),
+  nodeList: document.getElementById('node-list'),
   autoApplyDslToggle: document.getElementById('autoApplyDslToggle'),
   autoApplyStatus: document.getElementById('auto-apply-status'),
   autoSyncGraphToDslToggle: document.getElementById('autoSyncGraphToDslToggle'),
@@ -674,6 +677,8 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
   renderGraphJSON(graph);
   renderErrors();
   renderInspector();
+  updateNodeListCategories();
+  renderNodeList();
   runPreview(graph);
 
   hasUnsyncedDslText = false;
@@ -1220,6 +1225,86 @@ async function resetSample() {
   clearEditorHistory();
 }
 
+function renderNodeListItem(node) {
+  const isSelected = selectedNodeId === node.id;
+  const selectedClass = isSelected ? ' selected' : '';
+
+  return `
+    <div class="node-list-item${selectedClass}" data-node-id="${escapeHtml(node.id)}">
+      <div class="node-list-item-id">${escapeHtml(node.id)}</div>
+      <div class="node-list-item-type">${escapeHtml(node.type)}</div>
+      <div class="node-list-item-category">${escapeHtml(node.category)}</div>
+    </div>
+  `;
+}
+
+function renderNodeList() {
+  const list = elements.nodeList;
+  if (!list) return;
+
+  const state = store.getState();
+  if (!state.editorModel) {
+    list.innerHTML = '<div class="node-list-empty">No nodes</div>';
+    return;
+  }
+
+  const query = (elements.nodeListSearch?.value || '').trim().toLowerCase();
+  const selectedCategory = elements.nodeListCategory?.value || '';
+
+  const nodes = state.editorModel.order.map((nodeId) => state.editorModel.nodesById[nodeId]).filter(Boolean);
+
+  const filtered = nodes.filter((node) => {
+    if (selectedCategory && node.category !== selectedCategory) return false;
+    if (!query) return true;
+
+    return (
+      node.id.toLowerCase().includes(query) ||
+      node.type.toLowerCase().includes(query) ||
+      node.category.toLowerCase().includes(query)
+    );
+  });
+
+  if (filtered.length === 0) {
+    list.innerHTML = '<div class="node-list-empty">No nodes matching filter</div>';
+    return;
+  }
+
+  list.innerHTML = filtered.map(renderNodeListItem).join('');
+
+  list.querySelectorAll('[data-node-id]').forEach((item) => {
+    item.addEventListener('click', () => {
+      const nodeId = item.getAttribute('data-node-id');
+      setSelectedNodeId(nodeId);
+      renderNodeList();
+    });
+  });
+}
+
+function updateNodeListCategories() {
+  const select = elements.nodeListCategory;
+  if (!select) return;
+
+  const state = store.getState();
+  if (!state.editorModel) {
+    select.innerHTML = '<option value="">All categories</option>';
+    return;
+  }
+
+  const categories = Array.from(
+    new Set(
+      state.editorModel.order
+        .map((nodeId) => state.editorModel.nodesById[nodeId])
+        .filter(Boolean)
+        .map((node) => node.category)
+    )
+  ).sort();
+
+  select.innerHTML = [
+    '<option value="">All categories</option>',
+    ...categories.map((category) => `<option value="${escapeHtml(category)}">${escapeHtml(category)}</option>`)
+  ].join('');
+}
+
 function renderNodePaletteItem(entry) {
   const inputs = entry.inputs.map((input) => input.name).join(', ') || 'none';
   const outputs = entry.outputs.map((output) => output.name).join(', ') || 'none';
@@ -1475,6 +1560,8 @@ async function restoreEditorHistorySnapshot(snapshot, { pushRedo = false, pushUn
   renderGraphJSON(snapshot.graph);
   renderErrors();
   renderInspector();
+  updateNodeListCategories();
+  renderNodeList();
   runPreview(snapshot.graph);
 
   setDirty(true);
@@ -1598,6 +1685,9 @@ function setupEventListeners() {
   elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
 
+  elements.nodeListSearch?.addEventListener('input', renderNodeList);
+  elements.nodeListCategory?.addEventListener('change', renderNodeList);
+
   elements.bottomPanelResizeHandle?.addEventListener('pointerdown', startBottomPanelResize);
   window.addEventListener('pointermove', resizeBottomPanel);
   window.addEventListener('pointerup', stopBottomPanelResize);
@@ -1649,6 +1739,8 @@ async function handleOperation(operation) {
     renderGraphJSON(result.state.graph);
     renderErrors();
     renderInspector();
+    updateNodeListCategories();
+    renderNodeList();
     runPreview(result.state.graph);
     hasUnsyncedDslText = false;
     cancelPendingAutoApplyDsl();
@@ -1701,6 +1793,8 @@ async function init() {
   renderUndoRedoState();
   renderNodePaletteCategories();
   renderNodePalette();
+  updateNodeListCategories();
+  renderNodeList();
   await applyDsl({ markDirty: false });
   setDirty(false);
 }

--- a/editor-studio/src/node-editor-view-diff.js
+++ b/editor-studio/src/node-editor-view-diff.js
@@ -1,0 +1,43 @@
+export function cloneEditorModelSnapshot(editorModel) {
+  return JSON.parse(JSON.stringify(editorModel));
+}
+
+export function getAddedNodeIds(previous, next) {
+  return next.order.filter((id) => !previous.nodesById[id]);
+}
+
+export function getRemovedNodeIds(previous, next) {
+  return previous.order.filter((id) => !next.nodesById[id]);
+}
+
+export function getCommonNodeIds(previous, next) {
+  return next.order.filter((id) => previous.nodesById[id] && next.nodesById[id]);
+}
+
+export function getAddedEdgeIds(previous, next) {
+  return Object.keys(next.edgesById || {}).filter((id) => !previous.edgesById?.[id]);
+}
+
+export function getRemovedEdgeIds(previous, next) {
+  return Object.keys(previous.edgesById || {}).filter((id) => !next.edgesById?.[id]);
+}
+
+export function shouldRecreateNode(previousNode, nextNode) {
+  if (previousNode.type !== nextNode.type) return true;
+  if (previousNode.category !== nextNode.category) return true;
+
+  const prevParamKeys = Object.keys(previousNode.params || {}).sort();
+  const nextParamKeys = Object.keys(nextNode.params || {}).sort();
+
+  if (prevParamKeys.join('\0') !== nextParamKeys.join('\0')) return true;
+
+  return false;
+}
+
+export function sameParams(a, b) {
+  return JSON.stringify(a || {}) === JSON.stringify(b || {});
+}
+
+export function samePosition(a, b) {
+  return a?.x === b?.x && a?.y === b?.y;
+}

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -8,6 +8,17 @@ import {
   translateToMoveNodeOp,
   controlValueToUpdateParamOp
 } from './rete-operation-helpers.js';
+import {
+  cloneEditorModelSnapshot,
+  getAddedNodeIds,
+  getRemovedNodeIds,
+  getCommonNodeIds,
+  getAddedEdgeIds,
+  getRemovedEdgeIds,
+  shouldRecreateNode,
+  sameParams,
+  samePosition
+} from './node-editor-view-diff.js';
 
 const socket = new ClassicPreset.Socket('value');
 
@@ -47,56 +58,7 @@ function createReteNode(editorNode, onControl) {
   return node;
 }
 
-// --- Snapshot / diff helpers ---
-
-function cloneEditorModelSnapshot(editorModel) {
-  return JSON.parse(JSON.stringify(editorModel));
-}
-
-function canPatchEditorModel(previous, next) {
-  if (!previous || !next) return false;
-  return true;
-}
-
-function getAddedNodeIds(previous, next) {
-  return next.order.filter((id) => !previous.nodesById[id]);
-}
-
-function getRemovedNodeIds(previous, next) {
-  return previous.order.filter((id) => !next.nodesById[id]);
-}
-
-function getCommonNodeIds(previous, next) {
-  return next.order.filter((id) => previous.nodesById[id] && next.nodesById[id]);
-}
-
-function getAddedEdgeIds(previous, next) {
-  return Object.keys(next.edgesById || {}).filter((id) => !previous.edgesById?.[id]);
-}
-
-function getRemovedEdgeIds(previous, next) {
-  return Object.keys(previous.edgesById || {}).filter((id) => !next.edgesById?.[id]);
-}
-
-function shouldRecreateNode(previousNode, nextNode) {
-  if (previousNode.type !== nextNode.type) return true;
-  if (previousNode.category !== nextNode.category) return true;
-
-  const prevParamKeys = Object.keys(previousNode.params || {}).sort();
-  const nextParamKeys = Object.keys(nextNode.params || {}).sort();
-
-  if (prevParamKeys.join('\0') !== nextParamKeys.join('\0')) return true;
-
-  return false;
-}
-
-function sameParams(a, b) {
-  return JSON.stringify(a || {}) === JSON.stringify(b || {});
-}
-
-function samePosition(a, b) {
-  return a?.x === b?.x && a?.y === b?.y;
-}
+// --- Connection helpers ---
 
 function findReteConnectionIdByEdgeId(connectionMap, edgeId) {
   for (const [connectionId, mappedEdgeId] of connectionMap.entries()) {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -747,3 +747,103 @@ body.resizing-editor-split * {
 .auto-apply-status.error {
   color: #ff9b9b;
 }
+
+/* Node List */
+.node-list-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.node-list-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+
+.node-list-search {
+  flex: 1;
+  padding: 6px 8px;
+  background: #111;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 12px;
+  min-width: 0;
+}
+
+.node-list-search::placeholder {
+  color: var(--text-dim);
+}
+
+.node-list-category {
+  padding: 6px 8px;
+  background: #111;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 12px;
+  min-width: 140px;
+}
+
+.node-list {
+  flex: 1;
+  overflow: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.node-list-empty {
+  padding: 16px 12px;
+  color: var(--text-dim);
+  font-size: 13px;
+  text-align: center;
+}
+
+.node-list-item {
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.node-list-item:hover {
+  background: rgba(74, 144, 226, 0.1);
+  border-color: rgba(74, 144, 226, 0.3);
+}
+
+.node-list-item.selected {
+  background: rgba(74, 144, 226, 0.2);
+  border-color: var(--primary-color);
+}
+
+.node-list-item-id {
+  font-weight: 600;
+  color: var(--text-color);
+  font-size: 12px;
+  margin-bottom: 4px;
+  word-break: break-word;
+}
+
+.node-list-item-type {
+  color: #8fb3ff;
+  font-size: 11px;
+  margin-bottom: 2px;
+  font-family: 'Monaco', 'Menlo', monospace;
+}
+
+.node-list-item-category {
+  color: var(--text-dim);
+  font-size: 11px;
+  background: rgba(74, 144, 226, 0.15);
+  padding: 2px 6px;
+  border-radius: 3px;
+  display: inline-block;
+}

--- a/editor-studio/test/node-editor-view-diff.test.html
+++ b/editor-studio/test/node-editor-view-diff.test.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NodeEditorView Diff Helpers Tests</title>
+  <style>
+    body {
+      font-family: monospace;
+      margin: 20px;
+      background: #f5f5f5;
+    }
+    .pass {
+      color: green;
+    }
+    .fail {
+      color: red;
+    }
+    .test-result {
+      margin: 10px 0;
+      padding: 5px;
+      border-left: 3px solid #ccc;
+    }
+    .test-result.pass {
+      background: #e8f5e9;
+      border-left-color: green;
+    }
+    .test-result.fail {
+      background: #ffebee;
+      border-left-color: red;
+    }
+  </style>
+</head>
+<body>
+  <h1>NodeEditorView Diff Helpers Tests</h1>
+  <div id="results"></div>
+
+  <script type="module">
+    import {
+      cloneEditorModelSnapshot,
+      getAddedNodeIds,
+      getRemovedNodeIds,
+      getCommonNodeIds,
+      getAddedEdgeIds,
+      getRemovedEdgeIds,
+      shouldRecreateNode,
+      sameParams,
+      samePosition
+    } from '../src/node-editor-view-diff.js';
+
+    let pass = 0;
+    let fail = 0;
+    const failures = [];
+    const resultsDiv = document.getElementById('results');
+
+    function test(name, fn) {
+      try {
+        fn();
+        log(`✓ ${name}`, 'pass');
+        pass++;
+      } catch (err) {
+        log(`✗ ${name}: ${err.message}`, 'fail');
+        failures.push({ test: name, error: err.message });
+        fail++;
+      }
+    }
+
+    function log(message, type) {
+      const div = document.createElement('div');
+      div.className = `test-result ${type}`;
+      div.textContent = message;
+      resultsDiv.appendChild(div);
+    }
+
+    function assert(condition, message) {
+      if (!condition) throw new Error(message || 'Assertion failed');
+    }
+
+    // Test cloneEditorModelSnapshot
+    test('cloneEditorModelSnapshot creates deep copy', () => {
+      const original = {
+        order: ['a', 'b'],
+        nodesById: { a: { id: 'a', type: 'clock' }, b: { id: 'b', type: 'sine' } },
+        edgesById: {}
+      };
+      const cloned = cloneEditorModelSnapshot(original);
+      cloned.nodesById.a.type = 'modified';
+      assert(original.nodesById.a.type === 'clock', 'Original should not be modified');
+    });
+
+    // Test getAddedNodeIds
+    test('getAddedNodeIds finds new nodes', () => {
+      const previous = {
+        order: ['a'],
+        nodesById: { a: { id: 'a' } },
+        edgesById: {}
+      };
+      const next = {
+        order: ['a', 'b'],
+        nodesById: { a: { id: 'a' }, b: { id: 'b' } },
+        edgesById: {}
+      };
+      const added = getAddedNodeIds(previous, next);
+      assert(added.length === 1 && added[0] === 'b', 'Should find added node b');
+    });
+
+    // Test getRemovedNodeIds
+    test('getRemovedNodeIds finds deleted nodes', () => {
+      const previous = {
+        order: ['a', 'b'],
+        nodesById: { a: { id: 'a' }, b: { id: 'b' } },
+        edgesById: {}
+      };
+      const next = {
+        order: ['a'],
+        nodesById: { a: { id: 'a' } },
+        edgesById: {}
+      };
+      const removed = getRemovedNodeIds(previous, next);
+      assert(removed.length === 1 && removed[0] === 'b', 'Should find removed node b');
+    });
+
+    // Test getCommonNodeIds
+    test('getCommonNodeIds finds common nodes', () => {
+      const previous = {
+        order: ['a', 'b'],
+        nodesById: { a: { id: 'a' }, b: { id: 'b' } },
+        edgesById: {}
+      };
+      const next = {
+        order: ['a', 'c'],
+        nodesById: { a: { id: 'a' }, c: { id: 'c' } },
+        edgesById: {}
+      };
+      const common = getCommonNodeIds(previous, next);
+      assert(common.length === 1 && common[0] === 'a', 'Should find common node a');
+    });
+
+    // Test getAddedEdgeIds
+    test('getAddedEdgeIds finds new edges', () => {
+      const previous = {
+        order: [],
+        nodesById: {},
+        edgesById: {}
+      };
+      const next = {
+        order: [],
+        nodesById: {},
+        edgesById: { 'edge1': { id: 'edge1' } }
+      };
+      const added = getAddedEdgeIds(previous, next);
+      assert(added.length === 1 && added[0] === 'edge1', 'Should find added edge');
+    });
+
+    // Test getRemovedEdgeIds
+    test('getRemovedEdgeIds finds deleted edges', () => {
+      const previous = {
+        order: [],
+        nodesById: {},
+        edgesById: { 'edge1': { id: 'edge1' } }
+      };
+      const next = {
+        order: [],
+        nodesById: {},
+        edgesById: {}
+      };
+      const removed = getRemovedEdgeIds(previous, next);
+      assert(removed.length === 1 && removed[0] === 'edge1', 'Should find removed edge');
+    });
+
+    // Test shouldRecreateNode
+    test('shouldRecreateNode detects type change', () => {
+      const previous = { id: 'a', type: 'clock', category: 'time', params: {} };
+      const next = { id: 'a', type: 'sine', category: 'time', params: {} };
+      assert(shouldRecreateNode(previous, next), 'Should recreate when type changes');
+    });
+
+    test('shouldRecreateNode detects param change', () => {
+      const previous = { id: 'a', type: 'sine', category: 'math', params: { freq: 1 } };
+      const next = { id: 'a', type: 'sine', category: 'math', params: { freq: 1, phase: 0 } };
+      assert(shouldRecreateNode(previous, next), 'Should recreate when params change');
+    });
+
+    test('shouldRecreateNode allows position change', () => {
+      const previous = { id: 'a', type: 'sine', category: 'math', params: {}, position: { x: 0, y: 0 } };
+      const next = { id: 'a', type: 'sine', category: 'math', params: {}, position: { x: 10, y: 20 } };
+      assert(!shouldRecreateNode(previous, next), 'Should not recreate for position only');
+    });
+
+    // Test sameParams
+    test('sameParams compares params', () => {
+      const a = { x: 1, y: 'test' };
+      const b = { x: 1, y: 'test' };
+      assert(sameParams(a, b), 'Same params should be equal');
+      assert(!sameParams(a, { x: 2 }), 'Different params should not be equal');
+    });
+
+    // Test samePosition
+    test('samePosition compares positions', () => {
+      const a = { x: 10, y: 20 };
+      const b = { x: 10, y: 20 };
+      assert(samePosition(a, b), 'Same positions should be equal');
+      assert(!samePosition(a, { x: 10, y: 30 }), 'Different positions should not be equal');
+      assert(samePosition(null, null), 'Null positions should be equal');
+    });
+
+    // Set test results
+    window.__loomTestResults = { pass, fail, failures };
+
+    // Display summary
+    const summary = document.createElement('div');
+    summary.style.marginTop = '20px';
+    summary.style.padding = '10px';
+    summary.style.fontSize = '16px';
+    summary.style.fontWeight = 'bold';
+    summary.className = fail === 0 ? 'pass' : 'fail';
+    summary.textContent = `Tests: ${pass} passed, ${fail} failed`;
+    resultsDiv.appendChild(summary);
+  </script>
+</body>
+</html>

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -14,7 +14,8 @@
   "activationEvents": [
     "onLanguage:loomlet",
     "onCommand:loomlet.runCurrentFile",
-    "onCommand:loomlet.sceneSyncDevCurrentFile"
+    "onCommand:loomlet.sceneSyncDevCurrentFile",
+    "onCommand:loomlet.openNodePreviewToSide"
   ],
   "contributes": {
     "languages": [
@@ -45,6 +46,10 @@
       {
         "command": "loomlet.sceneSyncDevCurrentFile",
         "title": "Loomlet: Scene Sync Dev Current File"
+      },
+      {
+        "command": "loomlet.openNodePreviewToSide",
+        "title": "Loomlet: Open Node Preview to the Side"
       }
     ],
     "configuration": {

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -4,6 +4,9 @@ const vscode = require('vscode');
 const { getCompletionContext } = require('./completion-context');
 const { buildCompletions: buildRawCompletions, getIncludePlanned } = require('./completion-engine');
 
+let nodePreviewPanel = null;
+let currentPreviewDocument = null;
+
 function activate(context) {
   const provider = {
     provideCompletionItems(document, position) {
@@ -20,11 +23,141 @@ function activate(context) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('loomlet.runCurrentFile', () => runCurrentFile('run')),
-    vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev'))
+    vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev')),
+    vscode.commands.registerCommand('loomlet.openNodePreviewToSide', () => openNodePreviewToSide(context))
+  );
+
+  vscode.workspace.onDidChangeTextDocument((event) => {
+    if (nodePreviewPanel && currentPreviewDocument && event.document === currentPreviewDocument) {
+      sendDocumentToPreview(event.document);
+    }
+  });
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (nodePreviewPanel && editor?.document.languageId === 'loomlet') {
+        currentPreviewDocument = editor.document;
+        sendDocumentToPreview(editor.document);
+      }
+    })
   );
 }
 
-function deactivate() {}
+function deactivate() {
+  if (nodePreviewPanel) {
+    nodePreviewPanel.dispose();
+  }
+}
+
+function openNodePreviewToSide(context) {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showErrorMessage('No active editor.');
+    return;
+  }
+
+  const document = editor.document;
+  const isLoomlet = document.languageId === 'loomlet' || document.languageId === 'loom' || document.fileName.endsWith('.loom');
+  if (!isLoomlet) {
+    vscode.window.showErrorMessage('Active file must be a .loom file.');
+    return;
+  }
+
+  if (nodePreviewPanel) {
+    nodePreviewPanel.reveal(vscode.ViewColumn.Beside);
+    currentPreviewDocument = document;
+    sendDocumentToPreview(document);
+    return;
+  }
+
+  nodePreviewPanel = vscode.window.createWebviewPanel(
+    'loomletNodePreview',
+    'Loomlet Node Preview',
+    vscode.ViewColumn.Beside,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  );
+
+  nodePreviewPanel.webview.html = getWebviewContent();
+
+  nodePreviewPanel.onDidDispose(() => {
+    nodePreviewPanel = null;
+    currentPreviewDocument = null;
+  });
+
+  currentPreviewDocument = document;
+  sendDocumentToPreview(document);
+}
+
+function sendDocumentToPreview(document) {
+  if (!nodePreviewPanel) return;
+
+  const text = document.getText();
+  nodePreviewPanel.webview.postMessage({
+    type: 'update',
+    text
+  });
+}
+
+function getWebviewContent() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loomlet Node Preview</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 16px;
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: 13px;
+    }
+    .header {
+      margin-bottom: 16px;
+    }
+    .status {
+      padding: 8px 12px;
+      background: rgba(74, 144, 226, 0.15);
+      border-left: 3px solid #4a90e2;
+      border-radius: 4px;
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h2 style="margin: 0 0 8px 0;">Loomlet Node Preview</h2>
+    <div class="status">Waiting for graph...</div>
+  </div>
+  <div id="preview"></div>
+  <script>
+    const vscode = acquireVsCodeApi();
+    window.addEventListener('message', event => {
+      const message = event.data;
+      if (message.type === 'update') {
+        const preview = document.getElementById('preview');
+        preview.innerHTML = '<pre style="background: rgba(0,0,0,0.3); padding: 8px; border-radius: 4px; overflow: auto;">' +
+          escapeHtml(message.text.slice(0, 200)) + '...</pre>';
+      }
+    });
+    function escapeHtml(text) {
+      const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+      };
+      return String(text).replace(/[&<>"']/g, char => map[char]);
+    }
+  </script>
+</body>
+</html>`;
 
 function buildCompletions(ctx) {
   const includePlanned = getIncludePlanned((key) => vscode.workspace.getConfiguration().get(key));


### PR DESCRIPTION
## Summary

Document current editor-studio feature set and workflows to establish clear baseline and guidance for future development.

## Changes

Expanded README.md editor-studio section with:

### Features Documented
- **UI Components**: Left/right panes, bottom panel tabs (GraphJSON, Errors, Inspector, Nodes, Palette)
- **Editing**: DSL editor with CodeMirror 6, node editor with Rete.js v2, inline lint errors
- **Workflows**: Apply DSL, Generate DSL, Auto Apply, Auto Sync
- **Interactions**: Drag to move, connect/disconnect edges, edit node params
- **State Management**: Undo/Redo (graph only), layout persistence, resizable panels
- **Search**: Searchable node list with id/type/category filters

### Design Principles
- **EditorModel as single source of truth**: Rete.js is view layer
- **Manual sync by default**: DSL ↔ Node require explicit buttons
- **Canonical DSL**: Node → DSL preserves no original formatting
- **Incremental rendering**: Only changed nodes/edges update on apply
- **Separate undo scopes**: CodeMirror text undo independent from graph undo

### Source-of-Truth Model
Clear explanation of:
1. DSL text ← user typing
2. Apply DSL → parse/compile → EditorModel
3. Invalid DSL shows errors, keeps previous graph
4. Node operations modify EditorModel
5. Auto Sync generates canonical DSL from EditorModel
6. Save chooses appropriate format based on state

### CLI Commands
Documented development commands:
- `npm run dev` - development server
- `npm run build` - production build
- `npm run test:unit` - unit tests
- `npm run test:browser` - browser tests

### Language
- Uses "experimental editor-studio" consistently
- Avoids overpromising (no full VS Code integration, stable production-ready UI claims)
- Clear about current scope vs future work

## Why This Matters

- Gives contributors clear understanding of current design
- Avoids breaking existing workflows when adding features
- Establishes baseline for Tasks A-E improvements
- Clarifies which state updates where (test correctness)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dtev93CxpjrXEnCVjDqkq)_