### PR TITLE
Show DSL diagnostics in CodeMirror

### DIFF
--- a/editor-studio/src/loomlet-codemirror.js
+++ b/editor-studio/src/loomlet-codemirror.js
@@ -2,7 +2,7 @@ import { StreamLanguage, syntaxHighlighting, HighlightStyle } from '@codemirror/
 import { tags } from '@lezer/highlight';
 import { EditorView } from '@codemirror/view';
 import { autocompletion } from '@codemirror/autocomplete';
-import { linter, lintGutter } from '@codemirror/lint';
+import { linter, lintGutter, forceLinting } from '@codemirror/lint';
 
 // Create a set of valid node/function names from metadata
 function createNodeTypeNameSet(nodeTypes = {}) {
@@ -270,20 +270,41 @@ export function getParamCompletionOptionsForNode(nodeTypes = {}, nodeName) {
   }));
 }
 
-function resolveErrorPosition(doc, error) {
+function getErrorStartLine(error) {
+  return error?.line ?? error?.span?.start?.line ?? null;
+}
+
+function getErrorStartColumn(error) {
+  return error?.column ?? error?.span?.start?.column ?? 1;
+}
+
+function getErrorEndLine(error) {
+  return error?.span?.end?.line ?? getErrorStartLine(error);
+}
+
+function getErrorEndColumn(error) {
+  return error?.span?.end?.column ?? getErrorStartColumn(error);
+}
+
+function resolveErrorPosition(doc, error, endpoint = 'start') {
   if (!error) return 0;
 
-  const line = error.line !== undefined ? error.line : null;
-  const column = error.column !== undefined ? error.column : 0;
+  const line = endpoint === 'end'
+    ? getErrorEndLine(error)
+    : getErrorStartLine(error);
 
-  if (line === null || line < 1) {
-    return 0;
-  }
+  const column = endpoint === 'end'
+    ? getErrorEndColumn(error)
+    : getErrorStartColumn(error);
+
+  if (!line || line < 1) return 0;
 
   try {
     const lineObject = doc.line(line);
-    if (!lineObject) return 0;
-    const colOffset = Math.max(0, Math.min(column || 0, lineObject.length));
+    const colOffset = Math.max(
+      0,
+      Math.min((column || 1) - 1, lineObject.length)
+    );
     return lineObject.from + colOffset;
   } catch {
     return 0;
@@ -295,19 +316,9 @@ export function createLoomletDslLinter({ getErrors } = {}) {
     const errors = getErrors?.() || [];
 
     return errors.map((error) => {
-      const from = resolveErrorPosition(view.state.doc, error);
-      let to = from + 1;
-
-      if (error.line !== undefined) {
-        try {
-          const lineObject = view.state.doc.line(error.line);
-          if (lineObject) {
-            to = lineObject.to;
-          }
-        } catch {
-          to = from + 1;
-        }
-      }
+      const from = resolveErrorPosition(view.state.doc, error, 'start');
+      const explicitTo = resolveErrorPosition(view.state.doc, error, 'end');
+      const to = Math.max(from + 1, explicitTo);
 
       return {
         from,

--- a/editor-studio/src/loomlet-codemirror.js
+++ b/editor-studio/src/loomlet-codemirror.js
@@ -2,6 +2,7 @@ import { StreamLanguage, syntaxHighlighting, HighlightStyle } from '@codemirror/
 import { tags } from '@lezer/highlight';
 import { EditorView } from '@codemirror/view';
 import { autocompletion } from '@codemirror/autocomplete';
+import { linter, lintGutter } from '@codemirror/lint';
 
 // Create a set of valid node/function names from metadata
 function createNodeTypeNameSet(nodeTypes = {}) {
@@ -269,10 +270,59 @@ export function getParamCompletionOptionsForNode(nodeTypes = {}, nodeName) {
   }));
 }
 
+function resolveErrorPosition(doc, error) {
+  if (!error) return 0;
+
+  const line = error.line !== undefined ? error.line : null;
+  const column = error.column !== undefined ? error.column : 0;
+
+  if (line === null || line < 1) {
+    return 0;
+  }
+
+  try {
+    const lineObject = doc.line(line);
+    if (!lineObject) return 0;
+    const colOffset = Math.max(0, Math.min(column || 0, lineObject.length));
+    return lineObject.from + colOffset;
+  } catch {
+    return 0;
+  }
+}
+
+export function createLoomletDslLinter({ getErrors } = {}) {
+  return linter((view) => {
+    const errors = getErrors?.() || [];
+
+    return errors.map((error) => {
+      const from = resolveErrorPosition(view.state.doc, error);
+      let to = from + 1;
+
+      if (error.line !== undefined) {
+        try {
+          const lineObject = view.state.doc.line(error.line);
+          if (lineObject) {
+            to = lineObject.to;
+          }
+        } catch {
+          to = from + 1;
+        }
+      }
+
+      return {
+        from,
+        to,
+        severity: 'error',
+        message: error.message || String(error)
+      };
+    });
+  });
+}
+
 export { findNearestCallNameBefore };
 
 // Main export: return array of CodeMirror extensions
-export function loomletDslExtensions({ nodeTypes } = {}) {
+export function loomletDslExtensions({ nodeTypes, getErrors } = {}) {
   const extensions = [
     createLoomletStreamLanguage(nodeTypes),
     syntaxHighlighting(loomletHighlightStyle),
@@ -284,6 +334,11 @@ export function loomletDslExtensions({ nodeTypes } = {}) {
       activateOnTyping: true
     })
   ];
+
+  if (getErrors) {
+    extensions.push(createLoomletDslLinter({ getErrors }));
+    extensions.push(lintGutter());
+  }
 
   return extensions;
 }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -4,6 +4,7 @@ import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
 import { bracketMatching, foldGutter, indentOnInput } from '@codemirror/language';
 import { searchKeymap, highlightSelectionMatches } from '@codemirror/search';
 import { closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete';
+import { forceLinting } from '@codemirror/lint';
 
 import { Loom, NODE_TYPES } from '../../src/loom.js';
 import { loomletDslExtensions } from './loomlet-codemirror.js';
@@ -789,14 +790,16 @@ function renderGraphJSON(graph) {
 function renderErrors() {
   const state = store.getState();
   const html = state.errors.map(err => {
-    const line = err.line ? `:${err.line}` : '';
-    const col = err.column ? `:${err.column}` : '';
+    const lineNumber = err.line ?? err.span?.start?.line;
+    const columnNumber = err.column ?? err.span?.start?.column;
+    const line = lineNumber ? `:${lineNumber}` : '';
+    const col = columnNumber ? `:${columnNumber}` : '';
     return `<div class="error-item"><strong>${err.code || 'ERROR'}${line}${col}</strong>: ${err.message}</div>`;
   }).join('');
   elements.errorsList.innerHTML = html || '<div class="error-item">No errors</div>';
 
   if (dslEditor) {
-    dslEditor.dispatch({});
+    forceLinting(dslEditor);
   }
 }
 

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -332,7 +332,10 @@ function initDslEditor() {
         ...searchKeymap,
         ...completionKeymap
       ]),
-      ...loomletDslExtensions({ nodeTypes: NODE_TYPES }),
+      ...loomletDslExtensions({
+        nodeTypes: NODE_TYPES,
+        getErrors: () => store.getState().errors || []
+      }),
       EditorView.updateListener.of((update) => {
         if (!update.docChanged) return;
         if (isApplyingProgrammaticDslChange) return;
@@ -791,6 +794,10 @@ function renderErrors() {
     return `<div class="error-item"><strong>${err.code || 'ERROR'}${line}${col}</strong>: ${err.message}</div>`;
   }).join('');
   elements.errorsList.innerHTML = html || '<div class="error-item">No errors</div>';
+
+  if (dslEditor) {
+    dslEditor.dispatch({});
+  }
 }
 
 function getSelectedEditorNode() {


### PR DESCRIPTION
## Summary

Show Loomlet DSL parse and compile errors inline in the CodeMirror editor via the lint gutter, making DSL editing feel more IDE-like.

Builds on #99 (searchable node list), providing immediate visual feedback for syntax and compilation errors.

## Features

- **Inline diagnostics**: Parse/compile errors appear as underlines and gutter marks in DSL editor
- **Error position mapping**: Maps error line/column info to document positions with fallback to line start
- **Live updates**: Lint refreshes whenever errors change (apply, auto-apply, graph operations)
- **No source map dependency**: Works immediately without perfect AST source mapping

## Implementation

- Added `createLoomletDslLinter()` function that creates a CodeMirror linter from current errors
- Integrated `lintGutter()` into editor extensions for visual error markers
- Uses existing `@codemirror/lint` dependency (already in package.json)
- Error position resolution handles missing line/column gracefully

## Files Changed

- `editor-studio/src/loomlet-codemirror.js`: Added linter setup and error position mapping
- `editor-studio/src/main.js`: Pass getErrors callback and refresh lint when errors update

## Testing

1. Type invalid DSL syntax (e.g., remove closing paren from a function call)
2. Confirm error appears in Errors tab
3. Confirm red underline and gutter marker appear in DSL editor
4. Fix the syntax
5. Confirm error clears from both Errors tab and CodeMirror editor
6. Test Auto Apply - should show/clear errors in real time
7. Graph operations creating invalid state should update lint immediately

## Notes

- Only includes CodeMirror diagnostics changes
- Does not include node list, VS Code preview, or other tasks
- Depends on #99 (searchable node list) already merged

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dtev93CxpjrXEnCVjDqkq)_