### PR TITLE
Add VS Code node preview webview foundation

### DIFF
--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -14,7 +14,8 @@
   "activationEvents": [
     "onLanguage:loomlet",
     "onCommand:loomlet.runCurrentFile",
-    "onCommand:loomlet.sceneSyncDevCurrentFile"
+    "onCommand:loomlet.sceneSyncDevCurrentFile",
+    "onCommand:loomlet.openNodePreviewToSide"
   ],
   "contributes": {
     "languages": [
@@ -45,6 +46,10 @@
       {
         "command": "loomlet.sceneSyncDevCurrentFile",
         "title": "Loomlet: Scene Sync Dev Current File"
+      },
+      {
+        "command": "loomlet.openNodePreviewToSide",
+        "title": "Loomlet: Open Node Preview to the Side"
       }
     ],
     "configuration": {

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -4,6 +4,9 @@ const vscode = require('vscode');
 const { getCompletionContext } = require('./completion-context');
 const { buildCompletions: buildRawCompletions, getIncludePlanned } = require('./completion-engine');
 
+let nodePreviewPanel = null;
+let currentPreviewDocument = null;
+
 function activate(context) {
   const provider = {
     provideCompletionItems(document, position) {
@@ -20,11 +23,142 @@ function activate(context) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('loomlet.runCurrentFile', () => runCurrentFile('run')),
-    vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev'))
+    vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev')),
+    vscode.commands.registerCommand('loomlet.openNodePreviewToSide', () => openNodePreviewToSide(context))
+  );
+
+  vscode.workspace.onDidChangeTextDocument((event) => {
+    if (nodePreviewPanel && currentPreviewDocument && event.document === currentPreviewDocument) {
+      sendDocumentToPreview(event.document);
+    }
+  });
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (nodePreviewPanel && editor?.document.languageId === 'loomlet') {
+        currentPreviewDocument = editor.document;
+        sendDocumentToPreview(editor.document);
+      }
+    })
   );
 }
 
-function deactivate() {}
+function deactivate() {
+  if (nodePreviewPanel) {
+    nodePreviewPanel.dispose();
+  }
+}
+
+function openNodePreviewToSide(context) {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showErrorMessage('No active editor.');
+    return;
+  }
+
+  const document = editor.document;
+  const isLoomlet = document.languageId === 'loomlet' || document.languageId === 'loom' || document.fileName.endsWith('.loom');
+  if (!isLoomlet) {
+    vscode.window.showErrorMessage('Active file must be a .loom file.');
+    return;
+  }
+
+  if (nodePreviewPanel) {
+    nodePreviewPanel.reveal(vscode.ViewColumn.Beside);
+    currentPreviewDocument = document;
+    sendDocumentToPreview(document);
+    return;
+  }
+
+  nodePreviewPanel = vscode.window.createWebviewPanel(
+    'loomletNodePreview',
+    'Loomlet Node Preview',
+    vscode.ViewColumn.Beside,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  );
+
+  nodePreviewPanel.webview.html = getWebviewContent();
+
+  nodePreviewPanel.onDidDispose(() => {
+    nodePreviewPanel = null;
+    currentPreviewDocument = null;
+  });
+
+  currentPreviewDocument = document;
+  sendDocumentToPreview(document);
+}
+
+function sendDocumentToPreview(document) {
+  if (!nodePreviewPanel) return;
+
+  const text = document.getText();
+  nodePreviewPanel.webview.postMessage({
+    type: 'update',
+    text
+  });
+}
+
+function getWebviewContent() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loomlet Node Preview</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 16px;
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: 13px;
+    }
+    .header {
+      margin-bottom: 16px;
+    }
+    .status {
+      padding: 8px 12px;
+      background: rgba(74, 144, 226, 0.15);
+      border-left: 3px solid #4a90e2;
+      border-radius: 4px;
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h2 style="margin: 0 0 8px 0;">Loomlet Node Preview</h2>
+    <div class="status">Waiting for graph...</div>
+  </div>
+  <div id="preview"></div>
+  <script>
+    const vscode = acquireVsCodeApi();
+    window.addEventListener('message', event => {
+      const message = event.data;
+      if (message.type === 'update') {
+        const preview = document.getElementById('preview');
+        preview.innerHTML = '<pre style="background: rgba(0,0,0,0.3); padding: 8px; border-radius: 4px; overflow: auto;">' +
+          escapeHtml(message.text.slice(0, 200)) + '...</pre>';
+      }
+    });
+    function escapeHtml(text) {
+      const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+      };
+      return String(text).replace(/[&<>"']/g, char => map[char]);
+    }
+  </script>
+</body>
+</html>`;
+}
 
 function buildCompletions(ctx) {
   const includePlanned = getIncludePlanned((key) => vscode.workspace.getConfiguration().get(key));

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -24,16 +24,12 @@ function activate(context) {
   context.subscriptions.push(
     vscode.commands.registerCommand('loomlet.runCurrentFile', () => runCurrentFile('run')),
     vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev')),
-    vscode.commands.registerCommand('loomlet.openNodePreviewToSide', () => openNodePreviewToSide(context))
-  );
-
-  vscode.workspace.onDidChangeTextDocument((event) => {
-    if (nodePreviewPanel && currentPreviewDocument && event.document === currentPreviewDocument) {
-      sendDocumentToPreview(event.document);
-    }
-  });
-
-  context.subscriptions.push(
+    vscode.commands.registerCommand('loomlet.openNodePreviewToSide', () => openNodePreviewToSide(context)),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      if (nodePreviewPanel && currentPreviewDocument && event.document.uri.toString() === currentPreviewDocument.uri.toString()) {
+        sendDocumentToPreview(event.document);
+      }
+    }),
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (nodePreviewPanel && editor?.document.languageId === 'loomlet') {
         currentPreviewDocument = editor.document;


### PR DESCRIPTION
## Summary

Add foundational VS Code webview support for Node Preview. Opens a preview panel beside the editor that receives the active .loom document and updates in real-time.

## Features

- **New command**: `loomlet.openNodePreviewToSide`
- **Webview panel**: Opens beside active editor, persists across document changes
- **Document sync**: Sends active .loom file text to webview
- **Live updates**: Webview updates when document text changes
- **Validation**: Confirms active file is a .loom file before opening

## Implementation

- Added command to extension package.json and activation events
- Created `openNodePreviewToSide()` that creates webview panel
- Added `sendDocumentToPreview()` to post document text to webview
- Registered document change listener to update webview
- Added placeholder webview HTML with basic styling

## Limitations (Deferred)

- Webview shows text preview only (no graph compilation yet)
- No Rete.js rendering in this PR
- Graph parsing/compilation deferred to next PR
- No bidirectional sync, Scene Sync integration, or save integration

## Files Changed

- `extensions/vscode-loomlet/package.json`: Added new command and activation
- `extensions/vscode-loomlet/src/extension.js`: Implemented webview creation and document sync

## Testing

1. Install/reload VS Code extension in dev host
2. Open any .loom file
3. Run command "Loomlet: Open Node Preview to the Side"
4. Confirm webview opens beside editor
5. Edit document text
6. Confirm preview updates with new text
7. Switch between .loom files
8. Confirm preview shows active document
9. Close and reopen webview
10. Confirm no console errors

## Scope

This PR includes **only** VS Code extension preview foundation. Does not include:
- Node list / Nodes tab
- CodeMirror diagnostics
- NodeEditorView diff helper extraction
- Documentation updates

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dtev93CxpjrXEnCVjDqkq)_