### PR TITLE
Polish editor studio interactions

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -34,6 +34,11 @@
         <input id="autoSyncGraphToDslToggle" type="checkbox" checked />
         <span>Auto Sync DSL</span>
       </label>
+      <div class="toolbar-status" aria-label="Editor status">
+        <span id="dirty-status" class="status-pill">Saved</span>
+        <span id="auto-apply-status-pill" class="status-pill">Auto Apply OFF</span>
+        <span id="auto-sync-status-pill" class="status-pill">Auto Sync OFF</span>
+      </div>
       <span id="auto-apply-status" class="auto-apply-status">Manual</span>
     </div>
 

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -37,6 +37,7 @@ render bar(width: width, color: "#80ed99", height: 48)
 const BOTTOM_PANEL_HEIGHT_KEY = 'loomlet.editorStudio.bottomPanelHeight';
 const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
 const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';
+const ACTIVE_BOTTOM_TAB_KEY = 'loomlet.editorStudio.activeBottomTab';
 
 const MAX_HISTORY_ENTRIES = 100;
 const MOVE_HISTORY_COALESCE_MS = 250;
@@ -115,7 +116,10 @@ const elements = {
   editorPanels: document.querySelector('.editor-panels'),
   editorSplitResizeHandle: document.getElementById('editor-split-resize-handle'),
   undoBtn: document.getElementById('undo-btn'),
-  redoBtn: document.getElementById('redo-btn')
+  redoBtn: document.getElementById('redo-btn'),
+  dirtyStatus: document.getElementById('dirty-status'),
+  autoApplyStatusPill: document.getElementById('auto-apply-status-pill'),
+  autoSyncStatusPill: document.getElementById('auto-sync-status-pill')
 };
 
 function setPanelsVisible(visible) {
@@ -278,6 +282,35 @@ function saveEditorSplitLayout() {
   localStorage.setItem(EDITOR_SPLIT_WIDTH_KEY, String(dslPaneWidth));
 }
 
+function selectBottomTab(tabName) {
+  elements.tabBtns.forEach(b => b.classList.remove('active'));
+  elements.tabPanes.forEach(p => p.classList.remove('active'));
+
+  const button = document.querySelector(`[data-tab="${tabName}"]`);
+  const pane = document.getElementById(`${tabName}-tab`);
+
+  if (button) {
+    button.classList.add('active');
+  }
+  if (pane) {
+    pane.classList.add('active');
+  }
+
+  localStorage.setItem(ACTIVE_BOTTOM_TAB_KEY, tabName);
+}
+
+function loadActiveBottomTab() {
+  const savedTab = localStorage.getItem(ACTIVE_BOTTOM_TAB_KEY);
+  if (!savedTab) return;
+
+  const button = document.querySelector(`[data-tab="${savedTab}"]`);
+  const pane = document.getElementById(`${savedTab}-tab`);
+
+  if (!button || !pane) return;
+
+  selectBottomTab(savedTab);
+}
+
 function startEditorSplitResize(event) {
   isResizingEditorSplit = true;
   document.body.classList.add('resizing-editor-split');
@@ -376,6 +409,7 @@ function setDslText(text) {
 function setDirty(dirty) {
   isDirty = dirty;
   renderFileStatus();
+  renderDirtyStatus();
 }
 
 function renderFileStatus() {
@@ -413,6 +447,32 @@ function renderAutoApplyStatus(status = null) {
 
   elements.autoApplyStatus.textContent = 'Auto: on';
   elements.autoApplyStatus.className = 'auto-apply-status';
+}
+
+function renderDirtyStatus() {
+  if (!elements.dirtyStatus) return;
+
+  elements.dirtyStatus.textContent = isDirty ? 'Dirty' : 'Saved';
+  elements.dirtyStatus.classList.toggle('is-dirty', isDirty);
+  elements.dirtyStatus.classList.toggle('is-saved', !isDirty);
+}
+
+function renderAutoApplyStatusPill() {
+  if (!elements.autoApplyStatusPill) return;
+
+  elements.autoApplyStatusPill.textContent =
+    autoApplyDslEnabled ? 'Auto Apply ON' : 'Auto Apply OFF';
+
+  elements.autoApplyStatusPill.classList.toggle('is-on', autoApplyDslEnabled);
+}
+
+function renderAutoSyncStatusPill() {
+  if (!elements.autoSyncStatusPill) return;
+
+  elements.autoSyncStatusPill.textContent =
+    autoSyncGraphToDslEnabled ? 'Auto Sync ON' : 'Auto Sync OFF';
+
+  elements.autoSyncStatusPill.classList.toggle('is-on', autoSyncGraphToDslEnabled);
 }
 
 function scheduleAutoApplyDsl() {
@@ -796,7 +856,7 @@ function renderErrors() {
     const col = columnNumber ? `:${columnNumber}` : '';
     return `<div class="error-item"><strong>${err.code || 'ERROR'}${line}${col}</strong>: ${err.message}</div>`;
   }).join('');
-  elements.errorsList.innerHTML = html || '<div class="error-item">No errors</div>';
+  elements.errorsList.innerHTML = html || '<div class="empty-state">No errors</div>';
 
   if (dslEditor) {
     forceLinting(dslEditor);
@@ -911,8 +971,8 @@ function renderInspector() {
 
   if (!node) {
     panel.innerHTML = `
-      <div class="inspector-empty">
-        Select a node to edit its literal params.
+      <div class="empty-state">
+        Select a node to edit its parameters.
       </div>
     `;
     return;
@@ -1254,7 +1314,7 @@ function renderNodeList() {
 
   const state = store.getState();
   if (!state.editorModel) {
-    list.innerHTML = '<div class="node-list-empty">No nodes</div>';
+    list.innerHTML = '<div class="empty-state">No nodes in this graph.</div>';
     return;
   }
 
@@ -1275,7 +1335,7 @@ function renderNodeList() {
   });
 
   if (filtered.length === 0) {
-    list.innerHTML = '<div class="node-list-empty">No nodes matching filter</div>';
+    list.innerHTML = '<div class="empty-state">No matching nodes.</div>';
     return;
   }
 
@@ -1675,10 +1735,12 @@ function setupEventListeners() {
         autoApplyTimer = null;
       }
       renderAutoApplyStatus();
+      renderAutoApplyStatusPill();
       return;
     }
 
     renderAutoApplyStatus();
+    renderAutoApplyStatusPill();
 
     if (hasUnsyncedDslText) {
       scheduleAutoApplyDsl();
@@ -1687,6 +1749,7 @@ function setupEventListeners() {
 
   elements.autoSyncGraphToDslToggle?.addEventListener('change', () => {
     autoSyncGraphToDslEnabled = Boolean(elements.autoSyncGraphToDslToggle.checked);
+    renderAutoSyncStatusPill();
 
     if (autoSyncGraphToDslEnabled && !hasUnsyncedDslText) {
       syncGraphToDslEditor({ markDirty: false });
@@ -1696,10 +1759,7 @@ function setupEventListeners() {
   elements.tabBtns.forEach(btn => {
     btn.addEventListener('click', () => {
       const tabName = btn.getAttribute('data-tab');
-      elements.tabBtns.forEach(b => b.classList.remove('active'));
-      elements.tabPanes.forEach(p => p.classList.remove('active'));
-      btn.classList.add('active');
-      document.getElementById(`${tabName}-tab`)?.classList.add('active');
+      selectBottomTab(tabName);
     });
   });
 
@@ -1809,8 +1869,12 @@ async function init() {
   setupEventListeners();
   loadBottomPanelLayout();
   loadEditorSplitLayout();
+  loadActiveBottomTab();
   renderFileStatus();
+  renderDirtyStatus();
   renderAutoApplyStatus();
+  renderAutoApplyStatusPill();
+  renderAutoSyncStatusPill();
   renderUndoRedoState();
   renderNodePaletteCategories();
   renderNodePalette();

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -278,8 +278,8 @@ body.resizing-editor-split * {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
+  min-width: 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(0, 0, 0, 0.3);
 }
@@ -290,10 +290,13 @@ body.resizing-editor-split * {
   gap: 4px;
   min-width: 0;
   overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  flex: 1;
 }
 
 .tab-btn {
-  flex: 1;
+  flex: 0 0 auto;
   padding: 10px 16px;
   background: transparent;
   border: none;
@@ -303,6 +306,7 @@ body.resizing-editor-split * {
   font-size: 13px;
   font-weight: 500;
   transition: all 0.2s;
+  white-space: nowrap;
 }
 
 .tab-btn:hover {
@@ -319,6 +323,7 @@ body.resizing-editor-split * {
   font-size: 12px;
   padding: 3px 8px;
   margin-right: 4px;
+  margin-left: auto;
 }
 
 .tab-content {
@@ -400,6 +405,20 @@ body.resizing-editor-split * {
 
 .btn:active {
   transform: scale(0.98);
+}
+
+button:disabled,
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: grayscale(0.3);
+}
+
+button:disabled:hover,
+.btn:disabled:hover {
+  transform: none;
+  box-shadow: none;
+  background: rgba(20, 20, 20, 0.8);
 }
 
 .btn-primary {
@@ -846,4 +865,49 @@ body.resizing-editor-split * {
   padding: 2px 6px;
   border-radius: 3px;
   display: inline-block;
+}
+
+.empty-state {
+  padding: 16px;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.toolbar-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.58);
+  white-space: nowrap;
+}
+
+.status-pill.is-dirty {
+  color: #ff9b9b;
+  border-color: rgba(255, 155, 155, 0.3);
+  background: rgba(255, 155, 155, 0.08);
+}
+
+.status-pill.is-saved {
+  color: #80ed99;
+  border-color: rgba(128, 237, 153, 0.3);
+  background: rgba(128, 237, 153, 0.08);
+}
+
+.status-pill.is-on {
+  color: #80ed99;
+  border-color: rgba(128, 237, 153, 0.3);
+  background: rgba(128, 237, 153, 0.08);
 }


### PR DESCRIPTION
Add UI/UX improvements to editor-studio:

1. Persist active bottom tab using localStorage, restoring selected tab on page reload
2. Add toolbar status indicators for editor state:
   - Dirty/Saved status with visual indication
   - Auto Apply DSL toggle status
   - Auto Sync DSL toggle status
3. Improve disabled button styling with reduced opacity and grayscale filter
4. Improve tab header overflow behavior with horizontal scroll support
5. Add/clean up empty states for:
   - Errors tab (shows "No errors" when clean)
   - Inspector tab (shows "Select a node..." when none selected)
   - Nodes tab (shows appropriate messages for no nodes / no search results)

All changes are UI/UX polish only; core editor behavior unchanged.

https://claude.ai/code/session_01T4sZjzYVNn9kZnzS7kbQ1G