### PR TITLE
Add editor output panel

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -77,6 +77,7 @@
             <button class="tab-btn" data-tab="inspector">Inspector</button>
             <button class="tab-btn" data-tab="nodes">Nodes</button>
             <button class="tab-btn" data-tab="palette">Palette</button>
+            <button class="tab-btn" data-tab="output">Output</button>
           </div>
           <button id="bottom-panel-collapse-btn" class="bottom-panel-collapse-btn" title="Collapse bottom panel">Collapse</button>
         </div>
@@ -115,6 +116,14 @@
                 </select>
               </div>
               <div id="node-palette-list" class="node-palette-list"></div>
+            </div>
+          </div>
+          <div id="output-tab" class="tab-pane">
+            <div class="output-panel">
+              <div class="output-toolbar">
+                <button id="clear-output-btn" class="btn">Clear</button>
+              </div>
+              <pre id="output-log" class="output-log"></pre>
             </div>
           </div>
         </div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -42,6 +42,9 @@ const ACTIVE_BOTTOM_TAB_KEY = 'loomlet.editorStudio.activeBottomTab';
 const MAX_HISTORY_ENTRIES = 100;
 const MOVE_HISTORY_COALESCE_MS = 250;
 
+let outputEntries = [];
+const MAX_OUTPUT_ENTRIES = 500;
+
 const DEFAULT_BOTTOM_PANEL_HEIGHT = 260;
 const MIN_BOTTOM_PANEL_HEIGHT = 120;
 const MAX_BOTTOM_PANEL_RATIO = 0.6;
@@ -119,7 +122,9 @@ const elements = {
   redoBtn: document.getElementById('redo-btn'),
   dirtyStatus: document.getElementById('dirty-status'),
   autoApplyStatusPill: document.getElementById('auto-apply-status-pill'),
-  autoSyncStatusPill: document.getElementById('auto-sync-status-pill')
+  autoSyncStatusPill: document.getElementById('auto-sync-status-pill'),
+  outputLog: document.getElementById('output-log'),
+  clearOutputBtn: document.getElementById('clear-output-btn')
 };
 
 function setPanelsVisible(visible) {
@@ -577,6 +582,7 @@ async function saveDslAsFile() {
       }
 
       setDirty(false);
+      appendOutput({ level: 'info', message: 'File saved.' });
       return;
     }
 
@@ -587,6 +593,7 @@ async function saveDslAsFile() {
     }
 
     setDirty(false);
+    appendOutput({ level: 'info', message: 'File saved.' });
   } catch (error) {
     if (isAbortError(error)) return;
     setEditorError(`Save failed: ${error.message}`);
@@ -613,6 +620,7 @@ async function saveDslFile() {
     }
 
     setDirty(false);
+    appendOutput({ level: 'info', message: 'File saved.' });
   } catch (error) {
     if (isAbortError(error)) return;
     setEditorError(`Save failed: ${error.message}`);
@@ -650,6 +658,7 @@ async function openLoomFile() {
       hasUnsyncedDslText = false;
       setDirty(false);
       clearEditorHistory();
+      appendOutput({ level: 'info', message: 'File opened.' });
       return;
     }
 
@@ -668,6 +677,7 @@ async function openLoomFile() {
       hasUnsyncedDslText = false;
       setDirty(false);
       clearEditorHistory();
+      appendOutput({ level: 'info', message: 'File opened.' });
     });
     input.click();
   } catch (error) {
@@ -764,8 +774,11 @@ async function applyDsl({ markDirty = true } = {}) {
   });
 
   if (result.ok) {
+    appendOutput({ level: 'info', message: 'DSL applied successfully.' });
     cancelPendingAutoApplyDsl();
     clearEditorHistory();
+  } else {
+    appendOutput({ level: 'error', message: 'DSL apply failed.' });
   }
 
   return result;
@@ -835,11 +848,47 @@ async function autoApplyDslFromEditor(requestId) {
   if (requestId !== autoApplyRequestId) return;
 
   if (result.ok) {
+    appendOutput({ level: 'info', message: 'Auto Apply DSL success.' });
     renderAutoApplyStatus('ok');
     clearEditorHistory();
   } else {
+    appendOutput({ level: 'error', message: 'Auto Apply DSL error.' });
     renderAutoApplyStatus('error');
   }
+}
+
+function appendOutput(entry) {
+  outputEntries.push({
+    time: new Date().toISOString(),
+    level: entry.level || 'info',
+    message: String(entry.message ?? '')
+  });
+
+  if (outputEntries.length > MAX_OUTPUT_ENTRIES) {
+    outputEntries = outputEntries.slice(-MAX_OUTPUT_ENTRIES);
+  }
+
+  renderOutput();
+}
+
+function clearOutput() {
+  outputEntries = [];
+  renderOutput();
+}
+
+function renderOutput() {
+  if (!elements.outputLog) return;
+
+  if (!outputEntries.length) {
+    elements.outputLog.textContent = 'No output yet.';
+    elements.outputLog.classList.add('is-empty');
+    return;
+  }
+
+  elements.outputLog.classList.remove('is-empty');
+  elements.outputLog.textContent = outputEntries
+    .map((entry) => `[${entry.level}] ${entry.message}`)
+    .join('\n');
 }
 
 function renderGraphJSON(graph) {
@@ -1763,6 +1812,8 @@ function setupEventListeners() {
     });
   });
 
+  elements.clearOutputBtn?.addEventListener('click', clearOutput);
+
   elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
 
@@ -1880,6 +1931,7 @@ async function init() {
   renderNodePalette();
   updateNodeListCategories();
   renderNodeList();
+  renderOutput();
   await applyDsl({ markDirty: false });
   setDirty(false);
 }

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -767,18 +767,22 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
   };
 }
 
-async function applyDsl({ markDirty = true } = {}) {
+async function applyDsl({ markDirty = true, logOutput = true } = {}) {
   const result = await applyDslTextToGraph(getDslText(), {
     markDirty,
     preserveGraphOnError: false
   });
 
   if (result.ok) {
-    appendOutput({ level: 'info', message: 'DSL applied successfully.' });
+    if (logOutput) {
+      appendOutput({ level: 'info', message: 'DSL applied successfully.' });
+    }
     cancelPendingAutoApplyDsl();
     clearEditorHistory();
   } else {
-    appendOutput({ level: 'error', message: 'DSL apply failed.' });
+    if (logOutput) {
+      appendOutput({ level: 'error', message: 'DSL apply failed.' });
+    }
   }
 
   return result;
@@ -848,7 +852,6 @@ async function autoApplyDslFromEditor(requestId) {
   if (requestId !== autoApplyRequestId) return;
 
   if (result.ok) {
-    appendOutput({ level: 'info', message: 'Auto Apply DSL success.' });
     renderAutoApplyStatus('ok');
     clearEditorHistory();
   } else {
@@ -876,6 +879,10 @@ function clearOutput() {
   renderOutput();
 }
 
+function formatOutputTime(isoString) {
+  return isoString.slice(11, 19);
+}
+
 function renderOutput() {
   if (!elements.outputLog) return;
 
@@ -887,7 +894,10 @@ function renderOutput() {
 
   elements.outputLog.classList.remove('is-empty');
   elements.outputLog.textContent = outputEntries
-    .map((entry) => `[${entry.level}] ${entry.message}`)
+    .map((entry) => {
+      const time = formatOutputTime(entry.time);
+      return `${time} [${entry.level}] ${entry.message}`;
+    })
     .join('\n');
 }
 
@@ -1932,7 +1942,7 @@ async function init() {
   updateNodeListCategories();
   renderNodeList();
   renderOutput();
-  await applyDsl({ markDirty: false });
+  await applyDsl({ markDirty: false, logOutput: false });
   setDirty(false);
 }
 

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -911,3 +911,33 @@ button:disabled:hover,
   border-color: rgba(128, 237, 153, 0.3);
   background: rgba(128, 237, 153, 0.08);
 }
+
+.output-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.output-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.output-log {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  margin: 0;
+  padding: 12px;
+  font-family: Monaco, Menlo, Consolas, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.output-log.is-empty {
+  color: rgba(255, 255, 255, 0.48);
+}


### PR DESCRIPTION
Add Output tab to bottom panel with:
- Output log display with timestamp and level prefix
- Clear button to reset output
- Output buffer (500 entries max)
- Messages for DSL apply (manual and auto), save, and open operations
- Responsive output panel styling

https://claude.ai/code/session_01HK23Tknvy4gXmK7rCn1nKJ