### PR TITLE
Implement overlap detection for node layout positioning

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -14,7 +14,8 @@ import {
   editorModelToGraph,
   applyNodeEditorOperationState,
   preserveEditorModelLayout,
-  findNonOverlappingPosition
+  findNonOverlappingPosition,
+  NODE_LAYOUT_STEP_Y
 } from '../../src/node-editor-core.js';
 import { graphToCanonicalDSL } from './canonical-dsl.js';
 import { createStore } from './studio-store.js';
@@ -1467,7 +1468,7 @@ async function addNodeFromPalette(typeName) {
     type: typeName,
     category,
     params: createDefaultParamsForNodeType(typeName, NODE_TYPES),
-    position: createPositionForNewNode(category, nodes, findNonOverlappingPosition)
+    position: createPositionForNewNode(category, nodes, findNonOverlappingPosition, NODE_LAYOUT_STEP_Y)
   };
 
   await handleOperation({

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -13,7 +13,8 @@ import {
   graphToEditorModel,
   editorModelToGraph,
   applyNodeEditorOperationState,
-  preserveEditorModelLayout
+  preserveEditorModelLayout,
+  findNonOverlappingPosition
 } from '../../src/node-editor-core.js';
 import { graphToCanonicalDSL } from './canonical-dsl.js';
 import { createStore } from './studio-store.js';
@@ -1466,7 +1467,7 @@ async function addNodeFromPalette(typeName) {
     type: typeName,
     category,
     params: createDefaultParamsForNodeType(typeName, NODE_TYPES),
-    position: createPositionForNewNode(category, nodes)
+    position: createPositionForNewNode(category, nodes, findNonOverlappingPosition)
   };
 
   await handleOperation({

--- a/editor-studio/src/node-palette-model.js
+++ b/editor-studio/src/node-palette-model.js
@@ -35,7 +35,7 @@ export function createNodeIdFromType(typeName, existingNodeIds) {
   return `${base}_${index}`;
 }
 
-export function createPositionForNewNode(category, nodes) {
+export function createPositionForNewNode(category, nodes, findNonOverlappingPosition) {
   const categoryX = {
     input: 0,
     transform: 300,
@@ -44,11 +44,17 @@ export function createPositionForNewNode(category, nodes) {
   };
 
   const sameCategoryCount = (nodes || []).filter((node) => node.category === category).length;
-
-  return {
+  const desiredPosition = {
     x: categoryX[category] ?? 1200,
     y: sameCategoryCount * 120
   };
+
+  if (!findNonOverlappingPosition) {
+    return desiredPosition;
+  }
+
+  const existingPositions = (nodes || []).map((node) => node.position).filter(Boolean);
+  return findNonOverlappingPosition(desiredPosition, existingPositions);
 }
 
 export function getNodeTypeEntries(NODE_TYPES) {

--- a/editor-studio/src/node-palette-model.js
+++ b/editor-studio/src/node-palette-model.js
@@ -35,7 +35,7 @@ export function createNodeIdFromType(typeName, existingNodeIds) {
   return `${base}_${index}`;
 }
 
-export function createPositionForNewNode(category, nodes, findNonOverlappingPosition) {
+export function createPositionForNewNode(category, nodes, findNonOverlappingPosition, NODE_LAYOUT_STEP_Y) {
   const categoryX = {
     input: 0,
     transform: 300,
@@ -46,7 +46,7 @@ export function createPositionForNewNode(category, nodes, findNonOverlappingPosi
   const sameCategoryCount = (nodes || []).filter((node) => node.category === category).length;
   const desiredPosition = {
     x: categoryX[category] ?? 1200,
-    y: sameCategoryCount * 120
+    y: sameCategoryCount * (NODE_LAYOUT_STEP_Y || 120)
   };
 
   if (!findNonOverlappingPosition) {

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -1,12 +1,12 @@
 import { NODE_TYPES } from './loom.js';
 
-const DEFAULT_NODE_WIDTH = 220;
-const DEFAULT_NODE_HEIGHT = 120;
-const NODE_LAYOUT_GAP = 32;
-const NODE_LAYOUT_STEP_X = 260;
-const NODE_LAYOUT_STEP_Y = 160;
-const NODE_LAYOUT_MAX_ROWS = 50;
-const NODE_LAYOUT_MAX_COLS = 50;
+export const DEFAULT_NODE_WIDTH = 220;
+export const DEFAULT_NODE_HEIGHT = 120;
+export const NODE_LAYOUT_GAP = 32;
+export const NODE_LAYOUT_STEP_X = 260;
+export const NODE_LAYOUT_STEP_Y = 160;
+export const NODE_LAYOUT_MAX_ROWS = 50;
+export const NODE_LAYOUT_MAX_COLS = 50;
 
 /**
  * @typedef {Object} EditorNode
@@ -134,7 +134,7 @@ export function layoutFallback(nodes) {
     const idx = counts[category] || 0;
     counts[category] = idx + 1;
 
-    const desiredPosition = { x, y: idx * 120 };
+    const desiredPosition = { x, y: idx * NODE_LAYOUT_STEP_Y };
     const finalPosition = findNonOverlappingPosition(desiredPosition, occupiedPositions);
     occupiedPositions.push(finalPosition);
 

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -1,5 +1,13 @@
 import { NODE_TYPES } from './loom.js';
 
+const DEFAULT_NODE_WIDTH = 220;
+const DEFAULT_NODE_HEIGHT = 120;
+const NODE_LAYOUT_GAP = 32;
+const NODE_LAYOUT_STEP_X = 260;
+const NODE_LAYOUT_STEP_Y = 160;
+const NODE_LAYOUT_MAX_ROWS = 50;
+const NODE_LAYOUT_MAX_COLS = 50;
+
 /**
  * @typedef {Object} EditorNode
  * @property {string} id
@@ -61,6 +69,50 @@ function validateNodeId(id) {
   return trimmed;
 }
 
+export function doRectsOverlap(a, b) {
+  return !(
+    a.x + a.width <= b.x ||
+    b.x + b.width <= a.x ||
+    a.y + a.height <= b.y ||
+    b.y + b.height <= a.y
+  );
+}
+
+export function makeNodeLayoutRect(position) {
+  return {
+    x: position.x,
+    y: position.y,
+    width: DEFAULT_NODE_WIDTH + NODE_LAYOUT_GAP,
+    height: DEFAULT_NODE_HEIGHT + NODE_LAYOUT_GAP
+  };
+}
+
+export function findNonOverlappingPosition(desiredPosition, occupiedPositions) {
+  const occupiedRects = occupiedPositions
+    .filter(Boolean)
+    .map(makeNodeLayoutRect);
+
+  for (let row = 0; row < NODE_LAYOUT_MAX_ROWS; row++) {
+    for (let col = 0; col < NODE_LAYOUT_MAX_COLS; col++) {
+      const candidate = {
+        x: desiredPosition.x + col * NODE_LAYOUT_STEP_X,
+        y: desiredPosition.y + row * NODE_LAYOUT_STEP_Y
+      };
+
+      const candidateRect = makeNodeLayoutRect(candidate);
+      const overlaps = occupiedRects.some((rect) =>
+        doRectsOverlap(candidateRect, rect)
+      );
+
+      if (!overlaps) {
+        return candidate;
+      }
+    }
+  }
+
+  return desiredPosition;
+}
+
 export function layoutFallback(nodes) {
   const categoryX = {
     input: 0,
@@ -69,9 +121,11 @@ export function layoutFallback(nodes) {
     sink: 900
   };
   const counts = {};
+  const occupiedPositions = [];
 
   return nodes.map((node) => {
     if (node.position && Number.isFinite(node.position.x) && Number.isFinite(node.position.y)) {
+      occupiedPositions.push(node.position);
       return { ...node, position: { ...node.position } };
     }
 
@@ -80,9 +134,13 @@ export function layoutFallback(nodes) {
     const idx = counts[category] || 0;
     counts[category] = idx + 1;
 
+    const desiredPosition = { x, y: idx * 120 };
+    const finalPosition = findNonOverlappingPosition(desiredPosition, occupiedPositions);
+    occupiedPositions.push(finalPosition);
+
     return {
       ...node,
-      position: { x, y: idx * 120 }
+      position: finalPosition
     };
   });
 }

--- a/src/node-editor-core.js
+++ b/src/node-editor-core.js
@@ -3,7 +3,10 @@ export {
   graphToEditorModel,
   editorModelToGraph,
   applyEditorOperation,
-  preserveEditorModelLayout
+  preserveEditorModelLayout,
+  findNonOverlappingPosition,
+  doRectsOverlap,
+  makeNodeLayoutRect
 } from './loom-editor-model.js';
 
 export {

--- a/src/node-editor-core.js
+++ b/src/node-editor-core.js
@@ -6,7 +6,14 @@ export {
   preserveEditorModelLayout,
   findNonOverlappingPosition,
   doRectsOverlap,
-  makeNodeLayoutRect
+  makeNodeLayoutRect,
+  DEFAULT_NODE_WIDTH,
+  DEFAULT_NODE_HEIGHT,
+  NODE_LAYOUT_GAP,
+  NODE_LAYOUT_STEP_X,
+  NODE_LAYOUT_STEP_Y,
+  NODE_LAYOUT_MAX_ROWS,
+  NODE_LAYOUT_MAX_COLS
 } from './loom-editor-model.js';
 
 export {

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -8,7 +8,7 @@
   <h1>Loom Editor Model テスト</h1>
   <div id="results"></div>
   <script type="module">
-    import { graphToEditorModel, editorModelToGraph, applyEditorOperation, layoutFallback, preserveEditorModelLayout } from "../src/loom-editor-model.js";
+    import { graphToEditorModel, editorModelToGraph, applyEditorOperation, layoutFallback, preserveEditorModelLayout, doRectsOverlap, makeNodeLayoutRect, findNonOverlappingPosition } from "../src/loom-editor-model.js";
 
     const results = [];
     function test(name, fn) { results.push({ name, fn }); }
@@ -259,6 +259,84 @@
       const merged = preserveEditorModelLayout(next, previous);
 
       assert(!merged.nodesById.old, 'removed node should not be restored');
+    });
+
+    test('18. doRectsOverlap detects overlapping rectangles', () => {
+      const rect1 = { x: 0, y: 0, width: 100, height: 100 };
+      const rect2 = { x: 50, y: 50, width: 100, height: 100 };
+      const rect3 = { x: 200, y: 200, width: 100, height: 100 };
+
+      assert(doRectsOverlap(rect1, rect2), 'overlapping rects should overlap');
+      assert(!doRectsOverlap(rect1, rect3), 'non-overlapping rects should not overlap');
+    });
+
+    test('19. makeNodeLayoutRect creates rect with gap', () => {
+      const pos = { x: 10, y: 20 };
+      const rect = makeNodeLayoutRect(pos);
+
+      assertEqual(rect.x, 10);
+      assertEqual(rect.y, 20);
+      assert(rect.width > 0, 'width should be positive');
+      assert(rect.height > 0, 'height should be positive');
+    });
+
+    test('20. findNonOverlappingPosition avoids occupied positions', () => {
+      const occupied = [{ x: 0, y: 0 }];
+      const result = findNonOverlappingPosition({ x: 0, y: 0 }, occupied);
+
+      assert(result.x !== 0 || result.y !== 0, 'should move away from occupied position');
+    });
+
+    test('21. findNonOverlappingPosition returns desired when no overlap', () => {
+      const occupied = [{ x: 100, y: 100 }];
+      const desired = { x: 0, y: 0 };
+      const result = findNonOverlappingPosition(desired, occupied);
+
+      assertEqual(result, desired);
+    });
+
+    test('22. layoutFallback avoids overlaps for multiple unpositioned nodes', () => {
+      const nodes = [
+        { id: 'a', category: 'input', position: { x: 0, y: 0 } },
+        { id: 'b', category: 'input', position: null },
+        { id: 'c', category: 'input', position: null },
+        { id: 'd', category: 'input', position: null }
+      ];
+
+      const laid = layoutFallback(nodes);
+
+      const positions = laid.map(n => n.position);
+      for (let i = 0; i < positions.length; i++) {
+        for (let j = i + 1; j < positions.length; j++) {
+          const rect1 = makeNodeLayoutRect(positions[i]);
+          const rect2 = makeNodeLayoutRect(positions[j]);
+          assert(!doRectsOverlap(rect1, rect2), `nodes at ${i} and ${j} should not overlap`);
+        }
+      }
+    });
+
+    test('23. layoutFallback preserves explicitly positioned nodes', () => {
+      const nodes = [
+        { id: 'a', category: 'input', position: { x: 42, y: 99 } },
+        { id: 'b', category: 'input', position: null }
+      ];
+
+      const laid = layoutFallback(nodes);
+
+      assertEqual(laid[0].position, { x: 42, y: 99 });
+    });
+
+    test('24. layoutFallback maintains deterministic output', () => {
+      const nodes = [
+        { id: 'a', category: 'input', position: null },
+        { id: 'b', category: 'transform', position: null },
+        { id: 'c', category: 'state', position: null }
+      ];
+
+      const laid1 = layoutFallback(nodes);
+      const laid2 = layoutFallback(nodes);
+
+      assertEqual(JSON.stringify(laid1), JSON.stringify(laid2));
     });
 
     async function run() {

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -288,7 +288,7 @@
     });
 
     test('21. findNonOverlappingPosition returns desired when no overlap', () => {
-      const occupied = [{ x: 100, y: 100 }];
+      const occupied = [{ x: 1000, y: 1000 }];
       const desired = { x: 0, y: 0 };
       const result = findNonOverlappingPosition(desired, occupied);
 


### PR DESCRIPTION
## Summary
This PR adds intelligent node positioning logic to prevent overlapping nodes in the editor canvas. It introduces rectangle overlap detection and a position-finding algorithm that automatically adjusts node placement when conflicts are detected.

## Key Changes
- **New utility functions in `loom-editor-model.js`**:
  - `doRectsOverlap()`: Detects if two rectangles overlap using AABB (axis-aligned bounding box) collision detection
  - `makeNodeLayoutRect()`: Creates a rectangle representation of a node with configurable dimensions and gap spacing
  - `findNonOverlappingPosition()`: Searches for a non-overlapping position by iterating through a grid of candidate positions

- **Enhanced `layoutFallback()` function**: Now tracks occupied positions and uses `findNonOverlappingPosition()` to place unpositioned nodes without overlaps, while preserving explicitly positioned nodes

- **Updated `createPositionForNewNode()` in `node-palette-model.js`**: Now accepts an optional `findNonOverlappingPosition` parameter to enable overlap-aware positioning when creating new nodes from the palette

- **Exported new functions** from `node-editor-core.js` to make overlap detection utilities available to consuming modules

- **Added layout configuration constants**: `DEFAULT_NODE_WIDTH`, `DEFAULT_NODE_HEIGHT`, `NODE_LAYOUT_GAP`, `NODE_LAYOUT_STEP_X`, `NODE_LAYOUT_STEP_Y`, `NODE_LAYOUT_MAX_ROWS`, `NODE_LAYOUT_MAX_COLS`

## Notable Implementation Details
- The overlap detection uses a grid-based search algorithm that iterates through rows and columns to find the first non-overlapping position
- Node rectangles include a configurable gap to ensure visual separation between nodes
- The implementation maintains backward compatibility by making the `findNonOverlappingPosition` parameter optional in `createPositionForNewNode()`
- Comprehensive test coverage added (tests 18-24) validating overlap detection, position finding, and deterministic layout behavior

https://claude.ai/code/session_01JMUrV67C9FFzCUi99s8tpu