### PR TITLE
Add editor metadata persistence for node layout positions

### DIFF
--- a/editor-studio/src/editor-metadata.js
+++ b/editor-studio/src/editor-metadata.js
@@ -1,0 +1,109 @@
+const EDITOR_METADATA_PREFIX = '# @loomlet.editor ';
+
+export function extractEditorMetadataFromDsl(sourceText) {
+  if (typeof sourceText !== 'string') {
+    return { textWithoutMetadata: sourceText, metadata: null };
+  }
+
+  const lines = sourceText.split('\n');
+  let metadataLine = null;
+  let metadataLineIndex = -1;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith(EDITOR_METADATA_PREFIX)) {
+      metadataLine = lines[i];
+      metadataLineIndex = i;
+      break;
+    }
+    if (trimmed && !trimmed.startsWith('#')) {
+      break;
+    }
+  }
+
+  if (!metadataLine) {
+    return { textWithoutMetadata: sourceText, metadata: null };
+  }
+
+  const jsonStr = metadataLine.substring(metadataLine.indexOf(EDITOR_METADATA_PREFIX) + EDITOR_METADATA_PREFIX.length);
+  let metadata = null;
+
+  try {
+    metadata = JSON.parse(jsonStr);
+  } catch (err) {
+    return { textWithoutMetadata: sourceText, metadata: null };
+  }
+
+  const textLines = lines.slice(0, metadataLineIndex);
+  const textWithoutMetadata = textLines.join('\n').trimEnd() + (textLines.length > 0 ? '\n' : '');
+
+  return { textWithoutMetadata, metadata };
+}
+
+export function appendEditorMetadataToDsl(sourceText, metadata) {
+  if (!metadata || typeof sourceText !== 'string') {
+    return sourceText;
+  }
+
+  const { textWithoutMetadata } = extractEditorMetadataFromDsl(sourceText);
+  const metadataJson = JSON.stringify(metadata);
+  const metadataLine = EDITOR_METADATA_PREFIX + metadataJson;
+
+  const text = textWithoutMetadata.trimEnd();
+  return text.length > 0 ? `${text}\n\n${metadataLine}\n` : `${metadataLine}\n`;
+}
+
+export function createEditorLayoutMetadata(editorModel) {
+  if (!editorModel || !editorModel.nodesById) {
+    return { version: 1, layout: { nodes: {} } };
+  }
+
+  const nodes = {};
+
+  for (const [id, node] of Object.entries(editorModel.nodesById)) {
+    if (
+      Number.isFinite(node.position?.x) &&
+      Number.isFinite(node.position?.y)
+    ) {
+      nodes[id] = {
+        x: node.position.x,
+        y: node.position.y
+      };
+    }
+  }
+
+  return {
+    version: 1,
+    layout: { nodes }
+  };
+}
+
+export function applyLayoutMetadataToEditorModel(editorModel, metadata) {
+  if (!editorModel || !metadata) {
+    return editorModel;
+  }
+
+  const layoutNodes = metadata?.layout?.nodes || {};
+  const nodesById = {};
+
+  for (const [id, node] of Object.entries(editorModel.nodesById || {})) {
+    const position = layoutNodes[id];
+
+    if (
+      Number.isFinite(position?.x) &&
+      Number.isFinite(position?.y)
+    ) {
+      nodesById[id] = {
+        ...node,
+        position: { x: position.x, y: position.y }
+      };
+    } else {
+      nodesById[id] = node;
+    }
+  }
+
+  return {
+    ...editorModel,
+    nodesById
+  };
+}

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -27,6 +27,12 @@ import {
   createPositionForNewNode,
   getNodeTypeEntries
 } from './node-palette-model.js';
+import {
+  extractEditorMetadataFromDsl,
+  appendEditorMetadataToDsl,
+  createEditorLayoutMetadata,
+  applyLayoutMetadataToEditorModel
+} from './editor-metadata.js';
 
 const SAMPLE_DSL = `t = clock()
 wave = sine(t, freq: 0.35)
@@ -584,26 +590,29 @@ function downloadTextFile(text, filename) {
 }
 
 function getCurrentSavePayload() {
-  if (hasUnsyncedDslText) {
-    return {
-      text: getDslText(),
-      source: 'dsl'
-    };
-  }
-
   const state = store.getState();
+  let text = '';
+  let source = '';
 
-  if (state.editorModel) {
+  if (hasUnsyncedDslText) {
+    text = getDslText();
+    source = 'dsl';
+  } else if (state.editorModel) {
     const graph = editorModelToGraph(state.editorModel, state.graph);
-    return {
-      text: graphToCanonicalDSL(graph),
-      source: 'graph'
-    };
+    text = graphToCanonicalDSL(graph);
+    source = 'graph';
+  } else {
+    text = getDslText();
+    source = 'dsl';
   }
+
+  const { textWithoutMetadata } = extractEditorMetadataFromDsl(text);
+  const metadata = createEditorLayoutMetadata(state.editorModel);
+  const textWithMetadata = appendEditorMetadataToDsl(textWithoutMetadata, metadata);
 
   return {
-    text: getDslText(),
-    source: 'dsl'
+    text: textWithMetadata,
+    source
   };
 }
 
@@ -743,7 +752,9 @@ async function openLoomFile() {
 }
 
 async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraphOnError = false, shouldCommit = null } = {}) {
-  const { ast, errors: parseErrors } = parseDSLToAST(sourceText);
+  const { textWithoutMetadata, metadata } = extractEditorMetadataFromDsl(sourceText);
+
+  const { ast, errors: parseErrors } = parseDSLToAST(textWithoutMetadata);
 
   if (parseErrors.length) {
     store.setState({ errors: parseErrors });
@@ -782,10 +793,14 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
   }
 
   const previousEditorModel = store.getState().editorModel;
-  const editorModel = preserveEditorModelLayout(
+  let editorModel = preserveEditorModelLayout(
     graphToEditorModel(graph),
     previousEditorModel
   );
+
+  if (metadata) {
+    editorModel = applyLayoutMetadataToEditorModel(editorModel, metadata);
+  }
 
   if (shouldCommit && !shouldCommit()) {
     return { ok: false, stale: true, errors: [] };
@@ -858,7 +873,13 @@ function generateCanonicalDslFromState() {
 function syncGraphToDslEditor({ markDirty = true, force = false } = {}) {
   if (!force && !autoSyncGraphToDslEnabled) return null;
 
-  const dsl = generateCanonicalDslFromState();
+  let dsl = generateCanonicalDslFromState();
+  const state = store.getState();
+
+  if (state.editorModel) {
+    const metadata = createEditorLayoutMetadata(state.editorModel);
+    dsl = appendEditorMetadataToDsl(dsl, metadata);
+  }
 
   setDslText(dsl);
 

--- a/test/editor-metadata.test.html
+++ b/test/editor-metadata.test.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Editor Metadata Tests</title>
+</head>
+<body>
+  <h1>Editor Metadata Tests</h1>
+  <div id="results"></div>
+  <script type="module">
+    import {
+      extractEditorMetadataFromDsl,
+      appendEditorMetadataToDsl,
+      createEditorLayoutMetadata,
+      applyLayoutMetadataToEditorModel
+    } from "../editor-studio/src/editor-metadata.js";
+
+    const results = [];
+    function test(name, fn) { results.push({ name, fn }); }
+    function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+    function assertEqual(a, b, msg) {
+      const av = JSON.stringify(a);
+      const bv = JSON.stringify(b);
+      if (av !== bv) throw new Error(msg || `expected ${bv}, got ${av}`);
+    }
+
+    // extractEditorMetadataFromDsl tests
+    test('extractEditorMetadataFromDsl: extracts metadata from DSL', () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.35)
+render bar(width: wave)
+
+# @loomlet.editor {"version":1,"layout":{"nodes":{"wave":{"x":120,"y":80}}}}`;
+
+      const { textWithoutMetadata, metadata } = extractEditorMetadataFromDsl(dsl);
+
+      assert(textWithoutMetadata.includes('t = clock()'), 'text should contain original code');
+      assert(!textWithoutMetadata.includes('@loomlet.editor'), 'text should not contain metadata');
+      assertEqual(metadata.version, 1, 'metadata version');
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80 }, 'node positions');
+    });
+
+    test('extractEditorMetadataFromDsl: returns null metadata if not present', () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.35)
+render bar(width: wave)`;
+
+      const { textWithoutMetadata, metadata } = extractEditorMetadataFromDsl(dsl);
+
+      assert(metadata === null, 'metadata should be null');
+      assertEqual(textWithoutMetadata, dsl, 'text should be unchanged');
+    });
+
+    test('extractEditorMetadataFromDsl: handles invalid metadata gracefully', () => {
+      const dsl = `t = clock()
+# @loomlet.editor {invalid json}`;
+
+      const { textWithoutMetadata, metadata } = extractEditorMetadataFromDsl(dsl);
+
+      assert(metadata === null, 'metadata should be null for invalid JSON');
+      assertEqual(textWithoutMetadata, dsl, 'text should be unchanged');
+    });
+
+    test('extractEditorMetadataFromDsl: only extracts from end of file', () => {
+      const dsl = `t = clock()
+# @loomlet.editor {"version":1}
+wave = sine(t, freq: 0.35)`;
+
+      const { metadata } = extractEditorMetadataFromDsl(dsl);
+
+      assert(metadata === null, 'metadata in middle should not be extracted');
+    });
+
+    // appendEditorMetadataToDsl tests
+    test('appendEditorMetadataToDsl: appends metadata to DSL', () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.35)
+render bar(width: wave)`;
+      const metadata = { version: 1, layout: { nodes: { wave: { x: 120, y: 80 } } } };
+
+      const result = appendEditorMetadataToDsl(dsl, metadata);
+
+      assert(result.includes('# @loomlet.editor'), 'should contain metadata marker');
+      assert(result.includes('"version":1'), 'should contain version');
+      assert(result.includes('"x":120'), 'should contain x position');
+      assert(result.includes('"y":80'), 'should contain y position');
+    });
+
+    test('appendEditorMetadataToDsl: replaces existing metadata', () => {
+      const dsl = `t = clock()
+# @loomlet.editor {"version":1,"layout":{"nodes":{"wave":{"x":50,"y":50}}}}`;
+      const newMetadata = { version: 1, layout: { nodes: { wave: { x: 120, y: 80 } } } };
+
+      const result = appendEditorMetadataToDsl(dsl, newMetadata);
+
+      assert(result.includes('"x":120'), 'should have new x value');
+      assert(!result.includes('"x":50'), 'should not have old x value');
+    });
+
+    test('appendEditorMetadataToDsl: does not duplicate metadata', () => {
+      const dsl = `t = clock()
+# @loomlet.editor {"version":1}`;
+      const metadata = { version: 1, layout: { nodes: {} } };
+
+      const result = appendEditorMetadataToDsl(dsl, metadata);
+      const metadataCount = (result.match(/# @loomlet.editor/g) || []).length;
+
+      assert(metadataCount === 1, 'metadata should appear exactly once');
+    });
+
+    // createEditorLayoutMetadata tests
+    test('createEditorLayoutMetadata: creates metadata from editor model', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 } },
+          t: { id: 't', type: 'clock', category: 'input', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['t', 'wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.version, 1, 'version should be 1');
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80 }, 'wave position');
+      assertEqual(metadata.layout.nodes.t, { x: 0, y: 0 }, 't position');
+    });
+
+    test('createEditorLayoutMetadata: ignores nodes without valid positions', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 } },
+          t: { id: 't', type: 'clock', category: 'input', position: null }
+        },
+        edgesById: {},
+        order: ['t', 'wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80 }, 'wave should be included');
+      assert(!('t' in metadata.layout.nodes), 't should not be in metadata');
+    });
+
+    test('createEditorLayoutMetadata: handles empty editor model', () => {
+      const metadata = createEditorLayoutMetadata({});
+
+      assertEqual(metadata, { version: 1, layout: { nodes: {} } }, 'empty model');
+    });
+
+    // applyLayoutMetadataToEditorModel tests
+    test('applyLayoutMetadataToEditorModel: applies positions from metadata', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 0, y: 0 } },
+          t: { id: 't', type: 'clock', category: 'input', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['t', 'wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80 },
+            t: { x: 10, y: 20 }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(result.nodesById.wave.position, { x: 120, y: 80 }, 'wave position');
+      assertEqual(result.nodesById.t.position, { x: 10, y: 20 }, 't position');
+    });
+
+    test('applyLayoutMetadataToEditorModel: preserves positions for non-matching ids', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 50, y: 50 } },
+          t: { id: 't', type: 'clock', category: 'input', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['t', 'wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80 }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(result.nodesById.wave.position, { x: 120, y: 80 }, 'wave position from metadata');
+      assertEqual(result.nodesById.t.position, { x: 0, y: 0 }, 't position preserved');
+    });
+
+    test('applyLayoutMetadataToEditorModel: ignores metadata for deleted nodes', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80 },
+            deleted: { x: 200, y: 200 }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(result.nodesById.wave.position, { x: 120, y: 80 }, 'wave position');
+      assert(!('deleted' in result.nodesById), 'deleted should not be in result');
+    });
+
+    async function run() {
+      let pass = 0; let fail = 0; const failures = [];
+      for (const t of results) {
+        try { await t.fn(); pass++; }
+        catch (e) { fail++; failures.push({ name: t.name, error: e.message }); }
+      }
+      window.__loomTestResults = { pass, fail, failures };
+      const html = `<strong>${pass} passed, ${fail} failed</strong>`;
+      if (failures.length > 0) {
+        const failureHtml = failures.map(f => `<div style="color:red;"><strong>${f.name}</strong>: ${f.error}</div>`).join('');
+        document.getElementById('results').innerHTML = html + failureHtml;
+      } else {
+        document.getElementById('results').innerHTML = html;
+      }
+    }
+    run();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds functionality to persist and restore node layout positions in the editor by embedding metadata in DSL comments. Node positions are now saved alongside the DSL code and automatically restored when files are loaded.

## Key Changes
- **New `editor-metadata.js` module** with four core functions:
  - `extractEditorMetadataFromDsl()`: Parses metadata from DSL comment blocks at end of file
  - `appendEditorMetadataToDsl()`: Embeds layout metadata into DSL as JSON in comments
  - `createEditorLayoutMetadata()`: Generates metadata from current editor model state
  - `applyLayoutMetadataToEditorModel()`: Restores node positions from metadata to editor model

- **Updated `main.js`** to integrate metadata handling:
  - `getCurrentSavePayload()`: Now extracts existing metadata, creates fresh layout metadata, and appends it to saved DSL
  - `applyDslTextToGraph()`: Extracts metadata from loaded DSL and applies positions to editor model
  - `syncGraphToDslEditor()`: Appends current layout metadata when syncing graph changes to DSL editor

- **Comprehensive test suite** (`editor-metadata.test.html`) covering:
  - Metadata extraction from DSL with validation
  - Metadata appending and replacement
  - Layout metadata creation from editor models
  - Position restoration with edge cases (deleted nodes, missing positions, etc.)

## Implementation Details
- Metadata is stored as JSON in a comment line with prefix `# @loomlet.editor` at the end of DSL files
- Only metadata at the end of file is extracted (after last non-comment code)
- Invalid JSON metadata is gracefully ignored, falling back to default behavior
- Node positions are only persisted if they have valid finite x/y coordinates
- Metadata application preserves existing positions for nodes not in metadata

https://claude.ai/code/session_019aGMxdKJiYpNkssWNuvPrS