### PR TITLE
Refactor editor metadata handling to prevent duplication on save

### DIFF
--- a/editor-studio/src/editor-metadata.js
+++ b/editor-studio/src/editor-metadata.js
@@ -107,3 +107,8 @@ export function applyLayoutMetadataToEditorModel(editorModel, metadata) {
     nodesById
   };
 }
+
+export function stripEditorMetadataFromDsl(sourceText) {
+  const { textWithoutMetadata } = extractEditorMetadataFromDsl(sourceText);
+  return textWithoutMetadata;
+}

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -31,7 +31,8 @@ import {
   extractEditorMetadataFromDsl,
   appendEditorMetadataToDsl,
   createEditorLayoutMetadata,
-  applyLayoutMetadataToEditorModel
+  applyLayoutMetadataToEditorModel,
+  stripEditorMetadataFromDsl
 } from './editor-metadata.js';
 
 const SAMPLE_DSL = `t = clock()
@@ -592,6 +593,16 @@ function downloadTextFile(text, filename) {
   URL.revokeObjectURL(url);
 }
 
+function createDslTextForSave(baseDslText) {
+  const state = store.getState();
+
+  if (!state.editorModel) return baseDslText;
+
+  const cleanDsl = stripEditorMetadataFromDsl(baseDslText);
+  const metadata = createEditorLayoutMetadata(state.editorModel);
+  return appendEditorMetadataToDsl(cleanDsl, metadata);
+}
+
 function getCurrentSavePayload() {
   const state = store.getState();
   let text = '';
@@ -609,9 +620,7 @@ function getCurrentSavePayload() {
     source = 'dsl';
   }
 
-  const { textWithoutMetadata } = extractEditorMetadataFromDsl(text);
-  const metadata = createEditorLayoutMetadata(state.editorModel);
-  const textWithMetadata = appendEditorMetadataToDsl(textWithoutMetadata, metadata);
+  const textWithMetadata = createDslTextForSave(text);
 
   return {
     text: textWithMetadata,
@@ -643,7 +652,6 @@ async function saveDslAsFile() {
 
       currentFileHandle = handle;
       currentFileName = handle.name || 'loomlet-scene.loom';
-      setDslText(text);
 
       if (payload.source === 'graph') {
         hasUnsyncedDslText = false;
@@ -681,8 +689,6 @@ async function saveDslFile() {
     await writable.write(text);
     await writable.close();
 
-    setDslText(text);
-
     if (payload.source === 'graph') {
       hasUnsyncedDslText = false;
     }
@@ -693,6 +699,20 @@ async function saveDslFile() {
     if (isAbortError(error)) return;
     setEditorError(`Save failed: ${error.message}`);
   }
+}
+
+async function applyEditorMetadataToCurrentModel(metadata) {
+  const state = store.getState();
+  if (!state.editorModel) return;
+
+  const editorModel = applyLayoutMetadataToEditorModel(state.editorModel, metadata);
+
+  store.setState({ editorModel });
+  await nodeEditor?.renderModel(editorModel, { force: true });
+  renderGraphJSON(store.getState().graph);
+  renderInspector();
+  updateNodeListCategories();
+  renderNodeList();
 }
 
 async function openLoomFile() {
@@ -719,10 +739,16 @@ async function openLoomFile() {
       const file = await handle.getFile();
       const text = await file.text();
 
-      setDslText(text);
+      const { textWithoutMetadata, metadata } = extractEditorMetadataFromDsl(text);
+      setDslText(textWithoutMetadata);
       currentFileHandle = handle;
       currentFileName = handle.name;
-      await applyDsl({ markDirty: false });
+      const result = await applyDsl({ markDirty: false });
+
+      if (result.ok && metadata) {
+        await applyEditorMetadataToCurrentModel(metadata);
+      }
+
       hasUnsyncedDslText = false;
       setDirty(false);
       clearEditorHistory();
@@ -738,10 +764,16 @@ async function openLoomFile() {
       if (!file) return;
 
       const text = await file.text();
-      setDslText(text);
+      const { textWithoutMetadata, metadata } = extractEditorMetadataFromDsl(text);
+      setDslText(textWithoutMetadata);
       currentFileName = file.name;
       currentFileHandle = null;
-      await applyDsl({ markDirty: false });
+      const result = await applyDsl({ markDirty: false });
+
+      if (result.ok && metadata) {
+        await applyEditorMetadataToCurrentModel(metadata);
+      }
+
       hasUnsyncedDslText = false;
       setDirty(false);
       clearEditorHistory();
@@ -810,7 +842,7 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
   }
 
   store.setState({
-    sourceText,
+    sourceText: textWithoutMetadata,
     sourceAst: ast,
     graph,
     editorModel,
@@ -830,7 +862,7 @@ async function applyDslTextToGraph(sourceText, { markDirty = true, preserveGraph
   runPreview(graph);
 
   hasUnsyncedDslText = false;
-  latestSuccessfulDslText = sourceText;
+  latestSuccessfulDslText = textWithoutMetadata;
 
   if (markDirty) setDirty(true);
 
@@ -876,13 +908,7 @@ function generateCanonicalDslFromState() {
 function syncGraphToDslEditor({ markDirty = true, force = false } = {}) {
   if (!force && !autoSyncGraphToDslEnabled) return null;
 
-  let dsl = generateCanonicalDslFromState();
-  const state = store.getState();
-
-  if (state.editorModel) {
-    const metadata = createEditorLayoutMetadata(state.editorModel);
-    dsl = appendEditorMetadataToDsl(dsl, metadata);
-  }
+  const dsl = generateCanonicalDslFromState();
 
   setDslText(dsl);
 

--- a/test/editor-metadata.test.html
+++ b/test/editor-metadata.test.html
@@ -12,7 +12,8 @@
       extractEditorMetadataFromDsl,
       appendEditorMetadataToDsl,
       createEditorLayoutMetadata,
-      applyLayoutMetadataToEditorModel
+      applyLayoutMetadataToEditorModel,
+      stripEditorMetadataFromDsl
     } from "../editor-studio/src/editor-metadata.js";
 
     const results = [];
@@ -71,6 +72,40 @@ wave = sine(t, freq: 0.35)`;
       assert(metadata === null, 'metadata in middle should not be extracted');
     });
 
+    // stripEditorMetadataFromDsl tests
+    test('stripEditorMetadataFromDsl: removes trailing metadata comment', () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.35)
+render bar(width: wave)
+
+# @loomlet.editor {"version":1,"layout":{"nodes":{"wave":{"x":120,"y":80}}}}`;
+
+      const result = stripEditorMetadataFromDsl(dsl);
+
+      assert(result.includes('t = clock()'), 'should contain original code');
+      assert(result.includes('render bar(width: wave)'), 'should contain render statement');
+      assert(!result.includes('@loomlet.editor'), 'should not contain metadata');
+    });
+
+    test('stripEditorMetadataFromDsl: returns unchanged DSL if no metadata', () => {
+      const dsl = `t = clock()
+wave = sine(t, freq: 0.35)
+render bar(width: wave)`;
+
+      const result = stripEditorMetadataFromDsl(dsl);
+
+      assertEqual(result, dsl, 'should return DSL unchanged');
+    });
+
+    test('stripEditorMetadataFromDsl: handles invalid metadata gracefully', () => {
+      const dsl = `t = clock()
+# @loomlet.editor {invalid json}`;
+
+      const result = stripEditorMetadataFromDsl(dsl);
+
+      assertEqual(result, dsl, 'should return DSL unchanged when metadata is invalid');
+    });
+
     // appendEditorMetadataToDsl tests
     test('appendEditorMetadataToDsl: appends metadata to DSL', () => {
       const dsl = `t = clock()
@@ -106,6 +141,25 @@ render bar(width: wave)`;
       const metadataCount = (result.match(/# @loomlet.editor/g) || []).length;
 
       assert(metadataCount === 1, 'metadata should appear exactly once');
+    });
+
+    test('stripEditorMetadataFromDsl + appendEditorMetadataToDsl: does not duplicate after multiple saves', () => {
+      const original = `t = clock()
+wave = sine(t, freq: 0.35)
+render bar(width: wave)`;
+      const metadata = { version: 1, layout: { nodes: { wave: { x: 120, y: 80 } } } };
+
+      let result = appendEditorMetadataToDsl(original, metadata);
+      let metadataCount = (result.match(/# @loomlet.editor/g) || []).length;
+      assert(metadataCount === 1, 'first save should have one metadata comment');
+
+      result = appendEditorMetadataToDsl(stripEditorMetadataFromDsl(result), metadata);
+      metadataCount = (result.match(/# @loomlet.editor/g) || []).length;
+      assert(metadataCount === 1, 'second save should still have exactly one metadata comment');
+
+      result = appendEditorMetadataToDsl(stripEditorMetadataFromDsl(result), metadata);
+      metadataCount = (result.match(/# @loomlet.editor/g) || []).length;
+      assert(metadataCount === 1, 'third save should still have exactly one metadata comment');
     });
 
     // createEditorLayoutMetadata tests


### PR DESCRIPTION
## Summary
This PR refactors how editor metadata is handled during save and load operations to prevent metadata duplication and improve separation of concerns. The changes ensure that metadata is stripped before being re-applied, maintaining a clean DSL text internally while preserving layout information across save/load cycles.

## Key Changes

- **New `stripEditorMetadataFromDsl()` function**: Extracts and removes editor metadata comments from DSL text, enabling clean separation of DSL code from layout metadata
- **New `createDslTextForSave()` function**: Centralizes the logic for preparing DSL text for saving by stripping old metadata and appending fresh metadata based on current editor state
- **New `applyEditorMetadataToCurrentModel()` function**: Applies loaded metadata to the editor model after DSL parsing, ensuring layout information is restored when opening files
- **Refactored save operations**: Both `saveDslAsFile()` and `saveDslFile()` now use `createDslTextForSave()` and no longer call `setDslText()` with metadata-embedded text, preventing metadata duplication
- **Improved file loading**: `openLoomFile()` now extracts metadata from loaded files and applies it to the editor model after DSL parsing, restoring layout state
- **Cleaner internal state**: `sourceText` in store now contains only DSL code without metadata, while metadata is managed separately through the editor model
- **Simplified graph sync**: `syncGraphToDslEditor()` no longer manually appends metadata, relying instead on the save pipeline to handle it

## Implementation Details

- The refactoring maintains backward compatibility by gracefully handling DSL files without metadata
- Metadata is now applied asynchronously after DSL parsing completes, ensuring the graph is fully initialized before layout adjustments
- Tests added to verify metadata is not duplicated across multiple save cycles
- The changes follow a cleaner separation: DSL text is kept clean internally, metadata is embedded only when saving to files

https://claude.ai/code/session_013upCYvce8MHZR8GvbK8kMd