### PR TITLE
Improve node selection UX with keyboard shortcuts and focus feedback

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -365,6 +365,11 @@ function selectBottomTab(tabName) {
   localStorage.setItem(ACTIVE_BOTTOM_TAB_KEY, tabName);
 }
 
+function getActiveBottomTab() {
+  const activeButton = document.querySelector('.tab-btn.active');
+  return activeButton?.getAttribute('data-tab') || null;
+}
+
 function loadActiveBottomTab() {
   const savedTab = localStorage.getItem(ACTIVE_BOTTOM_TAB_KEY);
   if (!savedTab) return;
@@ -1065,6 +1070,7 @@ function setSelectedNodeId(nodeId) {
     selectedNodeId = nodeId || null;
   }
   renderInspector();
+  renderNodeList();
 }
 
 function setEditorError(message) {
@@ -1483,6 +1489,19 @@ function renderNodeListItem(node) {
   `;
 }
 
+function scrollSelectedNodeListItemIntoView() {
+  if (!elements.nodeList || !selectedNodeId) return;
+
+  const item = elements.nodeList.querySelector(
+    `[data-node-id="${CSS.escape(selectedNodeId)}"]`
+  );
+
+  item?.scrollIntoView({
+    block: 'nearest',
+    inline: 'nearest'
+  });
+}
+
 function renderNodeList() {
   const list = elements.nodeList;
   if (!list) return;
@@ -1521,7 +1540,6 @@ function renderNodeList() {
       if (e.target.classList.contains('btn-focus-node')) return;
       const nodeId = item.getAttribute('data-node-id');
       setSelectedNodeId(nodeId);
-      renderNodeList();
     });
   });
 
@@ -1529,12 +1547,24 @@ function renderNodeList() {
     btn.addEventListener('click', async () => {
       const nodeId = btn.getAttribute('data-focus-node-id');
       setSelectedNodeId(nodeId);
-      renderNodeList();
       if (nodeEditor?.focusNode) {
-        await nodeEditor.focusNode(nodeId);
+        try {
+          await nodeEditor.focusNode(nodeId);
+          const item = list.querySelector(`[data-node-id="${CSS.escape(nodeId)}"]`);
+          if (item) {
+            item.classList.add('is-focused-pulse');
+            setTimeout(() => {
+              item.classList.remove('is-focused-pulse');
+            }, 800);
+          }
+        } catch (err) {
+          console.error('Focus node error:', err);
+        }
       }
     });
   });
+
+  scrollSelectedNodeListItemIntoView();
 }
 
 function updateNodeListCategories() {
@@ -1680,6 +1710,26 @@ function isTextEditingTarget(target) {
 }
 
 function handleGlobalKeyDown(event) {
+  // Handle node search focus with Cmd/Ctrl+Shift+F or /
+  if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'f') {
+    if (!isTextEditingTarget(event.target)) {
+      event.preventDefault();
+      selectBottomTab('nodes');
+      elements.nodeListSearch?.focus();
+      return;
+    }
+  }
+
+  if (event.key === '/' && !isTextEditingTarget(event.target)) {
+    const activeTab = getActiveBottomTab();
+    if (activeTab === 'nodes') {
+      event.preventDefault();
+      elements.nodeListSearch?.focus();
+      return;
+    }
+  }
+
+  // Handle node deletion with Delete/Backspace
   if (event.key !== 'Delete' && event.key !== 'Backspace') return;
   if (!selectedNodeId) return;
   if (isTextEditingTarget(event.target)) return;

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1489,13 +1489,17 @@ function renderNodeListItem(node) {
   `;
 }
 
+function findNodeListItemById(nodeId) {
+  if (!elements.nodeList || !nodeId) return null;
+
+  return Array.from(elements.nodeList.querySelectorAll('[data-node-id]'))
+    .find((item) => item.getAttribute('data-node-id') === nodeId) || null;
+}
+
 function scrollSelectedNodeListItemIntoView() {
-  if (!elements.nodeList || !selectedNodeId) return;
+  if (!selectedNodeId) return;
 
-  const item = elements.nodeList.querySelector(
-    `[data-node-id="${CSS.escape(selectedNodeId)}"]`
-  );
-
+  const item = findNodeListItemById(selectedNodeId);
   item?.scrollIntoView({
     block: 'nearest',
     inline: 'nearest'
@@ -1550,7 +1554,7 @@ function renderNodeList() {
       if (nodeEditor?.focusNode) {
         try {
           await nodeEditor.focusNode(nodeId);
-          const item = list.querySelector(`[data-node-id="${CSS.escape(nodeId)}"]`);
+          const item = findNodeListItemById(nodeId);
           if (item) {
             item.classList.add('is-focused-pulse');
             setTimeout(() => {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -946,6 +946,22 @@ button:disabled:hover,
   transform: scale(0.95);
 }
 
+.node-list-item.is-focused-pulse {
+  animation: nodeFocusPulse 0.8s ease-out;
+}
+
+@keyframes nodeFocusPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(74, 144, 226, 0.7);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(74, 144, 226, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(74, 144, 226, 0);
+  }
+}
+
 .empty-state {
   padding: 16px;
   color: rgba(255, 255, 255, 0.58);


### PR DESCRIPTION
## Summary
This PR enhances the node selection and navigation experience by adding keyboard shortcuts for node search, visual feedback when focusing nodes, and improved state management for the node list.

## Key Changes
- **Keyboard shortcuts for node search**: Added `Cmd/Ctrl+Shift+F` and `/` (when on nodes tab) to quickly focus the node search input
- **Node focus visual feedback**: Added a pulse animation (`is-focused-pulse`) that plays when a node is focused via the focus button
- **Improved node list rendering**: 
  - Added `renderNodeList()` call in `setSelectedNodeId()` to keep the UI in sync when selection changes
  - Removed redundant `renderNodeList()` calls from click handlers since `setSelectedNodeId()` now handles it
  - Added `scrollSelectedNodeListItemIntoView()` to automatically scroll the selected node into view
- **Better error handling**: Wrapped `nodeEditor.focusNode()` in try-catch to gracefully handle focus errors
- **New utility functions**:
  - `getActiveBottomTab()`: Returns the currently active bottom tab name
  - `scrollSelectedNodeListItemIntoView()`: Auto-scrolls selected node item into viewport

## Implementation Details
- The pulse animation uses a box-shadow expanding effect with a 0.8s duration for smooth visual feedback
- Keyboard shortcuts respect text editing contexts via `isTextEditingTarget()` to avoid interfering with text input
- The `/` shortcut only activates when the nodes tab is already active, preventing accidental triggers in other contexts
- Node list item scrolling uses `block: 'nearest'` and `inline: 'nearest'` for minimal viewport disruption

https://claude.ai/code/session_013bZjMHuqjiyRWhjDwQzjhd