### PR TITLE
Add label and comment metadata support for nodes

### DIFF
--- a/editor-studio/src/editor-metadata.js
+++ b/editor-studio/src/editor-metadata.js
@@ -69,6 +69,14 @@ export function createEditorLayoutMetadata(editorModel) {
         x: node.position.x,
         y: node.position.y
       };
+
+      if (node.label) {
+        nodes[id].label = node.label;
+      }
+
+      if (node.comment) {
+        nodes[id].comment = node.comment;
+      }
     }
   }
 
@@ -88,18 +96,24 @@ export function applyLayoutMetadataToEditorModel(editorModel, metadata) {
 
   for (const [id, node] of Object.entries(editorModel.nodesById || {})) {
     const position = layoutNodes[id];
+    const updates = { ...node };
 
     if (
       Number.isFinite(position?.x) &&
       Number.isFinite(position?.y)
     ) {
-      nodesById[id] = {
-        ...node,
-        position: { x: position.x, y: position.y }
-      };
-    } else {
-      nodesById[id] = node;
+      updates.position = { x: position.x, y: position.y };
     }
+
+    if (position?.label) {
+      updates.label = position.label;
+    }
+
+    if (position?.comment) {
+      updates.comment = position.comment;
+    }
+
+    nodesById[id] = updates;
   }
 
   return {

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1180,6 +1180,30 @@ function renderInspector() {
       </div>
 
       <div class="inspector-section">
+        <div class="inspector-row">
+          <label class="inspector-label" for="selected-node-label-input">Label:</label>
+          <input
+            id="selected-node-label-input"
+            class="inspector-input"
+            type="text"
+            value="${escapeHtml(node.label || '')}"
+            placeholder="Optional display label"
+            spellcheck="false"
+          />
+        </div>
+        <div class="inspector-row">
+          <label class="inspector-label" for="selected-node-comment-input">Comment:</label>
+          <textarea
+            id="selected-node-comment-input"
+            class="inspector-input"
+            placeholder="Optional note"
+            rows="3"
+            spellcheck="true"
+          >${escapeHtml(node.comment || '')}</textarea>
+        </div>
+      </div>
+
+      <div class="inspector-section">
         <div class="inspector-label" style="margin-bottom: 8px;">Params:</div>
   `;
 
@@ -1307,6 +1331,16 @@ function attachInspectorActionListeners() {
     renameSelectedNode();
   });
 
+  const labelInput = elements.inspectorPanel.querySelector('#selected-node-label-input');
+  labelInput?.addEventListener('change', (event) => {
+    applyNodeMetadataEdit('label', event.target.value.trim() || null);
+  });
+
+  const commentInput = elements.inspectorPanel.querySelector('#selected-node-comment-input');
+  commentInput?.addEventListener('change', (event) => {
+    applyNodeMetadataEdit('comment', event.target.value.trim() || null);
+  });
+
   elements.inspectorPanel
     .querySelectorAll('[data-remove-edge-id]')
     .forEach((button) => {
@@ -1358,6 +1392,18 @@ function applyParamEdit(key, value) {
     id: selectedNodeId,
     key,
     value
+  });
+}
+
+function applyNodeMetadataEdit(field, value) {
+  if (!selectedNodeId) return;
+
+  handleOperation({
+    type: 'updateNodeMetadata',
+    id: selectedNodeId,
+    patch: {
+      [field]: value
+    }
   });
 }
 
@@ -1480,13 +1526,16 @@ async function resetSample() {
 function renderNodeListItem(node) {
   const isSelected = selectedNodeId === node.id;
   const selectedClass = isSelected ? ' selected' : '';
+  const commentIndicator = node.comment ? ' ●' : '';
+
+  const mainLabel = node.label || node.id;
+  const subtitle = node.label ? node.id : `${node.type} • ${node.category}`;
 
   return `
     <div class="node-list-item${selectedClass}" data-node-id="${escapeHtml(node.id)}">
       <div class="node-list-item-content">
-        <div class="node-list-item-id">${escapeHtml(node.id)}</div>
-        <div class="node-list-item-type">${escapeHtml(node.type)}</div>
-        <div class="node-list-item-category">${escapeHtml(node.category)}</div>
+        <div class="node-list-item-label">${escapeHtml(mainLabel)}</div>
+        <div class="node-list-item-subtitle">${escapeHtml(subtitle)}${commentIndicator}</div>
       </div>
       <button class="btn-focus-node" data-focus-node-id="${escapeHtml(node.id)}" title="Focus on node">Focus</button>
     </div>
@@ -1532,7 +1581,9 @@ function renderNodeList() {
     return (
       node.id.toLowerCase().includes(query) ||
       node.type.toLowerCase().includes(query) ||
-      node.category.toLowerCase().includes(query)
+      node.category.toLowerCase().includes(query) ||
+      (node.label && node.label.toLowerCase().includes(query)) ||
+      (node.comment && node.comment.toLowerCase().includes(query))
     );
   });
 
@@ -2142,15 +2193,22 @@ async function handleOperation(operation) {
       selectedNodeId = null;
     }
 
-    renderGraphJSON(result.state.graph);
+    const affectsDsl = result.change.affectsDsl !== false;
+
+    if (affectsDsl) {
+      renderGraphJSON(result.state.graph);
+      runPreview(result.state.graph);
+      hasUnsyncedDslText = false;
+      cancelPendingAutoApplyDsl();
+      syncGraphToDslEditor({ markDirty: true });
+    } else {
+      renderGraphJSON(result.state.graph);
+    }
+
     renderErrors();
     renderInspector();
     updateNodeListCategories();
     renderNodeList();
-    runPreview(result.state.graph);
-    hasUnsyncedDslText = false;
-    cancelPendingAutoApplyDsl();
-    syncGraphToDslEditor({ markDirty: true });
     setDirty(true);
 
     if (shouldPushHistory) {

--- a/editor-studio/src/node-editor-view-diff.js
+++ b/editor-studio/src/node-editor-view-diff.js
@@ -33,6 +33,7 @@ export function getRemovedEdgeIds(previous, next) {
 export function shouldRecreateNode(previousNode, nextNode) {
   if (previousNode.type !== nextNode.type) return true;
   if (previousNode.category !== nextNode.category) return true;
+  if ((previousNode.label || '') !== (nextNode.label || '')) return true;
 
   const prevParamKeys = Object.keys(previousNode.params || {}).sort();
   const nextParamKeys = Object.keys(nextNode.params || {}).sort();

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -29,8 +29,10 @@ function getPortName(port) {
 
 function createReteNode(editorNode, onControl) {
   const nodeTypeDef = NODE_TYPES[editorNode.type];
-  const node = new ClassicPreset.Node(editorNode.type);
+  const displayLabel = editorNode.label || editorNode.type;
+  const node = new ClassicPreset.Node(displayLabel);
   node.id = editorNode.id;
+  node._editorNode = editorNode;
 
   if (nodeTypeDef) {
     for (const input of nodeTypeDef.inputs || []) {

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -226,19 +226,25 @@ export function preserveEditorModelLayout(nextEditorModel, previousEditorModel) 
   const nodesById = {};
   for (const [id, node] of Object.entries(nextEditorModel.nodesById || {})) {
     const previousNode = previousEditorModel.nodesById?.[id];
+    const nextNode = { ...node };
 
     if (
       previousNode?.position &&
       Number.isFinite(previousNode.position.x) &&
       Number.isFinite(previousNode.position.y)
     ) {
-      nodesById[id] = {
-        ...node,
-        position: { ...previousNode.position }
-      };
-    } else {
-      nodesById[id] = node;
+      nextNode.position = { ...previousNode.position };
     }
+
+    if (typeof previousNode?.label === 'string' && previousNode.label !== '') {
+      nextNode.label = previousNode.label;
+    }
+
+    if (typeof previousNode?.comment === 'string' && previousNode.comment !== '') {
+      nextNode.comment = previousNode.comment;
+    }
+
+    nodesById[id] = nextNode;
   }
 
   return {

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -347,5 +347,31 @@ export function applyEditorOperation(em, op) {
     return next;
   }
 
+  if (op.type === 'updateNodeMetadata') {
+    const node = next.nodesById[op.id];
+    if (!node) throw new Error(`Node '${op.id}' does not exist`);
+
+    const updated = { ...node };
+    if (op.patch) {
+      if ('label' in op.patch) {
+        if (op.patch.label) {
+          updated.label = op.patch.label;
+        } else {
+          delete updated.label;
+        }
+      }
+      if ('comment' in op.patch) {
+        if (op.patch.comment) {
+          updated.comment = op.patch.comment;
+        } else {
+          delete updated.comment;
+        }
+      }
+    }
+
+    next.nodesById[op.id] = updated;
+    return next;
+  }
+
   throw new Error(`Unknown operation type: ${op.type}`);
 }

--- a/src/node-editor-session.js
+++ b/src/node-editor-session.js
@@ -47,6 +47,25 @@ function rewriteGraphReferencesForRename(graph, oldId, newId) {
 export function applyNodeEditorOperationState(state, operation) {
   try {
     const editorModel = applyEditorOperation(state.editorModel, operation);
+
+    // For metadata-only operations, don't regenerate the graph
+    if (operation.type === 'updateNodeMetadata') {
+      return {
+        state: {
+          ...state,
+          editorModel,
+          errors: []
+        },
+        change: {
+          operation,
+          graphChanged: false,
+          shouldRerenderView: true,
+          affectsDsl: false
+        },
+        error: null
+      };
+    }
+
     let graph = editorModelToGraph(editorModel, state.graph);
 
     if (operation.type === 'renameNode') {

--- a/test/editor-metadata.test.html
+++ b/test/editor-metadata.test.html
@@ -276,6 +276,171 @@ render bar(width: wave)`;
       assert(!('deleted' in result.nodesById), 'deleted should not be in result');
     });
 
+    // Label and Comment tests
+    test('createEditorLayoutMetadata: includes label when present', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 }, label: 'Wave Output' }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80, label: 'Wave Output' }, 'should include label');
+    });
+
+    test('createEditorLayoutMetadata: includes comment when present', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 }, comment: 'Produces a sine wave' }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80, comment: 'Produces a sine wave' }, 'should include comment');
+    });
+
+    test('createEditorLayoutMetadata: includes both label and comment', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 }, label: 'Wave Output', comment: 'Main sine wave' }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80, label: 'Wave Output', comment: 'Main sine wave' }, 'should include both label and comment');
+    });
+
+    test('createEditorLayoutMetadata: omits empty label and comment', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 }, label: '', comment: '' }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80 }, 'should not include empty label and comment');
+    });
+
+    test('createEditorLayoutMetadata: omits undefined label and comment', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 120, y: 80 } }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+
+      const metadata = createEditorLayoutMetadata(editorModel);
+
+      assertEqual(metadata.layout.nodes.wave, { x: 120, y: 80 }, 'should not include undefined label and comment');
+    });
+
+    test('applyLayoutMetadataToEditorModel: restores label', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80, label: 'Wave Output' }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(result.nodesById.wave.label, 'Wave Output', 'label should be restored');
+      assertEqual(result.nodesById.wave.position, { x: 120, y: 80 }, 'position should also be restored');
+    });
+
+    test('applyLayoutMetadataToEditorModel: restores comment', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80, comment: 'Produces a sine wave' }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(result.nodesById.wave.comment, 'Produces a sine wave', 'comment should be restored');
+      assertEqual(result.nodesById.wave.position, { x: 120, y: 80 }, 'position should also be restored');
+    });
+
+    test('applyLayoutMetadataToEditorModel: restores label and comment together', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80, label: 'Wave Output', comment: 'Produces a sine wave' }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(result.nodesById.wave.label, 'Wave Output', 'label should be restored');
+      assertEqual(result.nodesById.wave.comment, 'Produces a sine wave', 'comment should be restored');
+      assertEqual(result.nodesById.wave.position, { x: 120, y: 80 }, 'position should also be restored');
+    });
+
+    test('applyLayoutMetadataToEditorModel: does not create unknown nodes from metadata', () => {
+      const editorModel = {
+        nodesById: {
+          wave: { id: 'wave', type: 'sine', category: 'transform', position: { x: 0, y: 0 } }
+        },
+        edgesById: {},
+        order: ['wave']
+      };
+      const metadata = {
+        version: 1,
+        layout: {
+          nodes: {
+            wave: { x: 120, y: 80 },
+            unknown: { x: 200, y: 200, label: 'Unknown Node' }
+          }
+        }
+      };
+
+      const result = applyLayoutMetadataToEditorModel(editorModel, metadata);
+
+      assertEqual(Object.keys(result.nodesById).length, 1, 'should only have one node');
+      assert(!('unknown' in result.nodesById), 'unknown node should not be created');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -339,6 +339,72 @@
       assertEqual(JSON.stringify(laid1), JSON.stringify(laid2));
     });
 
+    test('25. updateNodeMetadata updates label', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { label: 'My Wave' } });
+      assertEqual(next.nodesById.wave.label, 'My Wave');
+      assertEqual(next.nodesById.wave.type, 'sine', 'type should be unchanged');
+      assertEqual(next.nodesById.wave.params, em.nodesById.wave.params, 'params should be unchanged');
+    });
+
+    test('26. updateNodeMetadata updates comment', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { comment: 'Produces sine output' } });
+      assertEqual(next.nodesById.wave.comment, 'Produces sine output');
+      assertEqual(next.nodesById.wave.type, 'sine', 'type should be unchanged');
+    });
+
+    test('27. updateNodeMetadata updates both label and comment', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const next = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { label: 'My Wave', comment: 'Produces sine output' } });
+      assertEqual(next.nodesById.wave.label, 'My Wave');
+      assertEqual(next.nodesById.wave.comment, 'Produces sine output');
+    });
+
+    test('28. updateNodeMetadata clears label when set to empty', () => {
+      let em = graphToEditorModel(sampleGraph());
+      em = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { label: 'My Wave' } });
+      const next = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { label: '' } });
+      assert(!('label' in next.nodesById.wave) || next.nodesById.wave.label === '', 'label should be empty or deleted');
+    });
+
+    test('29. updateNodeMetadata clears comment when set to empty', () => {
+      let em = graphToEditorModel(sampleGraph());
+      em = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { comment: 'My comment' } });
+      const next = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { comment: '' } });
+      assert(!('comment' in next.nodesById.wave) || next.nodesById.wave.comment === '', 'comment should be empty or deleted');
+    });
+
+    test('30. editorModelToGraph does not leak label into execution graph', () => {
+      let em = graphToEditorModel(sampleGraph());
+      em = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { label: 'My Wave' } });
+      const g = editorModelToGraph(em);
+      const waveNode = g.nodes.find(n => n.id === 'wave');
+      assert(!('label' in waveNode), 'label should not be in execution graph node');
+      assert(waveNode.meta.position, 'position should be in meta');
+    });
+
+    test('31. editorModelToGraph does not leak comment into execution graph', () => {
+      let em = graphToEditorModel(sampleGraph());
+      em = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { comment: 'My comment' } });
+      const g = editorModelToGraph(em);
+      const waveNode = g.nodes.find(n => n.id === 'wave');
+      assert(!('comment' in waveNode), 'comment should not be in execution graph node');
+    });
+
+    test('32. updateNodeMetadata throws for non-existent node', () => {
+      const em = graphToEditorModel(sampleGraph());
+      assertThrows(() => applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'nonexistent', patch: { label: 'test' } }));
+    });
+
+    test('33. updateNodeMetadata is immutable', () => {
+      const em = graphToEditorModel(sampleGraph());
+      const before = JSON.stringify(em);
+      const next = applyEditorOperation(em, { type: 'updateNodeMetadata', id: 'wave', patch: { label: 'test' } });
+      assertEqual(JSON.stringify(em), before, 'input should not be modified');
+      assert(next !== em, 'should return new object');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {

--- a/test/loom-editor-model.test.html
+++ b/test/loom-editor-model.test.html
@@ -261,6 +261,84 @@
       assert(!merged.nodesById.old, 'removed node should not be restored');
     });
 
+    test('17b. preserveEditorModelLayout preserves label and comment for matching nodes', () => {
+      const previous = graphToEditorModel(sampleGraph());
+      previous.nodesById.wave = {
+        ...previous.nodesById.wave,
+        label: 'Wave Label',
+        comment: 'Wave comment',
+        position: { x: 123, y: 456 }
+      };
+
+      const next = graphToEditorModel(sampleGraph());
+      const preserved = preserveEditorModelLayout(next, previous);
+
+      assertEqual(preserved.nodesById.wave.label, 'Wave Label');
+      assertEqual(preserved.nodesById.wave.comment, 'Wave comment');
+      assertEqual(preserved.nodesById.wave.position, { x: 123, y: 456 });
+    });
+
+    test('17c. preserveEditorModelLayout preserves label only when present', () => {
+      const previous = graphToEditorModel(sampleGraph());
+      previous.nodesById.wave = {
+        ...previous.nodesById.wave,
+        label: 'My Label',
+        position: { x: 100, y: 200 }
+      };
+
+      const next = graphToEditorModel(sampleGraph());
+      const preserved = preserveEditorModelLayout(next, previous);
+
+      assertEqual(preserved.nodesById.wave.label, 'My Label');
+      assert(!('comment' in preserved.nodesById.wave), 'comment should not be set when not in previous');
+      assertEqual(preserved.nodesById.wave.position, { x: 100, y: 200 });
+    });
+
+    test('17d. preserveEditorModelLayout ignores empty label and comment', () => {
+      const previous = graphToEditorModel(sampleGraph());
+      previous.nodesById.wave = {
+        ...previous.nodesById.wave,
+        label: '',
+        comment: '',
+        position: { x: 100, y: 200 }
+      };
+
+      const next = graphToEditorModel(sampleGraph());
+      const preserved = preserveEditorModelLayout(next, previous);
+
+      assert(!('label' in preserved.nodesById.wave) || preserved.nodesById.wave.label !== '', 'empty label should not be preserved');
+      assert(!('comment' in preserved.nodesById.wave) || preserved.nodesById.wave.comment !== '', 'empty comment should not be preserved');
+      assertEqual(preserved.nodesById.wave.position, { x: 100, y: 200 });
+    });
+
+    test('17e. preserveEditorModelLayout does not resurrect removed nodes with label/comment', () => {
+      const previous = {
+        nodesById: {
+          old: {
+            id: 'old',
+            type: 'sine',
+            category: 'transform',
+            params: {},
+            position: { x: 1, y: 2 },
+            label: 'Old Label',
+            comment: 'Old Comment'
+          }
+        },
+        edgesById: {},
+        order: ['old']
+      };
+
+      const next = {
+        nodesById: {},
+        edgesById: {},
+        order: []
+      };
+
+      const merged = preserveEditorModelLayout(next, previous);
+
+      assert(!merged.nodesById.old, 'removed node should not be restored even with label/comment');
+    });
+
     test('18. doRectsOverlap detects overlapping rectangles', () => {
       const rect1 = { x: 0, y: 0, width: 100, height: 100 };
       const rect2 = { x: 50, y: 50, width: 100, height: 100 };


### PR DESCRIPTION
## Summary
This PR adds support for optional label and comment metadata on nodes, allowing users to add custom display names and notes to nodes in the editor. Labels and comments are preserved in the editor layout metadata and do not leak into the execution graph.

## Key Changes

- **Node Metadata Fields**: Added `label` and `comment` optional fields to nodes
  - `label`: Custom display name for a node (shown in inspector and node list)
  - `comment`: Optional note/documentation for a node (shown in inspector)

- **Inspector UI**: Added input fields in the node inspector panel for editing label and comment
  - Label input: text field with placeholder "Optional display label"
  - Comment input: textarea with 3 rows for longer notes

- **Node List Display**: Enhanced node list rendering to show labels and comments
  - Displays label as primary identifier if present, otherwise node ID
  - Shows node type and category as subtitle
  - Adds a dot indicator (●) when a node has a comment
  - Includes label and comment in search/filter functionality

- **Metadata Persistence**: Label and comment are saved in editor layout metadata
  - `createEditorLayoutMetadata()` now includes label and comment in serialized layout
  - `applyLayoutMetadataToEditorModel()` restores label and comment from metadata
  - Empty/undefined labels and comments are omitted from metadata

- **Editor Operations**: New `updateNodeMetadata` operation type
  - Allows updating label and/or comment independently
  - Validates that node exists before updating
  - Immutable operation (doesn't modify input)
  - Marked as `affectsDsl: false` to avoid unnecessary graph regeneration

- **Graph Isolation**: Metadata fields don't leak into execution graph
  - `editorModelToGraph()` filters out label and comment from execution nodes
  - Only position metadata is included in the execution graph

- **Performance**: Optimized operation handling
  - Metadata-only operations skip graph regeneration
  - Only rerenders UI views without regenerating DSL or execution graph

## Implementation Details

- Metadata edits trigger `applyNodeMetadataEdit()` which dispatches `updateNodeMetadata` operations
- Empty strings are treated as null/undefined to clear metadata
- Node list items now show a visual hierarchy: label/id → type/category with comment indicator
- All metadata operations are immutable and include comprehensive test coverage

https://claude.ai/code/session_01R4Tikh31xsh5WbbQEXXNbt