### PR TITLE
Fix node editor layout when maximizing DSL or node panes

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -318,6 +318,15 @@ function applyEditorMaximizeMode() {
   updateEditorMaximizeButtons();
 }
 
+function notifyNodeEditorLayoutChanged() {
+  window.requestAnimationFrame(() => {
+    window.dispatchEvent(new Event('resize'));
+    if (nodeEditor?.resize) {
+      nodeEditor.resize();
+    }
+  });
+}
+
 function setEditorMaximizeMode(mode) {
   if (!['split', 'dsl', 'node'].includes(mode)) return;
 
@@ -331,6 +340,7 @@ function setEditorMaximizeMode(mode) {
   }
 
   applyEditorMaximizeMode();
+  notifyNodeEditorLayoutChanged();
   saveEditorMaximizeMode();
 }
 

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -90,6 +90,11 @@ body.panels-hidden .editor-panels {
   grid-template-columns: 1fr;
 }
 
+.editor-panels.is-maximized-dsl .dsl-pane {
+  grid-column: 1;
+  grid-row: 1;
+}
+
 .editor-panels.is-maximized-dsl .node-pane,
 .editor-panels.is-maximized-dsl .editor-split-resize-handle {
   display: none;
@@ -97,6 +102,11 @@ body.panels-hidden .editor-panels {
 
 .editor-panels.is-maximized-node {
   grid-template-columns: 1fr;
+}
+
+.editor-panels.is-maximized-node .node-pane {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .editor-panels.is-maximized-node .dsl-pane,


### PR DESCRIPTION
## Summary
This PR fixes layout issues that occur when maximizing the DSL or node editor panes by ensuring the node editor is properly notified of layout changes and explicitly positioning maximized panes.

## Key Changes
- **Added `notifyNodeEditorLayoutChanged()` function**: Dispatches a resize event and calls the node editor's resize method on the next animation frame to ensure proper layout recalculation when the editor layout changes
- **Updated `setEditorMaximizeMode()`**: Now calls `notifyNodeEditorLayoutChanged()` after applying maximize mode changes
- **Enhanced CSS grid positioning**: Added explicit `grid-column` and `grid-row` properties to maximized panes (`.is-maximized-dsl .dsl-pane` and `.is-maximized-node .node-pane`) to ensure they properly occupy the full grid space

## Implementation Details
The resize notification uses `requestAnimationFrame` to defer the layout update until the next frame, ensuring the DOM has been updated with the new maximize mode classes before the node editor attempts to resize itself. This prevents timing issues where the node editor might calculate dimensions based on stale layout information.

https://claude.ai/code/session_011nMdzida9zGBStLt7jszLo