### PR TITLE
Improve node label and comment input handling with better commit logic

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1327,6 +1327,30 @@ async function renameSelectedNode() {
   }
 }
 
+function commitSelectedNodeLabel(input) {
+  const node = getSelectedEditorNode();
+  if (!node) return;
+
+  const nextLabel = input.value;
+  const currentLabel = node.label || '';
+
+  if (nextLabel === currentLabel) return;
+
+  applyNodeMetadataEdit('label', nextLabel || null);
+}
+
+function commitSelectedNodeComment(textarea) {
+  const node = getSelectedEditorNode();
+  if (!node) return;
+
+  const nextComment = textarea.value;
+  const currentComment = node.comment || '';
+
+  if (nextComment === currentComment) return;
+
+  applyNodeMetadataEdit('comment', nextComment || null);
+}
+
 function attachInspectorActionListeners() {
   const deleteButton = elements.inspectorPanel.querySelector('#delete-selected-node-btn');
   deleteButton?.addEventListener('click', deleteSelectedNode);
@@ -1342,14 +1366,34 @@ function attachInspectorActionListeners() {
   });
 
   const labelInput = elements.inspectorPanel.querySelector('#selected-node-label-input');
-  labelInput?.addEventListener('change', (event) => {
-    applyNodeMetadataEdit('label', event.target.value.trim() || null);
-  });
+  if (labelInput) {
+    labelInput.addEventListener('change', () => {
+      commitSelectedNodeLabel(labelInput);
+    });
+
+    labelInput.addEventListener('blur', () => {
+      commitSelectedNodeLabel(labelInput);
+    });
+
+    labelInput.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+
+      event.preventDefault();
+      commitSelectedNodeLabel(labelInput);
+      labelInput.blur();
+    });
+  }
 
   const commentInput = elements.inspectorPanel.querySelector('#selected-node-comment-input');
-  commentInput?.addEventListener('change', (event) => {
-    applyNodeMetadataEdit('comment', event.target.value.trim() || null);
-  });
+  if (commentInput) {
+    commentInput.addEventListener('change', () => {
+      commitSelectedNodeComment(commentInput);
+    });
+
+    commentInput.addEventListener('blur', () => {
+      commitSelectedNodeComment(commentInput);
+    });
+  }
 
   elements.inspectorPanel
     .querySelectorAll('[data-remove-edge-id]')


### PR DESCRIPTION
## Summary
Refactored the inspector panel input handlers for node labels and comments to provide more robust commit behavior with dedicated handler functions and additional event listeners.

## Key Changes
- **New commit functions**: Added `commitSelectedNodeLabel()` and `commitSelectedNodeComment()` functions that:
  - Validate that the input value has actually changed before applying edits
  - Handle empty values by converting them to `null`
  - Centralize the commit logic for reusability across multiple event types

- **Enhanced label input handling**:
  - Added `blur` event listener to commit changes when focus is lost
  - Added `keydown` event listener to commit changes on Enter key press (with preventDefault to avoid form submission)
  - Kept existing `change` event listener for standard input changes
  - Improved code structure with explicit conditional checks instead of optional chaining

- **Enhanced comment input handling**:
  - Added `blur` event listener to commit changes when focus is lost
  - Kept existing `change` event listener for standard input changes
  - Improved code structure with explicit conditional checks

## Implementation Details
- The new commit functions compare the next value against the current node value to avoid unnecessary edits when nothing has changed
- Empty string inputs are converted to `null` to maintain consistent metadata representation
- The Enter key handler prevents default behavior and explicitly blurs the input to trigger the blur listener
- All event listeners are now attached within conditional blocks that check for element existence, improving code clarity

https://claude.ai/code/session_01LvmmYxPCEndzrUmsYk6LoX