### PR TITLE
Skip renderInspector for metadata-only operations to preserve focus

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -2248,6 +2248,7 @@ async function handleOperation(operation) {
     }
 
     const affectsDsl = result.change.affectsDsl !== false;
+    const isMetadataOnlyOperation = result.change.operation.type === 'updateNodeMetadata';
 
     if (affectsDsl) {
       renderGraphJSON(result.state.graph);
@@ -2260,7 +2261,11 @@ async function handleOperation(operation) {
     }
 
     renderErrors();
-    renderInspector();
+
+    if (!isMetadataOnlyOperation) {
+      renderInspector();
+    }
+
     updateNodeListCategories();
     renderNodeList();
     setDirty(true);


### PR DESCRIPTION
When updateNodeMetadata operations are applied, the Inspector DOM was being
completely re-rendered, causing label/comment input fields to lose focus.

Now we detect metadata-only operations and skip the renderInspector() call,
while still:
- updating editorModel
- updating Node Editor title/comment display
- updating Nodes tab (renderNodeList)
- marking dirty
- pushing undo history
- avoiding DSL sync

Other operations (renameNode, removeNode, addNode, updateParam, etc.) still
call renderInspector() normally. Undo/Redo continue to work via
restoreEditorHistorySnapshot() which calls renderInspector() directly.

https://claude.ai/code/session_01EzXiUuHAgdihHnVkPdwx5Q