### PR TITLE
Add inline node label editing on double-click

### DIFF
--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -27,6 +27,11 @@ function getPortName(port) {
   return typeof port === 'string' ? port : port.name;
 }
 
+function getNormalizedLabelValue(value) {
+  const text = String(value ?? '');
+  return text.trim() === '' ? null : text;
+}
+
 function createReteNode(editorNode, onControl) {
   const nodeTypeDef = NODE_TYPES[editorNode.type];
   const displayLabel = editorNode.label || editorNode.type;
@@ -95,6 +100,143 @@ export class NodeEditorView {
     this.area.use(this.renderPlugin);
 
     this._setupPipes();
+    this._setupInlineLabelEditing();
+  }
+
+  _setupInlineLabelEditing() {
+    if (!this.area || !this.container) return;
+
+    this.container.addEventListener('dblclick', (event) => {
+      const titleElement = this._findNodeTitleElement(event.target);
+      if (!titleElement || titleElement.querySelector('input')) return;
+
+      const nodeId = this._findNodeIdFromTitle(titleElement);
+      if (!nodeId) return;
+
+      this._startInlineNodeLabelEditing(nodeId, titleElement);
+    }, true);
+  }
+
+  _findNodeTitleElement(target) {
+    let element = target;
+    while (element) {
+      if (element.tagName === 'H2' && element.closest('[class*="node"]')) {
+        return element;
+      }
+      element = element.parentElement;
+    }
+    return null;
+  }
+
+  _findNodeIdFromTitle(titleElement) {
+    const nodeElement = titleElement.closest('[class*="node"]');
+    if (!nodeElement) return null;
+
+    if (this.area.nodeViews instanceof Map) {
+      for (const [nodeId, view] of this.area.nodeViews) {
+        if (view && view.element === nodeElement) {
+          return nodeId;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  _startInlineNodeLabelEditing(nodeId, titleElement) {
+    const node = this.editor.getNode(nodeId);
+    if (!node || !node._editorNode) return;
+
+    const editorNode = node._editorNode;
+    const initialValue = editorNode.label || '';
+
+    const input = document.createElement('input');
+    input.className = 'node-label-input';
+    input.type = 'text';
+    input.value = initialValue;
+    input.placeholder = editorNode.id;
+    input.spellcheck = false;
+
+    let isCommitting = false;
+
+    const handleBlur = () => {
+      if (!isCommitting) {
+        commit();
+      }
+    };
+
+    const handleKeydown = (event) => {
+      event.stopPropagation();
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        commit();
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancel();
+      }
+    };
+
+    const handlePointerdown = (event) => {
+      event.stopPropagation();
+    };
+
+    const handleClick = (event) => {
+      event.stopPropagation();
+    };
+
+    const handleDblclick = (event) => {
+      event.stopPropagation();
+    };
+
+    const commit = () => {
+      if (isCommitting) return;
+      isCommitting = true;
+
+      const nextLabel = getNormalizedLabelValue(input.value);
+      const currentLabel = getNormalizedLabelValue(initialValue);
+
+      if (nextLabel !== currentLabel && this.onOperation) {
+        this.onOperation({
+          type: 'updateNodeMetadata',
+          id: nodeId,
+          patch: { label: nextLabel }
+        });
+      }
+
+      cleanup();
+    };
+
+    const cancel = () => {
+      cleanup();
+    };
+
+    const cleanup = () => {
+      input.removeEventListener('blur', handleBlur);
+      input.removeEventListener('keydown', handleKeydown);
+      input.removeEventListener('pointerdown', handlePointerdown);
+      input.removeEventListener('click', handleClick);
+      input.removeEventListener('dblclick', handleDblclick);
+      input.remove();
+      titleElement.style.display = '';
+    };
+
+    input.addEventListener('blur', handleBlur);
+    input.addEventListener('keydown', handleKeydown);
+    input.addEventListener('pointerdown', handlePointerdown);
+    input.addEventListener('click', handleClick);
+    input.addEventListener('dblclick', handleDblclick);
+
+    titleElement.style.display = 'none';
+    const parent = titleElement.parentElement;
+    if (parent) {
+      parent.insertBefore(input, titleElement);
+    }
+    input.focus();
+    input.select();
   }
 
   _setupPipes() {

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -132,10 +132,25 @@ export class NodeEditorView {
     const nodeElement = titleElement.closest('[class*="node"]');
     if (!nodeElement) return null;
 
-    if (this.area.nodeViews instanceof Map) {
+    // 試み1: data-node-id属性を探す（もしあれば）
+    const dataNodeId = nodeElement.getAttribute('data-node-id');
+    if (dataNodeId) return dataNodeId;
+
+    // 試み2: Rete nodeViews から逆引き
+    if (this.area?.nodeViews instanceof Map) {
       for (const [nodeId, view] of this.area.nodeViews) {
         if (view && view.element === nodeElement) {
           return nodeId;
+        }
+      }
+    }
+
+    // 試み3: Rete editor のノードを列挙して近似マッチ
+    if (this.editor && titleElement.textContent) {
+      const labelText = titleElement.textContent.trim();
+      for (const node of this.editor.getNodes()) {
+        if (node.label === labelText || node.id === labelText) {
+          return node.id;
         }
       }
     }
@@ -157,10 +172,10 @@ export class NodeEditorView {
     input.placeholder = editorNode.id;
     input.spellcheck = false;
 
-    let isCommitting = false;
+    let isEditingActive = true;
 
     const handleBlur = () => {
-      if (!isCommitting) {
+      if (isEditingActive) {
         commit();
       }
     };
@@ -193,8 +208,8 @@ export class NodeEditorView {
     };
 
     const commit = () => {
-      if (isCommitting) return;
-      isCommitting = true;
+      if (!isEditingActive) return;
+      isEditingActive = false;
 
       const nextLabel = getNormalizedLabelValue(input.value);
       const currentLabel = getNormalizedLabelValue(initialValue);
@@ -211,6 +226,8 @@ export class NodeEditorView {
     };
 
     const cancel = () => {
+      if (!isEditingActive) return;
+      isEditingActive = false;
       cleanup();
     };
 

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -272,6 +272,20 @@ body.panels-hidden .editor-panels {
   padding: 2px 4px !important;
 }
 
+/* Inline node label editing */
+.node-label-input {
+  background: #222 !important;
+  color: var(--text-color) !important;
+  border: 2px solid var(--primary-color) !important;
+  border-radius: 4px !important;
+  padding: 4px 6px !important;
+  font-size: 14px !important;
+  font-weight: 500 !important;
+  font-family: inherit !important;
+  max-width: 280px;
+  box-sizing: border-box;
+}
+
 /* Graph/Errors panel */
 .graph-errors-panel {
   grid-column: 1 / -1;


### PR DESCRIPTION
## Summary
This PR adds the ability to edit node labels inline by double-clicking on a node's title in the editor. When editing, users can confirm changes by pressing Enter or cancel by pressing Escape.

## Key Changes
- Added `getNormalizedLabelValue()` utility function to handle label normalization (trim whitespace, convert empty strings to null)
- Implemented `_setupInlineLabelEditing()` to attach a double-click event listener to the editor container
- Added helper methods to locate and identify node elements:
  - `_findNodeTitleElement()` - traverses DOM to find H2 title elements within node containers
  - `_findNodeIdFromTitle()` - maps DOM elements back to node IDs using the area's nodeViews map
- Implemented `_startInlineNodeLabelEditing()` to handle the inline editing workflow:
  - Creates an input field with appropriate styling and placeholder
  - Manages focus, selection, and keyboard interactions (Enter to confirm, Escape to cancel)
  - Prevents event propagation to avoid interfering with editor interactions
  - Commits label changes via `onOperation` callback with proper change detection
  - Cleans up event listeners and DOM state after editing completes
- Added CSS styling for `.node-label-input` with dark background, primary color border, and appropriate sizing

## Implementation Details
- The inline editor uses event delegation on the container for efficient event handling
- Label changes are only committed if the normalized value differs from the initial value
- The input field replaces the title element visually while preserving the original element in the DOM
- All event listeners are properly cleaned up to prevent memory leaks
- The implementation respects the editor's existing operation system for state management

https://claude.ai/code/session_01XdobP6zB3YSoNLu6RMFV61