### PR TITLE
Prevent re-render when updating params via node editor controls

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -2236,7 +2236,11 @@ async function handleOperation(operation) {
   store.setState(result.state);
 
   if (!result.error) {
-    if (result.change.shouldRerenderView) {
+    const isNodeEditorControlParamEdit =
+      operation?.type === 'updateParam' &&
+      operation?.source === 'nodeEditorControl';
+
+    if (result.change.shouldRerenderView && !isNodeEditorControlParamEdit) {
       await nodeEditor?.renderModel(result.state.editorModel);
     }
 
@@ -2262,7 +2266,7 @@ async function handleOperation(operation) {
 
     renderErrors();
 
-    if (!isMetadataOnlyOperation) {
+    if (!isMetadataOnlyOperation && !isNodeEditorControlParamEdit) {
       renderInspector();
     }
 

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -52,7 +52,10 @@ function createReteNode(editorNode, onControl) {
     const ctrl = new ClassicPreset.InputControl(controlType, {
       initial: value,
       change(v) {
-        onControl(controlValueToUpdateParamOp(editorNode.id, key, v, controlType));
+        onControl({
+          ...controlValueToUpdateParamOp(editorNode.id, key, v, controlType),
+          source: 'nodeEditorControl'
+        });
       }
     });
     node.addControl(key, ctrl);


### PR DESCRIPTION
## Summary
This PR optimizes the editor's rendering behavior by skipping unnecessary view re-renders and inspector updates when parameter values are changed through node editor control inputs.

## Key Changes
- Added source tracking to parameter update operations originating from node editor controls
- Modified `handleOperation()` to skip `nodeEditor.renderModel()` call when the operation is a parameter edit from a node editor control
- Modified `handleOperation()` to skip `renderInspector()` call when the operation is a parameter edit from a node editor control
- Updated `createReteNode()` to tag control change operations with `source: 'nodeEditorControl'`

## Implementation Details
The changes introduce a new `isNodeEditorControlParamEdit` flag that identifies when a parameter update originates from a node editor control (as opposed to other sources like the inspector panel). This allows the system to avoid redundant re-renders since the control itself already reflects the updated value, preventing visual flicker and improving performance.

https://claude.ai/code/session_01KJEAgsSnPYxmKmGmsuYeBi