### PR TITLE
Add GitHub Pages deployment workflow and editor documentation

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,78 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build node editor
+        run: |
+          cd editor-studio
+          npm ci
+          VITE_BASE_PATH=/loomlet/node-editor/ npm run build
+
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p dist-pages/node-editor
+          cp -R editor-studio/dist/* dist-pages/node-editor/
+          mkdir -p dist-pages/editor
+          cp -R editor/* dist-pages/editor/
+
+      - name: Add index page
+        run: |
+          cat > dist-pages/index.html <<'HTML'
+          <!doctype html>
+          <html>
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>Loomlet</title>
+            </head>
+            <body>
+              <h1>Loomlet</h1>
+              <ul>
+                <li><a href="./editor/">Simple Editor</a></li>
+                <li><a href="./node-editor/">Node Editor</a></li>
+              </ul>
+            </body>
+          </html>
+          HTML
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist-pages
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ node_modules/
 ### CI / Testing
 playwright-report/
 test-results/
+
+### Pages build output
+dist-pages/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A small dataflow language for weaving values, signals, and scene behavior. Build
 
 ## Editor
 
-- `editor/`: simple editor (plain HTML/JS, no build step)
-- `editor-studio/`: source for the full Node Editor (Vite + React + Rete.js)
+- `editor/`: シンプル版エディタ。plain HTML/JS で、ビルドなしで動作します。
+- `editor-studio/`: フル版 Node Editor のソースです。Vite + React + Rete.js で構成されています。
 - GitHub Pages:
-  - [`/editor/`](https://afjk.github.io/loomlet/editor/): simple editor
-  - [`/node-editor/`](https://afjk.github.io/loomlet/node-editor/): full Node Editor
+  - [`/editor/`](https://afjk.github.io/loomlet/editor/): シンプル版エディタ
+  - [`/node-editor/`](https://afjk.github.io/loomlet/node-editor/): フル版 Node Editor
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 A small dataflow language for weaving values, signals, and scene behavior. Build reactive visual, audio, and 3D content by composing small graph parts.
 
+## Editor
+
+- `editor/`: simple editor (plain HTML/JS, no build step)
+- `editor-studio/`: source for the full Node Editor (Vite + React + Rete.js)
+- GitHub Pages:
+  - [`/editor/`](https://afjk.github.io/loomlet/editor/): simple editor
+  - [`/node-editor/`](https://afjk.github.io/loomlet/node-editor/): full Node Editor
+
 ---
 
 ブラウザで動くデータフロー実行エンジン。純粋関数ノードを基本にしつつ、必要な箇所だけを `state` ノードとして明示し、リアクティブな視覚・音響・3D コンテンツを構築します。

--- a/editor-studio/vite.config.js
+++ b/editor-studio/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: process.env.VITE_BASE_PATH || '/loomlet/node-editor/',
+  base: process.env.VITE_BASE_PATH || './',
   root: '.',
   build: {
     outDir: 'dist',

--- a/editor-studio/vite.config.js
+++ b/editor-studio/vite.config.js
@@ -1,8 +1,10 @@
-export default {
-  base: './',
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: process.env.VITE_BASE_PATH || '/loomlet/node-editor/',
   root: '.',
   build: {
     outDir: 'dist',
     emptyOutDir: true
   }
-};
+});

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "generate:vscode-metadata": "node scripts/generate-vscode-metadata.mjs",
     "pack:dry-run": "npm pack --dry-run",
     "pack:cli": "npm pack",
-    "pack:vscode": "cd extensions/vscode-loomlet && npx @vscode/vsce package"
+    "pack:vscode": "cd extensions/vscode-loomlet && npx @vscode/vsce package",
+    "build:node-editor": "cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build",
+    "pages:build": "rm -rf dist-pages && mkdir -p dist-pages/node-editor && cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build && cp -R dist/* ../dist-pages/node-editor/"
   },
   "devDependencies": {
     "http-server": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pack:cli": "npm pack",
     "pack:vscode": "cd extensions/vscode-loomlet && npx @vscode/vsce package",
     "build:node-editor": "cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build",
-    "pages:build": "rm -rf dist-pages && mkdir -p dist-pages/node-editor && cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build && cp -R dist/* ../dist-pages/node-editor/"
+    "pages:build": "rm -rf dist-pages && mkdir -p dist-pages/node-editor dist-pages/editor && cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build && cp -R dist/* ../dist-pages/node-editor/ && cd .. && cp -R editor/* dist-pages/editor/ && printf '<!doctype html>\\n<html>\\n<head><meta charset=\"utf-8\"/><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"/><title>Loomlet</title></head>\\n<body><h1>Loomlet</h1><ul><li><a href=\"./editor/\">Simple Editor</a></li><li><a href=\"./node-editor/\">Node Editor</a></li></ul></body>\\n</html>\\n' > dist-pages/index.html"
   },
   "devDependencies": {
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Summary
This PR adds automated GitHub Pages deployment and updates project documentation to reflect the available editors and their hosting locations.

## Key Changes

- **GitHub Pages Workflow**: Added `.github/workflows/deploy-pages.yml` to automatically build and deploy both the simple editor and Node Editor to GitHub Pages on pushes to main
  - Builds the Node Editor (Vite + React) with proper base path configuration
  - Aggregates both editors into a single deployable artifact
  - Creates an index page linking to both editors
  
- **Vite Configuration**: Updated `editor-studio/vite.config.js` to support dynamic base path via `VITE_BASE_PATH` environment variable, enabling proper asset resolution when deployed to a subdirectory

- **Documentation**: Updated `README.md` with an "Editor" section documenting:
  - Directory structure for both editors
  - Links to live GitHub Pages deployments
  
- **Build Scripts**: Added convenience npm scripts in `package.json`:
  - `build:node-editor`: Builds the Node Editor with correct base path
  - `pages:build`: Full Pages build pipeline

## Implementation Details

The workflow uses GitHub's official Pages actions and properly configures permissions for deployment. The Node Editor base path is set to `/loomlet/node-editor/` to match the GitHub Pages URL structure, while the simple editor is served from `/editor/`.

https://claude.ai/code/session_01BFbHvskuCGbySJZ8Cw46un