### PR TITLE
Include src/ directory in Pages artifact for simple editor

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,9 +35,12 @@ jobs:
       - name: Prepare Pages artifact
         run: |
           mkdir -p dist-pages/node-editor
-          cp -R editor-studio/dist/* dist-pages/node-editor/
           mkdir -p dist-pages/editor
+          # The simple editor imports ../src/*.js directly, so src/ must be included in the Pages artifact.
+          mkdir -p dist-pages/src
+          cp -R editor-studio/dist/* dist-pages/node-editor/
           cp -R editor/* dist-pages/editor/
+          cp -R src/* dist-pages/src/
 
       - name: Add index page
         run: |

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pack:cli": "npm pack",
     "pack:vscode": "cd extensions/vscode-loomlet && npx @vscode/vsce package",
     "build:node-editor": "cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build",
-    "pages:build": "rm -rf dist-pages && mkdir -p dist-pages/node-editor dist-pages/editor && cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build && cp -R dist/* ../dist-pages/node-editor/ && cd .. && cp -R editor/* dist-pages/editor/ && printf '<!doctype html>\\n<html>\\n<head><meta charset=\"utf-8\"/><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"/><title>Loomlet</title></head>\\n<body><h1>Loomlet</h1><ul><li><a href=\"./editor/\">Simple Editor</a></li><li><a href=\"./node-editor/\">Node Editor</a></li></ul></body>\\n</html>\\n' > dist-pages/index.html"
+    "pages:build": "rm -rf dist-pages && mkdir -p dist-pages/node-editor dist-pages/editor dist-pages/src && cd editor-studio && npm install && VITE_BASE_PATH=/loomlet/node-editor/ npm run build && cp -R dist/* ../dist-pages/node-editor/ && cd .. && cp -R editor/* dist-pages/editor/ && cp -R src/* dist-pages/src/ && printf '<!doctype html>\\n<html>\\n<head><meta charset=\"utf-8\"/><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"/><title>Loomlet</title></head>\\n<body><h1>Loomlet</h1><ul><li><a href=\"./editor/\">Simple Editor</a></li><li><a href=\"./node-editor/\">Node Editor</a></li></ul></body>\\n</html>\\n' > dist-pages/index.html"
   },
   "devDependencies": {
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Summary
The simple editor imports source files directly from `../src/*.js`, so the `src/` directory must be included in the GitHub Pages artifact for the editor to function properly when deployed.

## Changes
- Updated `.github/workflows/deploy-pages.yml` to create `dist-pages/src/` directory and copy all source files into it during the Pages artifact preparation step
- Updated `package.json` `pages:build` script to include the same `src/` directory creation and copying logic for consistency with the workflow

## Implementation Details
- The `src/` directory is now copied alongside the `node-editor/` and `editor/` directories in the Pages artifact
- Both the GitHub Actions workflow and the local build script have been synchronized to ensure consistent artifact generation

https://claude.ai/code/session_01J6ogCUu9xjp32yQixynDhY