### PR TITLE
Add runtime preview canvas and editor toggle UI

### DIFF
--- a/extensions/vscode-loomlet/media/node-editor-webview.js
+++ b/extensions/vscode-loomlet/media/node-editor-webview.js
@@ -15735,33 +15735,91 @@ var LoomletPreview = (() => {
   // webview-src/node-editor-webview.js
   var vscode = acquireVsCodeApi();
   var editorView = null;
+  var editorVisible = true;
+  var lastErrors = [];
+  function resizePreviewCanvas() {
+    const canvas = document.getElementById("lp-preview-canvas");
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(window.innerWidth * dpr);
+    canvas.height = Math.round(window.innerHeight * dpr);
+    drawPreviewPlaceholder(canvas, dpr);
+  }
+  function drawPreviewPlaceholder(canvas, dpr) {
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const w2 = canvas.width;
+    const h2 = canvas.height;
+    ctx.fillStyle = "#1a1a1a";
+    ctx.fillRect(0, 0, w2, h2);
+    const step = 28 * dpr;
+    ctx.fillStyle = "rgba(255,255,255,0.06)";
+    for (let x2 = step; x2 < w2; x2 += step) {
+      for (let y = step; y < h2; y += step) {
+        ctx.beginPath();
+        ctx.arc(x2, y, dpr, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = "rgba(255,255,255,0.18)";
+    ctx.font = `${Math.round(15 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+    ctx.fillText("Runtime Preview", w2 / 2, h2 / 2 - Math.round(13 * dpr));
+    ctx.fillStyle = "rgba(255,255,255,0.09)";
+    ctx.font = `${Math.round(11 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+    ctx.fillText("render output will appear here", w2 / 2, h2 / 2 + Math.round(13 * dpr));
+  }
   function setStatus(text, isError) {
     const el = document.getElementById("lp-status");
     if (!el) return;
     el.textContent = text;
     if (isError) {
       el.style.borderLeftColor = "#f44747";
-      el.style.background = "rgba(244,71,71,0.12)";
       el.style.color = "#f88";
     } else {
       el.style.borderLeftColor = "#4a90e2";
-      el.style.background = "rgba(74,144,226,0.12)";
       el.style.color = "#9cdcfe";
     }
   }
   function setErrors(errors) {
+    lastErrors = errors || [];
+    _renderErrors();
+  }
+  function _renderErrors() {
     const el = document.getElementById("lp-errors");
     if (!el) return;
-    if (!errors || errors.length === 0) {
+    if (!editorVisible || lastErrors.length === 0) {
       el.style.display = "none";
       el.innerHTML = "";
       return;
     }
     el.style.display = "block";
-    el.innerHTML = errors.map((e) => `<div class="lp-error-item">${escapeHtml(e.message || String(e))}</div>`).join("");
+    el.innerHTML = lastErrors.map((e) => `<div class="lp-error-item">${escapeHtml(e.message || String(e))}</div>`).join("");
   }
   function escapeHtml(str) {
     return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+  function toggleEditor() {
+    editorVisible = !editorVisible;
+    const panel = document.getElementById("lp-panel");
+    const container = document.getElementById("lp-editor-container");
+    const btn = document.getElementById("lp-toggle-editor");
+    if (editorVisible) {
+      if (container) container.style.display = "";
+      if (panel) panel.style.flex = "1";
+      if (btn) btn.textContent = "Hide Editor";
+      _renderErrors();
+    } else {
+      if (container) container.style.display = "none";
+      if (panel) panel.style.flex = "0 0 auto";
+      if (btn) btn.textContent = "Show Editor";
+      _renderErrors();
+    }
+  }
+  function initToggleButton() {
+    const btn = document.getElementById("lp-toggle-editor");
+    if (btn) btn.addEventListener("click", toggleEditor);
   }
   function initEditorView() {
     if (editorView) return;
@@ -15799,6 +15857,9 @@ var LoomletPreview = (() => {
       setStatus("Render error \xB7 Read-only Node Preview", true);
     }
   });
+  resizePreviewCanvas();
+  window.addEventListener("resize", resizePreviewCanvas);
+  initToggleButton();
   vscode.postMessage({ type: "ready" });
 })();
 /*! Bundled license information:

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -204,33 +204,84 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
     html, body {
       margin: 0; padding: 0;
       width: 100%; height: 100%;
-      background: #1e1e1e;
+      background: #1a1a1a;
       color: #d4d4d4;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       font-size: 13px;
       overflow: hidden;
     }
-    #lp-root {
-      display: flex;
-      flex-direction: column;
+    /* ── Background: Runtime Preview canvas ── */
+    #lp-preview-canvas {
+      position: fixed;
+      inset: 0;
       width: 100%;
       height: 100%;
+      z-index: 0;
+      display: block;
+    }
+    /* ── Foreground: Node Editor overlay ── */
+    #lp-overlay {
+      position: fixed;
+      inset: 12px;
+      z-index: 10;
+      display: flex;
+      flex-direction: column;
+      /* Pass pointer-events through to canvas where there is no panel */
+      pointer-events: none;
+    }
+    /* Panel wraps toolbar + errors + editor; collapses when editor is hidden */
+    #lp-panel {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      border: 1px solid rgba(255,255,255,0.09);
+      border-radius: 6px;
+      overflow: hidden;
+      pointer-events: auto;
+      flex: 1;
+    }
+    /* ── Toolbar ── */
+    #lp-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 10px;
+      background: rgba(24, 24, 24, 0.96);
+      border-bottom: 1px solid rgba(255,255,255,0.07);
+      flex-shrink: 0;
     }
     #lp-status {
-      padding: 4px 12px;
-      background: rgba(74, 144, 226, 0.12);
-      border-left: 3px solid #4a90e2;
-      color: #9cdcfe;
+      flex: 1;
       font-size: 12px;
-      flex-shrink: 0;
+      color: #9cdcfe;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      border-left: 3px solid #4a90e2;
+      padding-left: 8px;
+      line-height: 1.6;
     }
+    #lp-toggle-editor {
+      flex-shrink: 0;
+      padding: 2px 10px;
+      font-size: 11px;
+      font-family: inherit;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.14);
+      border-radius: 3px;
+      color: #bbb;
+      cursor: pointer;
+      line-height: 1.6;
+    }
+    #lp-toggle-editor:hover {
+      background: rgba(255,255,255,0.11);
+      color: #eee;
+    }
+    /* ── Errors ── */
     #lp-errors {
       padding: 6px 12px;
-      background: rgba(244, 71, 71, 0.12);
-      border-left: 3px solid #f44747;
+      background: rgba(244, 71, 71, 0.10);
+      border-bottom: 1px solid rgba(244, 71, 71, 0.25);
       overflow-y: auto;
       max-height: 120px;
       flex-shrink: 0;
@@ -242,20 +293,34 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
       font-size: 11px;
       color: #f88;
     }
+    /* ── Node Editor container ── */
     #lp-editor-container {
       flex: 1;
       position: relative;
       overflow: hidden;
-      background: #252526;
+      background: rgba(30, 30, 30, 0.80);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      min-height: 0;
     }
   </style>
 </head>
 <body>
-  <div id="lp-root">
-    <div id="lp-status">Waiting for graph...</div>
-    <div id="lp-errors"></div>
-    <div id="lp-editor-container"></div>
+  <!-- Background: Runtime Preview canvas (placeholder until runtime is wired) -->
+  <canvas id="lp-preview-canvas"></canvas>
+
+  <!-- Foreground: Node Editor overlay -->
+  <div id="lp-overlay">
+    <div id="lp-panel">
+      <div id="lp-toolbar">
+        <div id="lp-status">Waiting for graph...</div>
+        <button id="lp-toggle-editor">Hide Editor</button>
+      </div>
+      <div id="lp-errors"></div>
+      <div id="lp-editor-container"></div>
+    </div>
   </div>
+
   <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;

--- a/extensions/vscode-loomlet/webview-src/node-editor-webview.js
+++ b/extensions/vscode-loomlet/webview-src/node-editor-webview.js
@@ -5,7 +5,57 @@ import { NodeEditorView } from '../../../editor-studio/src/node-editor-view.js';
 const vscode = acquireVsCodeApi();
 let editorView = null;
 
-// --- DOM helpers ---
+// ── State ────────────────────────────────────────────────────────────────────
+
+let editorVisible = true;
+let lastErrors = [];
+
+// ── Canvas: Runtime Preview placeholder ──────────────────────────────────────
+
+function resizePreviewCanvas() {
+  const canvas = document.getElementById('lp-preview-canvas');
+  if (!canvas) return;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = Math.round(window.innerWidth * dpr);
+  canvas.height = Math.round(window.innerHeight * dpr);
+  drawPreviewPlaceholder(canvas, dpr);
+}
+
+function drawPreviewPlaceholder(canvas, dpr) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  // Dark background
+  ctx.fillStyle = '#1a1a1a';
+  ctx.fillRect(0, 0, w, h);
+
+  // Subtle dot grid
+  const step = 28 * dpr;
+  ctx.fillStyle = 'rgba(255,255,255,0.06)';
+  for (let x = step; x < w; x += step) {
+    for (let y = step; y < h; y += step) {
+      ctx.beginPath();
+      ctx.arc(x, y, dpr, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  // Centered label
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  ctx.fillStyle = 'rgba(255,255,255,0.18)';
+  ctx.font = `${Math.round(15 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+  ctx.fillText('Runtime Preview', w / 2, h / 2 - Math.round(13 * dpr));
+
+  ctx.fillStyle = 'rgba(255,255,255,0.09)';
+  ctx.font = `${Math.round(11 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+  ctx.fillText('render output will appear here', w / 2, h / 2 + Math.round(13 * dpr));
+}
+
+// ── Status & error helpers ────────────────────────────────────────────────────
 
 function setStatus(text, isError) {
   const el = document.getElementById('lp-status');
@@ -13,25 +63,29 @@ function setStatus(text, isError) {
   el.textContent = text;
   if (isError) {
     el.style.borderLeftColor = '#f44747';
-    el.style.background = 'rgba(244,71,71,0.12)';
     el.style.color = '#f88';
   } else {
     el.style.borderLeftColor = '#4a90e2';
-    el.style.background = 'rgba(74,144,226,0.12)';
     el.style.color = '#9cdcfe';
   }
 }
 
 function setErrors(errors) {
+  lastErrors = errors || [];
+  _renderErrors();
+}
+
+function _renderErrors() {
   const el = document.getElementById('lp-errors');
   if (!el) return;
-  if (!errors || errors.length === 0) {
+  // Hide errors when editor panel is collapsed or there are none
+  if (!editorVisible || lastErrors.length === 0) {
     el.style.display = 'none';
     el.innerHTML = '';
     return;
   }
   el.style.display = 'block';
-  el.innerHTML = errors
+  el.innerHTML = lastErrors
     .map(e => `<div class="lp-error-item">${escapeHtml(e.message || String(e))}</div>`)
     .join('');
 }
@@ -44,7 +98,36 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
-// --- Editor lifecycle ---
+// ── Hide / Show toggle ────────────────────────────────────────────────────────
+
+function toggleEditor() {
+  editorVisible = !editorVisible;
+
+  const panel = document.getElementById('lp-panel');
+  const container = document.getElementById('lp-editor-container');
+  const btn = document.getElementById('lp-toggle-editor');
+
+  if (editorVisible) {
+    if (container) container.style.display = '';
+    // Restore full-height flex to the panel
+    if (panel) panel.style.flex = '1';
+    if (btn) btn.textContent = 'Hide Editor';
+    _renderErrors();
+  } else {
+    if (container) container.style.display = 'none';
+    // Collapse panel to toolbar height only
+    if (panel) panel.style.flex = '0 0 auto';
+    if (btn) btn.textContent = 'Show Editor';
+    _renderErrors(); // hides errors too
+  }
+}
+
+function initToggleButton() {
+  const btn = document.getElementById('lp-toggle-editor');
+  if (btn) btn.addEventListener('click', toggleEditor);
+}
+
+// ── Node Editor lifecycle ─────────────────────────────────────────────────────
 
 function initEditorView() {
   if (editorView) return;
@@ -57,7 +140,7 @@ function initEditorView() {
   });
 }
 
-// --- Message handler ---
+// ── Message handler ───────────────────────────────────────────────────────────
 
 window.addEventListener('message', async (event) => {
   const message = event.data;
@@ -90,5 +173,11 @@ window.addEventListener('message', async (event) => {
   }
 });
 
-// Notify the extension that the webview is ready (optional handshake)
+// ── Boot ──────────────────────────────────────────────────────────────────────
+
+resizePreviewCanvas();
+window.addEventListener('resize', resizePreviewCanvas);
+initToggleButton();
+
+// Notify the extension that the webview is ready
 vscode.postMessage({ type: 'ready' });


### PR DESCRIPTION
## Summary
This PR enhances the Node Editor webview with a runtime preview canvas background and adds UI controls to toggle the editor panel visibility. The changes create a more polished interface with a placeholder canvas for future runtime output and allow users to collapse the editor to focus on preview content.

## Key Changes

- **Runtime Preview Canvas**: Added a full-screen canvas element with a dark background, subtle dot grid pattern, and centered placeholder text ("Runtime Preview") that will serve as the background for runtime output
- **Canvas Rendering**: Implemented `resizePreviewCanvas()` and `drawPreviewPlaceholder()` functions that handle DPI-aware canvas sizing and redraw on window resize
- **Editor Toggle Button**: Added a "Hide Editor" / "Show Editor" button in a new toolbar that allows users to collapse/expand the editor panel
- **Layout Restructuring**: Reorganized the HTML structure to use a fixed canvas background with a floating overlay panel containing the toolbar, status, errors, and editor
- **State Management**: Added `editorVisible` and `lastErrors` state variables to track panel visibility and conditionally render errors based on editor visibility
- **Styling Updates**: 
  - Updated color scheme (background changed from `#1e1e1e` to `#1a1a1a`)
  - Removed inline background colors from status element (now handled by toolbar styling)
  - Added backdrop blur effect to editor container
  - Implemented flexible panel layout that collapses to toolbar-only height when hidden
  - Added subtle border styling for the panel and improved button hover states

## Implementation Details

- The canvas uses `window.devicePixelRatio` for proper rendering on high-DPI displays
- Error display is now conditional on both error existence and editor visibility state
- The toggle button updates both the DOM visibility and flex layout properties to smoothly collapse/expand the panel
- All changes maintain backward compatibility with existing message handling and editor initialization

https://claude.ai/code/session_01Xg4VqLWvB5vFv1fZ6ZTpML