### PR TITLE
Add runtime canvas preview to VS Code Node Preview

### DIFF
--- a/extensions/vscode-loomlet/media/node-editor-webview.js
+++ b/extensions/vscode-loomlet/media/node-editor-webview.js
@@ -15373,6 +15373,473 @@ var LoomletPreview = (() => {
       }
     }
   };
+  var Loom = class {
+    constructor(graph) {
+      this._currentGraph = null;
+      this._pendingGraph = null;
+      this._sortedNodeIds = [];
+      this._values = /* @__PURE__ */ new Map();
+      this._prevOuts = /* @__PURE__ */ new Map();
+      this._eventQueue = [];
+      this._rafId = null;
+      this._startTime = null;
+      this._lastTimestamp = null;
+      this._inputStates = {};
+      this._effects = [];
+      this._loadGraphInternal(graph);
+    }
+    // 外部からノード型を追加するための静的メソッド（アダプタ層向け）
+    static registerNodeType(name, definition) {
+      if (NODE_TYPES[name]) {
+        throw new LoomError("DUPLICATE_NODE_TYPE", `Node type already registered: ${name}`, { name });
+      }
+      NODE_TYPES[name] = definition;
+    }
+    _activatePendingGraph(runLifecycle = true) {
+      if (this._pendingGraph === null) {
+        return;
+      }
+      if (runLifecycle && this._currentGraph) {
+        for (const node2 of this._currentGraph.nodes) {
+          const nodeType = NODE_TYPES[node2.type];
+          if (nodeType.onStop) {
+            nodeType.onStop(node2, this);
+          }
+        }
+      }
+      this._reconcileStateForGraph(this._pendingGraph);
+      this._currentGraph = this._pendingGraph;
+      this._sortedNodeIds = this._pendingNodeIds;
+      this._pendingGraph = null;
+      if (runLifecycle && this._currentGraph) {
+        for (const node2 of this._currentGraph.nodes) {
+          const nodeType = NODE_TYPES[node2.type];
+          if (nodeType.onStart) {
+            nodeType.onStart(node2, this);
+          }
+        }
+      }
+    }
+    evaluateAt(time, frameTimestamp = time * 1e3) {
+      this._activatePendingGraph(true);
+      if (!this._currentGraph) return;
+      this._effects = [];
+      const dt2 = this._computeDeltaTime(frameTimestamp);
+      const ctx = {
+        time,
+        dt: dt2,
+        engine: this,
+        nodePredicates: /* @__PURE__ */ new Map()
+      };
+      for (const node2 of this._currentGraph.nodes) {
+        const nodeType = NODE_TYPES[node2.type];
+        for (const output of nodeType.outputs) {
+          if (output.kind === "event") {
+            this._values.set(`${node2.id}.${output.name}`, []);
+          }
+        }
+      }
+      for (const { ref, payload } of this._eventQueue) {
+        const current = this._values.get(ref) || [];
+        current.push(payload);
+        this._values.set(ref, current);
+      }
+      this._eventQueue = [];
+      for (const nodeId of this._sortedNodeIds) {
+        const node2 = this._currentGraph.nodes.find((n2) => n2.id === nodeId);
+        const nodeType = NODE_TYPES[node2.type];
+        if (nodeType.category === "input" && nodeType.outputs.length > 0 && nodeType.outputs.every((o) => o.kind === "event")) {
+          continue;
+        }
+        const inputs = {};
+        for (const inputDef of nodeType.inputs) {
+          const portName = inputDef.name;
+          const ref = `${nodeId}.${portName}`;
+          const edge = this._currentGraph.edges.find((e) => e.to === ref);
+          if (edge) {
+            if (inputDef.kind === "event") {
+              inputs[portName] = this._values.get(edge.from) || [];
+            } else {
+              inputs[portName] = this._values.get(edge.from);
+            }
+          } else {
+            const paramValue = node2.params && node2.params[portName];
+            if (paramValue !== void 0) {
+              inputs[portName] = paramValue;
+            } else {
+              inputs[portName] = inputDef.default;
+            }
+          }
+        }
+        const params = {};
+        for (const paramDef of nodeType.params) {
+          const paramName = paramDef.name;
+          const paramValue = node2.params && node2.params[paramName];
+          if (paramValue !== void 0) {
+            params[paramName] = paramValue;
+          } else {
+            params[paramName] = paramDef.default;
+          }
+        }
+        let outputs;
+        if (nodeType.category === "state") {
+          const initial = coerceFiniteNumber(params.initial, 0);
+          const prevOut = this._prevOuts.has(nodeId) ? this._prevOuts.get(nodeId) : initial;
+          const stateCtx = { ...ctx, prevOut: sanitizeStateValue(prevOut, initial) };
+          try {
+            outputs = nodeType.evaluate(inputs, params, stateCtx);
+            const rawOut = outputs?.out;
+            const rawNewState = outputs?._newState !== void 0 ? outputs._newState : rawOut;
+            const safeOut = sanitizeStateValue(rawOut, initial);
+            const safeNewState = sanitizeStateValue(rawNewState, initial);
+            outputs = { ...outputs, out: safeOut };
+            this._prevOuts.set(nodeId, safeNewState);
+          } catch (error) {
+            console.error(`State node evaluation failed: ${nodeId}`, error);
+            outputs = { out: stateCtx.prevOut };
+          }
+        } else {
+          outputs = nodeType.evaluate(inputs, params, { ...ctx, currentNodeId: nodeId });
+        }
+        for (const outputDef of nodeType.outputs) {
+          const portName = outputDef.name;
+          const ref = `${nodeId}.${portName}`;
+          if (outputDef.kind === "event") {
+            this._values.set(ref, outputs[portName] || []);
+          } else {
+            this._values.set(ref, outputs[portName]);
+          }
+        }
+      }
+    }
+    evaluateOnce({ time = 0, dt: dt2 = 0 } = {}) {
+      const safeTime = Number.isFinite(time) ? time : 0;
+      const safeDt = Number.isFinite(dt2) ? Math.max(0, dt2) : 0;
+      const frameTimestamp = safeTime * 1e3;
+      this._activatePendingGraph(false);
+      this._lastTimestamp = frameTimestamp - safeDt * 1e3;
+      this.evaluateAt(safeTime, frameTimestamp);
+    }
+    getValue(ref) {
+      return this._values.get(ref);
+    }
+    getEffects() {
+      return [...this._effects];
+    }
+    _recordEffect(effect) {
+      this._effects.push(effect);
+    }
+    dispatchEvent(ref, payload) {
+      const [nodeId, portName] = ref.split(".");
+      if (!nodeId || !portName) {
+        throw new LoomError(
+          "INVALID_GRAPH",
+          'dispatchEvent ref must be in format "nodeId.portName"',
+          { reason: "invalid ref format" }
+        );
+      }
+      if (!this._currentGraph) {
+        throw new LoomError("UNKNOWN_NODE", `dispatchEvent references non-existent node: ${nodeId}`, { nodeId });
+      }
+      const node2 = this._currentGraph.nodes.find((n2) => n2.id === nodeId);
+      if (!node2) {
+        throw new LoomError("UNKNOWN_NODE", `dispatchEvent references non-existent node: ${nodeId}`, { nodeId });
+      }
+      const nodeType = NODE_TYPES[node2.type];
+      const outputPort = nodeType.outputs.find((o) => o.name === portName);
+      if (!outputPort) {
+        throw new LoomError(
+          "UNKNOWN_PORT",
+          `dispatchEvent references non-existent port: ${ref}`,
+          { nodeId, port: portName, side: "output" }
+        );
+      }
+      if (outputPort.kind !== "event") {
+        throw new LoomError(
+          "TYPE_MISMATCH",
+          `dispatchEvent target must be Event port`,
+          { from: ref, to: ref, fromType: outputPort.kind, toType: "event" }
+        );
+      }
+      this._eventQueue.push({ ref, payload });
+    }
+    load(graph) {
+      this._validateGraph(graph);
+      const sortedNodeIds = this._topologicalSort(graph);
+      this._pendingGraph = graph;
+      this._pendingNodeIds = sortedNodeIds;
+    }
+    start() {
+      if (this._rafId !== null) return;
+      if (this._currentGraph) {
+        for (const node2 of this._currentGraph.nodes) {
+          const nodeType = NODE_TYPES[node2.type];
+          if (nodeType.onStart) {
+            nodeType.onStart(node2, this);
+          }
+        }
+      }
+      this._lastTimestamp = null;
+      this._startTime = performance.now() / 1e3;
+      const tick = (timestamp) => {
+        const elapsed = timestamp / 1e3 - this._startTime;
+        this.evaluateAt(elapsed, timestamp);
+        this._rafId = requestAnimationFrame(tick);
+      };
+      this._rafId = requestAnimationFrame(tick);
+    }
+    stop() {
+      if (this._rafId !== null) {
+        cancelAnimationFrame(this._rafId);
+        this._rafId = null;
+      }
+      if (this._currentGraph) {
+        for (const node2 of this._currentGraph.nodes) {
+          const nodeType = NODE_TYPES[node2.type];
+          if (nodeType.onStop) {
+            nodeType.onStop(node2, this);
+          }
+        }
+      }
+    }
+    _computeDeltaTime(frameTimestamp) {
+      if (this._lastTimestamp === null) {
+        this._lastTimestamp = frameTimestamp;
+        return 0;
+      }
+      const dt2 = Math.max(0, (frameTimestamp - this._lastTimestamp) / 1e3);
+      this._lastTimestamp = frameTimestamp;
+      return Math.min(dt2, 0.1);
+    }
+    _reconcileStateForGraph(graph) {
+      const nextStateIds = new Set(
+        graph.nodes.filter((node2) => NODE_TYPES[node2.type]?.category === "state").map((node2) => node2.id)
+      );
+      for (const nodeId of Array.from(this._prevOuts.keys())) {
+        if (!nextStateIds.has(nodeId)) {
+          this._prevOuts.delete(nodeId);
+        }
+      }
+    }
+    // 内部メソッド：グラフの検証とソート
+    _loadGraphInternal(graph) {
+      this._validateGraph(graph);
+      const sortedNodeIds = this._topologicalSort(graph);
+      this._currentGraph = graph;
+      this._sortedNodeIds = sortedNodeIds;
+      this._pendingGraph = null;
+      this._reconcileStateForGraph(graph);
+    }
+    // グラフの検証
+    _validateGraph(graph) {
+      if (!graph || typeof graph !== "object") {
+        throw new LoomError("INVALID_GRAPH", "Graph must be an object", { reason: "not an object" });
+      }
+      if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+        throw new LoomError("INVALID_GRAPH", "Graph must have nodes and edges arrays", { reason: "nodes or edges not an array" });
+      }
+      const nodeIds = /* @__PURE__ */ new Set();
+      for (const node2 of graph.nodes) {
+        if (nodeIds.has(node2.id)) {
+          throw new LoomError("DUPLICATE_NODE_ID", `Duplicate node id: ${node2.id}`, { nodeId: node2.id });
+        }
+        nodeIds.add(node2.id);
+      }
+      for (const node2 of graph.nodes) {
+        if (!NODE_TYPES[node2.type]) {
+          throw new LoomError("UNKNOWN_NODE_TYPE", `Unknown node type: ${node2.type}`, { nodeId: node2.id, type: node2.type });
+        }
+      }
+      for (const edge of graph.edges) {
+        const fromParts = edge.from.split(".");
+        const toParts = edge.to.split(".");
+        if (fromParts.length !== 2) {
+          throw new LoomError("INVALID_GRAPH", 'Edge from must be in format "nodeId.portName"', { reason: "invalid edge format" });
+        }
+        if (toParts.length !== 2) {
+          throw new LoomError("INVALID_GRAPH", 'Edge to must be in format "nodeId.portName"', { reason: "invalid edge format" });
+        }
+        const fromNodeId = fromParts[0];
+        const toNodeId = toParts[0];
+        if (!nodeIds.has(fromNodeId)) {
+          throw new LoomError("UNKNOWN_NODE", `Edge references non-existent node: ${fromNodeId}`, { nodeId: fromNodeId });
+        }
+        if (!nodeIds.has(toNodeId)) {
+          throw new LoomError("UNKNOWN_NODE", `Edge references non-existent node: ${toNodeId}`, { nodeId: toNodeId });
+        }
+        const fromPortName = fromParts[1];
+        const toPortName = toParts[1];
+        const fromNode = graph.nodes.find((n2) => n2.id === fromNodeId);
+        const fromNodeType = NODE_TYPES[fromNode.type];
+        const fromPort = fromNodeType.outputs.find((o) => o.name === fromPortName);
+        if (!fromPort) {
+          throw new LoomError("UNKNOWN_PORT", `Unknown port: ${fromNodeId}.${fromPortName}`, { nodeId: fromNodeId, port: fromPortName, side: "output" });
+        }
+        const toNode = graph.nodes.find((n2) => n2.id === toNodeId);
+        const toNodeType = NODE_TYPES[toNode.type];
+        const toPort = toNodeType.inputs.find((i2) => i2.name === toPortName);
+        if (!toPort) {
+          throw new LoomError("UNKNOWN_PORT", `Unknown port: ${toNodeId}.${toPortName}`, { nodeId: toNodeId, port: toPortName, side: "input" });
+        }
+        const fromKind = fromPort.kind;
+        const toKind = toPort.kind;
+        const isSampleValueException = toNode.type === "sample" && toPortName === "value";
+        if (fromKind !== toKind && !isSampleValueException) {
+          throw new LoomError(
+            "TYPE_MISMATCH",
+            `Cannot connect ${fromKind} port to ${toKind} port`,
+            { from: edge.from, to: edge.to, fromType: fromKind, toType: toKind }
+          );
+        }
+      }
+      const inputEdges = /* @__PURE__ */ new Map();
+      for (const edge of graph.edges) {
+        const to = edge.to;
+        if (inputEdges.has(to)) {
+          const toParts = to.split(".");
+          throw new LoomError("DUPLICATE_INPUT_EDGE", `Multiple edges connected to input port: ${to}`, { nodeId: toParts[0], port: toParts[1] });
+        }
+        inputEdges.set(to, edge);
+      }
+      const hasCycle = this._hasCycle(graph);
+      if (hasCycle) {
+        const cycleNodeIds = this._findCycleNodeIds(graph);
+        throw new LoomError("CYCLE", "Graph contains a cycle", { nodeIds: cycleNodeIds });
+      }
+      for (const node2 of graph.nodes) {
+        if (node2.type === "filter") {
+          const predicate = (node2.params && node2.params.predicate) ?? "true";
+          const dslEval = new RestrictedDSLEvaluator(predicate, node2.id);
+          dslEval.evaluate();
+        }
+      }
+    }
+    // トポロジカルソート（Kahn のアルゴリズム）
+    _topologicalSort(graph) {
+      const nodes = graph.nodes;
+      const edges = graph.edges;
+      const inDegree = /* @__PURE__ */ new Map();
+      const adjList = /* @__PURE__ */ new Map();
+      for (const node2 of nodes) {
+        inDegree.set(node2.id, 0);
+        adjList.set(node2.id, []);
+      }
+      for (const edge of edges) {
+        const fromParts = edge.from.split(".");
+        const toParts = edge.to.split(".");
+        const fromNodeId = fromParts[0];
+        const toNodeId = toParts[0];
+        adjList.get(fromNodeId).push(toNodeId);
+        inDegree.set(toNodeId, inDegree.get(toNodeId) + 1);
+      }
+      const queue = [];
+      for (const [nodeId, degree] of inDegree) {
+        if (degree === 0) {
+          queue.push(nodeId);
+        }
+      }
+      const sorted = [];
+      while (queue.length > 0) {
+        const nodeId = queue.shift();
+        sorted.push(nodeId);
+        for (const neighbor of adjList.get(nodeId)) {
+          inDegree.set(neighbor, inDegree.get(neighbor) - 1);
+          if (inDegree.get(neighbor) === 0) {
+            queue.push(neighbor);
+          }
+        }
+      }
+      return sorted;
+    }
+    // サイクル検出（DFS）
+    _hasCycle(graph) {
+      const nodes = graph.nodes;
+      const edges = graph.edges;
+      const adjList = /* @__PURE__ */ new Map();
+      for (const node2 of nodes) {
+        adjList.set(node2.id, []);
+      }
+      for (const edge of edges) {
+        const fromParts = edge.from.split(".");
+        const toParts = edge.to.split(".");
+        const fromNodeId = fromParts[0];
+        const toNodeId = toParts[0];
+        adjList.get(fromNodeId).push(toNodeId);
+      }
+      const state = /* @__PURE__ */ new Map();
+      for (const node2 of nodes) {
+        state.set(node2.id, 0);
+      }
+      for (const node2 of nodes) {
+        if (state.get(node2.id) === 0) {
+          if (this._hasCycleDFS(node2.id, adjList, state)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+    // DFS ヘルパー
+    _hasCycleDFS(nodeId, adjList, state) {
+      state.set(nodeId, 1);
+      for (const neighbor of adjList.get(nodeId)) {
+        const neighborState = state.get(neighbor);
+        if (neighborState === 1) {
+          return true;
+        }
+        if (neighborState === 0) {
+          if (this._hasCycleDFS(neighbor, adjList, state)) {
+            return true;
+          }
+        }
+      }
+      state.set(nodeId, 2);
+      return false;
+    }
+    // サイクルに含まれるノード ID を見つける
+    _findCycleNodeIds(graph) {
+      const nodes = graph.nodes;
+      const edges = graph.edges;
+      const adjList = /* @__PURE__ */ new Map();
+      for (const node2 of nodes) {
+        adjList.set(node2.id, []);
+      }
+      for (const edge of edges) {
+        const fromParts = edge.from.split(".");
+        const toParts = edge.to.split(".");
+        const fromNodeId = fromParts[0];
+        const toNodeId = toParts[0];
+        adjList.get(fromNodeId).push(toNodeId);
+      }
+      const visited = /* @__PURE__ */ new Set();
+      const recStack = /* @__PURE__ */ new Set();
+      const cycleNodes = /* @__PURE__ */ new Set();
+      const dfs = (nodeId) => {
+        visited.add(nodeId);
+        recStack.add(nodeId);
+        for (const neighbor of adjList.get(nodeId)) {
+          if (!visited.has(neighbor)) {
+            if (dfs(neighbor)) {
+              cycleNodes.add(nodeId);
+              return true;
+            }
+          } else if (recStack.has(neighbor)) {
+            cycleNodes.add(nodeId);
+            cycleNodes.add(neighbor);
+            return true;
+          }
+        }
+        recStack.delete(nodeId);
+        return false;
+      };
+      for (const node2 of nodes) {
+        if (!visited.has(node2.id)) {
+          dfs(node2.id);
+        }
+      }
+      return Array.from(cycleNodes);
+    }
+  };
 
   // ../../editor-studio/src/rete-operation-helpers.js
   function connectionToAddEdgeOp(connection) {
@@ -15737,29 +16204,20 @@ var LoomletPreview = (() => {
   var editorView = null;
   var editorVisible = true;
   var lastErrors = [];
-  var currentRenderPreview = { items: [], unsupported: [] };
+  var loomEngine = null;
+  var loomRafId = null;
+  var currentGraph = null;
   function resizePreviewCanvas() {
     const canvas = document.getElementById("lp-preview-canvas");
     if (!canvas) return;
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.round(window.innerWidth * dpr);
     canvas.height = Math.round(window.innerHeight * dpr);
-    drawPreviewCanvas(dpr);
-  }
-  function drawPreviewCanvas(dpr) {
-    const canvas = document.getElementById("lp-preview-canvas");
-    if (!canvas) return;
-    drawPreviewBackground(canvas, dpr);
-    if (currentRenderPreview.items && currentRenderPreview.items.length > 0) {
-      drawRenderItems(canvas, currentRenderPreview.items, dpr);
-    } else {
-      drawPlaceholderText(canvas, dpr);
-    }
-    if (currentRenderPreview.unsupported && currentRenderPreview.unsupported.length > 0) {
-      drawUnsupportedHint(canvas, currentRenderPreview.unsupported, dpr);
+    if (!loomEngine) {
+      drawPlaceholder(canvas, dpr);
     }
   }
-  function drawPreviewBackground(canvas, dpr) {
+  function drawPlaceholder(canvas, dpr) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     const w2 = canvas.width;
@@ -15775,12 +16233,6 @@ var LoomletPreview = (() => {
         ctx.fill();
       }
     }
-  }
-  function drawPlaceholderText(canvas, dpr) {
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    const w2 = canvas.width;
-    const h2 = canvas.height;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.fillStyle = "rgba(255,255,255,0.18)";
@@ -15788,81 +16240,89 @@ var LoomletPreview = (() => {
     ctx.fillText("Runtime Preview", w2 / 2, h2 / 2 - Math.round(13 * dpr));
     ctx.fillStyle = "rgba(255,255,255,0.09)";
     ctx.font = `${Math.round(11 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
-    ctx.fillText("render output will appear here", w2 / 2, h2 / 2 + Math.round(13 * dpr));
+    ctx.fillText("add render bar() or render point() to see output", w2 / 2, h2 / 2 + Math.round(13 * dpr));
   }
-  function drawRenderItems(canvas, items, dpr) {
+  function resolveValue(engine, ref) {
+    if (typeof ref === "number") return ref;
+    if (ref === null || ref === void 0) return null;
+    const numVal = parseFloat(ref);
+    if (!isNaN(numVal) && String(ref).trim() === String(numVal)) return numVal;
+    return engine.getValue(ref);
+  }
+  function drawFrame() {
+    const canvas = document.getElementById("lp-preview-canvas");
+    if (!canvas || !loomEngine || !currentGraph) return;
+    const dpr = window.devicePixelRatio || 1;
     const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    for (const item of items) {
-      try {
-        if (item.kind === "circle") {
-          drawCircle(ctx, item, dpr);
-        } else if (item.kind === "rect") {
-          drawRect(ctx, item, dpr);
-        } else if (item.kind === "bar") {
-          drawBar(ctx, item, dpr);
-        } else if (item.kind === "text") {
-          drawText(ctx, item, dpr);
-        }
-      } catch (e) {
-        console.warn("Failed to draw render item:", item, e);
+    const w2 = canvas.width;
+    const h2 = canvas.height;
+    const renderConfig = currentGraph.render;
+    const trail = renderConfig?.trail !== void 0 ? renderConfig.trail : 0.1;
+    if (trail > 0) {
+      ctx.fillStyle = `rgba(0, 0, 0, ${trail})`;
+      ctx.fillRect(0, 0, w2, h2);
+    } else {
+      ctx.fillStyle = "#1a1a1a";
+      ctx.fillRect(0, 0, w2, h2);
+    }
+    if (renderConfig?.type === "point") {
+      const x2 = resolveValue(loomEngine, renderConfig.x);
+      const y = resolveValue(loomEngine, renderConfig.y);
+      const color = renderConfig.color || "#00ff00";
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      if (x2 !== null && typeof x2 === "number" && y !== null && typeof y === "number") {
+        ctx.arc(x2 * dpr, y * dpr, 4 * dpr, 0, Math.PI * 2);
+      } else {
+        ctx.arc(w2 / 2, h2 / 2, 4 * dpr, 0, Math.PI * 2);
+      }
+      ctx.fill();
+    } else if (renderConfig?.type === "bar") {
+      const width = resolveValue(loomEngine, renderConfig.width);
+      const color = renderConfig.color || "#00ccff";
+      const cssHeight = renderConfig.height !== void 0 ? renderConfig.height : 40;
+      const heightPx = cssHeight * dpr;
+      const cssY = renderConfig.y !== void 0 ? resolveValue(loomEngine, renderConfig.y) : null;
+      const yPx = cssY !== null && typeof cssY === "number" ? cssY * dpr : (h2 - heightPx) / 2;
+      if (width !== null && typeof width === "number") {
+        ctx.fillStyle = color;
+        ctx.fillRect(0, yPx, width * dpr, heightPx);
       }
     }
+    loomRafId = requestAnimationFrame(drawFrame);
   }
-  function drawCircle(ctx, item, dpr) {
-    const x2 = (item.x || 100) * dpr;
-    const y = (item.y || 100) * dpr;
-    const r2 = (item.r || 24) * dpr;
-    const color = item.color || "#80ed99";
-    ctx.fillStyle = color;
-    ctx.beginPath();
-    ctx.arc(x2, y, r2, 0, Math.PI * 2);
-    ctx.fill();
+  function stopLoom() {
+    if (loomRafId !== null) {
+      cancelAnimationFrame(loomRafId);
+      loomRafId = null;
+    }
+    if (loomEngine) {
+      try {
+        loomEngine.stop();
+      } catch (_) {
+      }
+      loomEngine = null;
+    }
   }
-  function drawRect(ctx, item, dpr) {
-    const x2 = (item.x || 80) * dpr;
-    const y = (item.y || 80) * dpr;
-    const width = (item.width || 120) * dpr;
-    const height = (item.height || 80) * dpr;
-    const color = item.color || "#70d6ff";
-    ctx.fillStyle = color;
-    ctx.fillRect(x2, y, width, height);
-  }
-  function drawBar(ctx, item, dpr) {
-    const x2 = (item.x || 40) * dpr;
-    const y = (item.y || 120) * dpr;
-    const width = (item.width || 240) * dpr;
-    const height = (item.height || 24) * dpr;
-    const value = Math.max(0, Math.min(1, item.value || 0.5));
-    const color = item.color || "#ffd166";
-    const bgColor = item.backgroundColor || "rgba(255,255,255,0.12)";
-    ctx.fillStyle = bgColor;
-    ctx.fillRect(x2, y, width, height);
-    ctx.fillStyle = color;
-    ctx.fillRect(x2, y, width * value, height);
-  }
-  function drawText(ctx, item, dpr) {
-    const x2 = (item.x || 40) * dpr;
-    const y = (item.y || 60) * dpr;
-    const text = item.text || "text";
-    const color = item.color || "#ffffff";
-    const size = item.size || 18;
-    ctx.fillStyle = color;
-    ctx.font = `${Math.round(size * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    ctx.fillText(text, x2, y);
-  }
-  function drawUnsupportedHint(canvas, unsupported, dpr) {
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    const count = unsupported.length;
-    const hintText = `${count} unsupported render item${count > 1 ? "s" : ""}`;
-    ctx.fillStyle = "rgba(255,150,100,0.4)";
-    ctx.font = `${Math.round(10 * dpr)}px monospace`;
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    ctx.fillText(hintText, Math.round(12 * dpr), Math.round(canvas.height - 24 * dpr));
+  function startLoom(graph) {
+    stopLoom();
+    currentGraph = graph || null;
+    if (!graph) {
+      const canvas = document.getElementById("lp-preview-canvas");
+      if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
+      return;
+    }
+    try {
+      const graphForLoom = { nodes: graph.nodes || [], edges: graph.edges || [] };
+      loomEngine = new Loom(graphForLoom);
+      loomEngine.start();
+      loomRafId = requestAnimationFrame(drawFrame);
+    } catch (e) {
+      console.error("[loomlet-preview] Loom engine start failed:", e);
+      stopLoom();
+      const canvas = document.getElementById("lp-preview-canvas");
+      if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
+    }
   }
   function setStatus(text, isError) {
     const el = document.getElementById("lp-status");
@@ -15875,22 +16335,6 @@ var LoomletPreview = (() => {
       el.style.borderLeftColor = "#4a90e2";
       el.style.color = "#9cdcfe";
     }
-  }
-  function buildStatusText(editorModel, errors, renderPreview) {
-    let status = "";
-    if (editorModel && renderPreview) {
-      status = "Synced";
-      if (renderPreview.items && renderPreview.items.length > 0) {
-        status += ` \xB7 ${renderPreview.items.length} render item${renderPreview.items.length > 1 ? "s" : ""}`;
-      }
-      if (renderPreview.unsupported && renderPreview.unsupported.length > 0) {
-        status += ` \xB7 ${renderPreview.unsupported.length} unsupported`;
-      }
-    } else {
-      status = "Empty";
-    }
-    status += " \xB7 Read-only Node Preview";
-    return status;
   }
   function setErrors(errors) {
     lastErrors = errors || [];
@@ -15947,25 +16391,22 @@ var LoomletPreview = (() => {
   window.addEventListener("message", async (event) => {
     const message = event.data;
     if (!message || message.type !== "setModel") return;
-    const { editorModel, errors, renderPreview } = message;
+    const { editorModel, graph, errors } = message;
     if (errors && errors.length > 0) {
       setStatus("DSL has errors \xB7 Read-only Node Preview", true);
       setErrors(errors);
       return;
     }
     setErrors([]);
-    if (renderPreview) {
-      currentRenderPreview = renderPreview;
-      resizePreviewCanvas();
-    }
+    startLoom(graph || null);
     if (!editorModel) {
-      setStatus(buildStatusText(null, [], renderPreview), false);
+      setStatus("Empty \xB7 Read-only Node Preview", false);
       return;
     }
     initEditorView();
     try {
       await editorView.renderModel(editorModel);
-      setStatus(buildStatusText(editorModel, [], renderPreview), false);
+      setStatus("Synced \xB7 Read-only Node Preview", false);
     } catch (e) {
       console.error("[loomlet-preview] renderModel failed:", e);
       setStatus("Render error \xB7 Read-only Node Preview", true);

--- a/extensions/vscode-loomlet/media/node-editor-webview.js
+++ b/extensions/vscode-loomlet/media/node-editor-webview.js
@@ -15737,15 +15737,29 @@ var LoomletPreview = (() => {
   var editorView = null;
   var editorVisible = true;
   var lastErrors = [];
+  var currentRenderPreview = { items: [], unsupported: [] };
   function resizePreviewCanvas() {
     const canvas = document.getElementById("lp-preview-canvas");
     if (!canvas) return;
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.round(window.innerWidth * dpr);
     canvas.height = Math.round(window.innerHeight * dpr);
-    drawPreviewPlaceholder(canvas, dpr);
+    drawPreviewCanvas(dpr);
   }
-  function drawPreviewPlaceholder(canvas, dpr) {
+  function drawPreviewCanvas(dpr) {
+    const canvas = document.getElementById("lp-preview-canvas");
+    if (!canvas) return;
+    drawPreviewBackground(canvas, dpr);
+    if (currentRenderPreview.items && currentRenderPreview.items.length > 0) {
+      drawRenderItems(canvas, currentRenderPreview.items, dpr);
+    } else {
+      drawPlaceholderText(canvas, dpr);
+    }
+    if (currentRenderPreview.unsupported && currentRenderPreview.unsupported.length > 0) {
+      drawUnsupportedHint(canvas, currentRenderPreview.unsupported, dpr);
+    }
+  }
+  function drawPreviewBackground(canvas, dpr) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     const w2 = canvas.width;
@@ -15761,6 +15775,12 @@ var LoomletPreview = (() => {
         ctx.fill();
       }
     }
+  }
+  function drawPlaceholderText(canvas, dpr) {
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const w2 = canvas.width;
+    const h2 = canvas.height;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.fillStyle = "rgba(255,255,255,0.18)";
@@ -15769,6 +15789,80 @@ var LoomletPreview = (() => {
     ctx.fillStyle = "rgba(255,255,255,0.09)";
     ctx.font = `${Math.round(11 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
     ctx.fillText("render output will appear here", w2 / 2, h2 / 2 + Math.round(13 * dpr));
+  }
+  function drawRenderItems(canvas, items, dpr) {
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    for (const item of items) {
+      try {
+        if (item.kind === "circle") {
+          drawCircle(ctx, item, dpr);
+        } else if (item.kind === "rect") {
+          drawRect(ctx, item, dpr);
+        } else if (item.kind === "bar") {
+          drawBar(ctx, item, dpr);
+        } else if (item.kind === "text") {
+          drawText(ctx, item, dpr);
+        }
+      } catch (e) {
+        console.warn("Failed to draw render item:", item, e);
+      }
+    }
+  }
+  function drawCircle(ctx, item, dpr) {
+    const x2 = (item.x || 100) * dpr;
+    const y = (item.y || 100) * dpr;
+    const r2 = (item.r || 24) * dpr;
+    const color = item.color || "#80ed99";
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(x2, y, r2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  function drawRect(ctx, item, dpr) {
+    const x2 = (item.x || 80) * dpr;
+    const y = (item.y || 80) * dpr;
+    const width = (item.width || 120) * dpr;
+    const height = (item.height || 80) * dpr;
+    const color = item.color || "#70d6ff";
+    ctx.fillStyle = color;
+    ctx.fillRect(x2, y, width, height);
+  }
+  function drawBar(ctx, item, dpr) {
+    const x2 = (item.x || 40) * dpr;
+    const y = (item.y || 120) * dpr;
+    const width = (item.width || 240) * dpr;
+    const height = (item.height || 24) * dpr;
+    const value = Math.max(0, Math.min(1, item.value || 0.5));
+    const color = item.color || "#ffd166";
+    const bgColor = item.backgroundColor || "rgba(255,255,255,0.12)";
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(x2, y, width, height);
+    ctx.fillStyle = color;
+    ctx.fillRect(x2, y, width * value, height);
+  }
+  function drawText(ctx, item, dpr) {
+    const x2 = (item.x || 40) * dpr;
+    const y = (item.y || 60) * dpr;
+    const text = item.text || "text";
+    const color = item.color || "#ffffff";
+    const size = item.size || 18;
+    ctx.fillStyle = color;
+    ctx.font = `${Math.round(size * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    ctx.fillText(text, x2, y);
+  }
+  function drawUnsupportedHint(canvas, unsupported, dpr) {
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const count = unsupported.length;
+    const hintText = `${count} unsupported render item${count > 1 ? "s" : ""}`;
+    ctx.fillStyle = "rgba(255,150,100,0.4)";
+    ctx.font = `${Math.round(10 * dpr)}px monospace`;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    ctx.fillText(hintText, Math.round(12 * dpr), Math.round(canvas.height - 24 * dpr));
   }
   function setStatus(text, isError) {
     const el = document.getElementById("lp-status");
@@ -15781,6 +15875,22 @@ var LoomletPreview = (() => {
       el.style.borderLeftColor = "#4a90e2";
       el.style.color = "#9cdcfe";
     }
+  }
+  function buildStatusText(editorModel, errors, renderPreview) {
+    let status = "";
+    if (editorModel && renderPreview) {
+      status = "Synced";
+      if (renderPreview.items && renderPreview.items.length > 0) {
+        status += ` \xB7 ${renderPreview.items.length} render item${renderPreview.items.length > 1 ? "s" : ""}`;
+      }
+      if (renderPreview.unsupported && renderPreview.unsupported.length > 0) {
+        status += ` \xB7 ${renderPreview.unsupported.length} unsupported`;
+      }
+    } else {
+      status = "Empty";
+    }
+    status += " \xB7 Read-only Node Preview";
+    return status;
   }
   function setErrors(errors) {
     lastErrors = errors || [];
@@ -15837,21 +15947,25 @@ var LoomletPreview = (() => {
   window.addEventListener("message", async (event) => {
     const message = event.data;
     if (!message || message.type !== "setModel") return;
-    const { editorModel, errors } = message;
+    const { editorModel, errors, renderPreview } = message;
     if (errors && errors.length > 0) {
       setStatus("DSL has errors \xB7 Read-only Node Preview", true);
       setErrors(errors);
       return;
     }
     setErrors([]);
+    if (renderPreview) {
+      currentRenderPreview = renderPreview;
+      resizePreviewCanvas();
+    }
     if (!editorModel) {
-      setStatus("Empty \xB7 Read-only Node Preview", false);
+      setStatus(buildStatusText(null, [], renderPreview), false);
       return;
     }
     initEditorView();
     try {
       await editorView.renderModel(editorModel);
-      setStatus("Synced \xB7 Read-only Node Preview", false);
+      setStatus(buildStatusText(editorModel, [], renderPreview), false);
     } catch (e) {
       console.error("[loomlet-preview] renderModel failed:", e);
       setStatus("Render error \xB7 Read-only Node Preview", true);

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -11,6 +11,7 @@ const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('./prev
 let nodePreviewPanel = null;
 let currentPreviewDocument = null;
 let previousEditorModel = null;
+let previousRenderPreview = null;
 let previewDebounceTimer = null;
 const PREVIEW_DEBOUNCE_MS = 300;
 
@@ -146,6 +147,7 @@ function openNodePreviewToSide(context) {
     nodePreviewPanel = null;
     currentPreviewDocument = null;
     previousEditorModel = null;
+    previousRenderPreview = null;
   });
 
   // When the WebView JS finishes loading it sends { type: 'ready' }.
@@ -178,15 +180,21 @@ function sendDocumentToPreview(document) {
   if (!nodePreviewPanel) return;
 
   const text = document.getText();
-  const { editorModel, errors } = buildPreviewModelFromDsl(text, previousEditorModel);
+  const { editorModel, errors, renderPreview } = buildPreviewModelFromDsl(text, previousEditorModel);
 
   if (errors.length === 0 && editorModel) {
     previousEditorModel = editorModel;
   }
 
+  // On successful parse/compile, update renderPreview; on error, keep the last one
+  if (errors.length === 0 && renderPreview) {
+    previousRenderPreview = renderPreview;
+  }
+
   nodePreviewPanel.webview.postMessage({
     type: 'setModel',
     editorModel: errors.length === 0 ? editorModel : null,
+    renderPreview: previousRenderPreview || { items: [], unsupported: [] },
     errors
   });
 }

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -11,7 +11,7 @@ const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('./prev
 let nodePreviewPanel = null;
 let currentPreviewDocument = null;
 let previousEditorModel = null;
-let previousRenderPreview = null;
+let previousGraph = null;
 let previewDebounceTimer = null;
 const PREVIEW_DEBOUNCE_MS = 300;
 
@@ -147,7 +147,7 @@ function openNodePreviewToSide(context) {
     nodePreviewPanel = null;
     currentPreviewDocument = null;
     previousEditorModel = null;
-    previousRenderPreview = null;
+    previousGraph = null;
   });
 
   // When the WebView JS finishes loading it sends { type: 'ready' }.
@@ -180,21 +180,21 @@ function sendDocumentToPreview(document) {
   if (!nodePreviewPanel) return;
 
   const text = document.getText();
-  const { editorModel, errors, renderPreview } = buildPreviewModelFromDsl(text, previousEditorModel);
+  const { editorModel, graph, errors } = buildPreviewModelFromDsl(text, previousEditorModel);
 
   if (errors.length === 0 && editorModel) {
     previousEditorModel = editorModel;
   }
 
-  // On successful parse/compile, update renderPreview; on error, keep the last one
-  if (errors.length === 0 && renderPreview) {
-    previousRenderPreview = renderPreview;
+  // On success, update the graph for the Loom runtime; on error, keep the previous graph running
+  if (errors.length === 0 && graph) {
+    previousGraph = graph;
   }
 
   nodePreviewPanel.webview.postMessage({
     type: 'setModel',
     editorModel: errors.length === 0 ? editorModel : null,
-    renderPreview: previousRenderPreview || { items: [], unsupported: [] },
+    graph: errors.length === 0 ? graph : null,
     errors
   });
 }

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -11,7 +11,6 @@ const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('./prev
 let nodePreviewPanel = null;
 let currentPreviewDocument = null;
 let previousEditorModel = null;
-let previousGraph = null;
 let previewDebounceTimer = null;
 const PREVIEW_DEBOUNCE_MS = 300;
 
@@ -147,7 +146,6 @@ function openNodePreviewToSide(context) {
     nodePreviewPanel = null;
     currentPreviewDocument = null;
     previousEditorModel = null;
-    previousGraph = null;
   });
 
   // When the WebView JS finishes loading it sends { type: 'ready' }.
@@ -186,11 +184,7 @@ function sendDocumentToPreview(document) {
     previousEditorModel = editorModel;
   }
 
-  // On success, update the graph for the Loom runtime; on error, keep the previous graph running
-  if (errors.length === 0 && graph) {
-    previousGraph = graph;
-  }
-
+  // On error, send graph: null so the WebView stops the runtime preview
   nodePreviewPanel.webview.postMessage({
     type: 'setModel',
     editorModel: errors.length === 0 ? editorModel : null,

--- a/extensions/vscode-loomlet/src/preview-model.js
+++ b/extensions/vscode-loomlet/src/preview-model.js
@@ -26,34 +26,188 @@ async function ensurePreviewModulesLoaded() {
 }
 
 /**
+ * Extract render statements from AST into a static preview payload.
+ * Supports render circle/rect/bar/text with literal arguments only.
+ */
+function extractRenderPreview(ast) {
+  const items = [];
+  const unsupported = [];
+
+  if (!ast || !ast.body) {
+    return { items, unsupported };
+  }
+
+  for (const stmt of ast.body) {
+    if (stmt.type === 'RenderStatement' && stmt.call && stmt.call.callee) {
+      const kind = stmt.call.callee.name;
+
+      // Only handle supported render kinds
+      if (!['circle', 'rect', 'bar', 'text'].includes(kind)) {
+        continue;
+      }
+
+      const item = extractRenderItem(kind, stmt.call.args || []);
+
+      if (item.supported) {
+        delete item.supported;
+        items.push(item);
+      } else {
+        unsupported.push({ kind, reason: item.reason });
+      }
+    }
+  }
+
+  return { items, unsupported };
+}
+
+/**
+ * Extract a single render item from a render call.
+ * Returns { kind, ...args, supported: true } or { reason, supported: false }
+ */
+function extractRenderItem(kind, args) {
+  const params = {};
+  let hasUnsupported = false;
+  let unsupportedReason = null;
+
+  // Extract named arguments
+  for (const arg of args) {
+    if (arg.type !== 'NamedArg') continue;
+
+    const paramName = arg.name?.name;
+    if (!paramName) continue;
+
+    const value = extractLiteralValue(arg.value);
+    if (value === undefined) {
+      // Non-literal argument
+      hasUnsupported = true;
+      if (!unsupportedReason) {
+        unsupportedReason = `${paramName} is not a literal`;
+      }
+    } else {
+      params[paramName] = value;
+    }
+  }
+
+  if (hasUnsupported) {
+    return { reason: unsupportedReason, supported: false };
+  }
+
+  const defaults = getRenderDefaults(kind);
+  const merged = { ...defaults, ...params, kind };
+
+  // Validate required fields
+  const required = getRenderRequired(kind);
+  for (const field of required) {
+    if (!(field in merged)) {
+      return { reason: `missing required field '${field}'`, supported: false };
+    }
+  }
+
+  // Clamp value for bar
+  if (kind === 'bar' && typeof merged.value === 'number') {
+    merged.value = Math.max(0, Math.min(1, merged.value));
+  }
+
+  return { ...merged, supported: true };
+}
+
+/**
+ * Extract a literal value from an AST node.
+ * Returns the JS value or undefined if not a literal.
+ */
+function extractLiteralValue(node) {
+  if (!node) return undefined;
+
+  if (node.type === 'NumberLiteral') {
+    return Number(node.value);
+  }
+
+  if (node.type === 'StringLiteral') {
+    return node.value;
+  }
+
+  if (node.type === 'BooleanLiteral') {
+    return Boolean(node.value);
+  }
+
+  // Any other type (Identifier, CallExpression, etc.) is unsupported
+  return undefined;
+}
+
+/**
+ * Get default values for a render kind.
+ */
+function getRenderDefaults(kind) {
+  const defaults = {
+    circle: { x: 100, y: 100, r: 24, color: '#80ed99' },
+    rect: { x: 80, y: 80, width: 120, height: 80, color: '#70d6ff' },
+    bar: { x: 40, y: 120, width: 240, height: 24, value: 0.5, color: '#ffd166', backgroundColor: 'rgba(255,255,255,0.12)' },
+    text: { x: 40, y: 60, text: 'text', color: '#ffffff', size: 18 }
+  };
+  return defaults[kind] || {};
+}
+
+/**
+ * Get required fields for a render kind.
+ */
+function getRenderRequired(kind) {
+  // For now, no fields are strictly required; all have defaults
+  return [];
+}
+
+/**
  * Build a preview model from DSL source text.
- * Returns { editorModel, errors } where errors is an array of error objects.
+ * Returns { editorModel, errors, renderPreview } where renderPreview has { items, unsupported }.
  * On parse/compile failure, editorModel is null and errors is non-empty.
+ * renderPreview is always extracted from AST, regardless of compile success.
  * previousEditorModel is used to preserve node positions across updates.
  *
  * @param {string} sourceText
  * @param {object|null} previousEditorModel
- * @returns {{ editorModel: object|null, errors: object[] }}
+ * @returns {{ editorModel: object|null, errors: object[], renderPreview: object }}
  */
 function buildPreviewModelFromDsl(sourceText, previousEditorModel = null) {
   if (!modulesLoaded) {
-    return { editorModel: null, errors: [{ message: 'Preview modules not yet loaded' }] };
+    return {
+      editorModel: null,
+      errors: [{ message: 'Preview modules not yet loaded' }],
+      renderPreview: { items: [], unsupported: [] }
+    };
   }
 
   const cleanText = stripEditorMetadataFromDsl(sourceText || '');
 
   if (cleanText.trim() === '') {
-    return { editorModel: null, errors: [] };
+    return {
+      editorModel: null,
+      errors: [],
+      renderPreview: { items: [], unsupported: [] }
+    };
   }
 
   const { ast, errors: parseErrors } = parseDSLToAST(cleanText);
   if (parseErrors && parseErrors.length > 0) {
-    return { editorModel: null, errors: parseErrors };
+    return {
+      editorModel: null,
+      errors: parseErrors,
+      renderPreview: { items: [], unsupported: [] }
+    };
   }
 
+  // Extract render preview from AST (before compile, so we show renders even if compile fails)
+  const renderPreview = extractRenderPreview(ast);
+
   const { graph, errors: compileErrors } = compileToGraph(ast);
-  if (compileErrors && compileErrors.length > 0) {
-    return { editorModel: null, errors: compileErrors };
+  // Filter out "Unknown render function" errors - those are expected for unsupported render types
+  // We can still display those renders statically, so don't treat them as errors
+  const filteredErrors = (compileErrors || []).filter(err => !err.message?.includes('Unknown render function'));
+
+  if (filteredErrors && filteredErrors.length > 0) {
+    return {
+      editorModel: null,
+      errors: filteredErrors,
+      renderPreview
+    };
   }
 
   let editorModel = graphToEditorModel(graph);
@@ -61,7 +215,8 @@ function buildPreviewModelFromDsl(sourceText, previousEditorModel = null) {
     editorModel = preserveEditorModelLayout(editorModel, previousEditorModel);
   }
 
-  return { editorModel, errors: [] };
+  return { editorModel, errors: [], renderPreview };
 }
 
 module.exports = { ensurePreviewModulesLoaded, buildPreviewModelFromDsl };
+

--- a/extensions/vscode-loomlet/src/preview-model.js
+++ b/extensions/vscode-loomlet/src/preview-model.js
@@ -26,188 +26,41 @@ async function ensurePreviewModulesLoaded() {
 }
 
 /**
- * Extract render statements from AST into a static preview payload.
- * Supports render circle/rect/bar/text with literal arguments only.
- */
-function extractRenderPreview(ast) {
-  const items = [];
-  const unsupported = [];
-
-  if (!ast || !ast.body) {
-    return { items, unsupported };
-  }
-
-  for (const stmt of ast.body) {
-    if (stmt.type === 'RenderStatement' && stmt.call && stmt.call.callee) {
-      const kind = stmt.call.callee.name;
-
-      // Only handle supported render kinds
-      if (!['circle', 'rect', 'bar', 'text'].includes(kind)) {
-        continue;
-      }
-
-      const item = extractRenderItem(kind, stmt.call.args || []);
-
-      if (item.supported) {
-        delete item.supported;
-        items.push(item);
-      } else {
-        unsupported.push({ kind, reason: item.reason });
-      }
-    }
-  }
-
-  return { items, unsupported };
-}
-
-/**
- * Extract a single render item from a render call.
- * Returns { kind, ...args, supported: true } or { reason, supported: false }
- */
-function extractRenderItem(kind, args) {
-  const params = {};
-  let hasUnsupported = false;
-  let unsupportedReason = null;
-
-  // Extract named arguments
-  for (const arg of args) {
-    if (arg.type !== 'NamedArg') continue;
-
-    const paramName = arg.name?.name;
-    if (!paramName) continue;
-
-    const value = extractLiteralValue(arg.value);
-    if (value === undefined) {
-      // Non-literal argument
-      hasUnsupported = true;
-      if (!unsupportedReason) {
-        unsupportedReason = `${paramName} is not a literal`;
-      }
-    } else {
-      params[paramName] = value;
-    }
-  }
-
-  if (hasUnsupported) {
-    return { reason: unsupportedReason, supported: false };
-  }
-
-  const defaults = getRenderDefaults(kind);
-  const merged = { ...defaults, ...params, kind };
-
-  // Validate required fields
-  const required = getRenderRequired(kind);
-  for (const field of required) {
-    if (!(field in merged)) {
-      return { reason: `missing required field '${field}'`, supported: false };
-    }
-  }
-
-  // Clamp value for bar
-  if (kind === 'bar' && typeof merged.value === 'number') {
-    merged.value = Math.max(0, Math.min(1, merged.value));
-  }
-
-  return { ...merged, supported: true };
-}
-
-/**
- * Extract a literal value from an AST node.
- * Returns the JS value or undefined if not a literal.
- */
-function extractLiteralValue(node) {
-  if (!node) return undefined;
-
-  if (node.type === 'NumberLiteral') {
-    return Number(node.value);
-  }
-
-  if (node.type === 'StringLiteral') {
-    return node.value;
-  }
-
-  if (node.type === 'BooleanLiteral') {
-    return Boolean(node.value);
-  }
-
-  // Any other type (Identifier, CallExpression, etc.) is unsupported
-  return undefined;
-}
-
-/**
- * Get default values for a render kind.
- */
-function getRenderDefaults(kind) {
-  const defaults = {
-    circle: { x: 100, y: 100, r: 24, color: '#80ed99' },
-    rect: { x: 80, y: 80, width: 120, height: 80, color: '#70d6ff' },
-    bar: { x: 40, y: 120, width: 240, height: 24, value: 0.5, color: '#ffd166', backgroundColor: 'rgba(255,255,255,0.12)' },
-    text: { x: 40, y: 60, text: 'text', color: '#ffffff', size: 18 }
-  };
-  return defaults[kind] || {};
-}
-
-/**
- * Get required fields for a render kind.
- */
-function getRenderRequired(kind) {
-  // For now, no fields are strictly required; all have defaults
-  return [];
-}
-
-/**
  * Build a preview model from DSL source text.
- * Returns { editorModel, errors, renderPreview } where renderPreview has { items, unsupported }.
- * On parse/compile failure, editorModel is null and errors is non-empty.
- * renderPreview is always extracted from AST, regardless of compile success.
+ * Returns { editorModel, graph, errors }.
+ * - editorModel: null on failure, used for Node Editor overlay
+ * - graph: null on failure, sent to WebView for Loom runtime rendering
+ * - errors: array of parse/compile error objects
+ *
  * previousEditorModel is used to preserve node positions across updates.
  *
  * @param {string} sourceText
  * @param {object|null} previousEditorModel
- * @returns {{ editorModel: object|null, errors: object[], renderPreview: object }}
+ * @returns {{ editorModel: object|null, graph: object|null, errors: object[] }}
  */
 function buildPreviewModelFromDsl(sourceText, previousEditorModel = null) {
   if (!modulesLoaded) {
     return {
       editorModel: null,
-      errors: [{ message: 'Preview modules not yet loaded' }],
-      renderPreview: { items: [], unsupported: [] }
+      graph: null,
+      errors: [{ message: 'Preview modules not yet loaded' }]
     };
   }
 
   const cleanText = stripEditorMetadataFromDsl(sourceText || '');
 
   if (cleanText.trim() === '') {
-    return {
-      editorModel: null,
-      errors: [],
-      renderPreview: { items: [], unsupported: [] }
-    };
+    return { editorModel: null, graph: null, errors: [] };
   }
 
   const { ast, errors: parseErrors } = parseDSLToAST(cleanText);
   if (parseErrors && parseErrors.length > 0) {
-    return {
-      editorModel: null,
-      errors: parseErrors,
-      renderPreview: { items: [], unsupported: [] }
-    };
+    return { editorModel: null, graph: null, errors: parseErrors };
   }
 
-  // Extract render preview from AST (before compile, so we show renders even if compile fails)
-  const renderPreview = extractRenderPreview(ast);
-
   const { graph, errors: compileErrors } = compileToGraph(ast);
-  // Filter out "Unknown render function" errors - those are expected for unsupported render types
-  // We can still display those renders statically, so don't treat them as errors
-  const filteredErrors = (compileErrors || []).filter(err => !err.message?.includes('Unknown render function'));
-
-  if (filteredErrors && filteredErrors.length > 0) {
-    return {
-      editorModel: null,
-      errors: filteredErrors,
-      renderPreview
-    };
+  if (compileErrors && compileErrors.length > 0) {
+    return { editorModel: null, graph: null, errors: compileErrors };
   }
 
   let editorModel = graphToEditorModel(graph);
@@ -215,8 +68,7 @@ function buildPreviewModelFromDsl(sourceText, previousEditorModel = null) {
     editorModel = preserveEditorModelLayout(editorModel, previousEditorModel);
   }
 
-  return { editorModel, errors: [], renderPreview };
+  return { editorModel, graph, errors: [] };
 }
 
 module.exports = { ensurePreviewModulesLoaded, buildPreviewModelFromDsl };
-

--- a/extensions/vscode-loomlet/test/preview-model.test.mjs
+++ b/extensions/vscode-loomlet/test/preview-model.test.mjs
@@ -106,108 +106,59 @@ await ensurePreviewModulesLoaded();
   assert.equal(result.editorModel, null, 'null input should produce null editorModel');
 }
 
-// Test 11: render circle with literal args produces renderPreview item
+// Test 11: buildPreviewModelFromDsl returns a graph object on success
 {
-  const result = buildPreviewModelFromDsl('render circle(x: 160, y: 120, r: 32, color: "#80ed99")');
-  assert.equal(result.errors.length, 0, 'Valid render should produce no errors');
-  assert.ok(result.renderPreview, 'Should have renderPreview');
-  assert.equal(result.renderPreview.items.length, 1, 'Should have one render item');
-  assert.equal(result.renderPreview.items[0].kind, 'circle', 'Item should be a circle');
-  assert.equal(result.renderPreview.items[0].x, 160, 'Circle x should be 160');
-  assert.equal(result.renderPreview.items[0].y, 120, 'Circle y should be 120');
-  assert.equal(result.renderPreview.items[0].r, 32, 'Circle r should be 32');
-  assert.equal(result.renderPreview.items[0].color, '#80ed99', 'Circle color should match');
+  const result = buildPreviewModelFromDsl('x = 1');
+  assert.ok(result.graph, 'Valid DSL should return a graph');
+  assert.ok(Array.isArray(result.graph.nodes), 'graph should have nodes array');
+  assert.ok(Array.isArray(result.graph.edges), 'graph should have edges array');
 }
 
-// Test 12: render rect with literal args produces renderPreview item
+// Test 12: graph is null on parse error
 {
-  const result = buildPreviewModelFromDsl('render rect(x: 40, y: 180, width: 180, height: 48, color: "#70d6ff")');
-  assert.equal(result.errors.length, 0, 'Valid render should produce no errors');
-  assert.equal(result.renderPreview.items.length, 1, 'Should have one render item');
-  assert.equal(result.renderPreview.items[0].kind, 'rect', 'Item should be a rect');
-  assert.equal(result.renderPreview.items[0].x, 40, 'Rect x should be 40');
-  assert.equal(result.renderPreview.items[0].width, 180, 'Rect width should be 180');
-  assert.equal(result.renderPreview.items[0].height, 48, 'Rect height should be 48');
-}
-
-// Test 13: render bar with value clamps to 0-1
-{
-  const result1 = buildPreviewModelFromDsl('render bar(value: 1.5)');
-  assert.equal(result1.renderPreview.items[0].value, 1, 'Value > 1 should be clamped to 1');
-
-  const result2 = buildPreviewModelFromDsl('render bar(value: -0.5)');
-  assert.equal(result2.renderPreview.items[0].value, 0, 'Value < 0 should be clamped to 0');
-
-  const result3 = buildPreviewModelFromDsl('render bar(value: 0.7)');
-  assert.equal(result3.renderPreview.items[0].value, 0.7, 'Value 0.7 should be 0.7');
-}
-
-// Test 14: render text extracts text string
-{
-  const result = buildPreviewModelFromDsl('render text(x: 40, y: 70, text: "Hello Loomlet", color: "#ffffff")');
-  assert.equal(result.errors.length, 0, 'Valid render should produce no errors');
-  assert.equal(result.renderPreview.items.length, 1, 'Should have one render item');
-  assert.equal(result.renderPreview.items[0].kind, 'text', 'Item should be text');
-  assert.equal(result.renderPreview.items[0].text, 'Hello Loomlet', 'Text should match');
-  assert.equal(result.renderPreview.items[0].color, '#ffffff', 'Color should match');
-}
-
-// Test 15: render with identifier arg becomes unsupported
-{
-  const result = buildPreviewModelFromDsl('x = 160\nrender circle(x: x, y: 120, r: 32)');
-  assert.equal(result.errors.length, 0, 'Valid DSL should produce no errors');
-  assert.equal(result.renderPreview.items.length, 0, 'Circle with identifier x should not be in items');
-  assert.equal(result.renderPreview.unsupported.length, 1, 'Should have one unsupported item');
-  assert.equal(result.renderPreview.unsupported[0].kind, 'circle', 'Unsupported kind should be circle');
-  assert.ok(result.renderPreview.unsupported[0].reason.includes('x'), 'Reason should mention x');
-}
-
-// Test 16: invalid DSL returns errors and no renderPreview items
-{
-  const result = buildPreviewModelFromDsl('invalid syntax here');
+  const result = buildPreviewModelFromDsl('x = math.sine(t, frequency:');
+  assert.equal(result.graph, null, 'Parse error should produce null graph');
   assert.ok(result.errors.length > 0, 'Should have parse errors');
-  assert.equal(result.renderPreview.items.length, 0, 'Should have no render items on error');
 }
 
-// Test 17: empty DSL returns empty renderPreview
+// Test 13: graph is null on compile error
+{
+  const result = buildPreviewModelFromDsl('a = 1\nb = add(a, undefined_var)');
+  assert.equal(result.graph, null, 'Compile error should produce null graph');
+  assert.ok(result.errors.length > 0, 'Should have compile errors');
+}
+
+// Test 14: render bar produces graph.render with type bar
+{
+  const result = buildPreviewModelFromDsl('t = clock()\nwave = sine(t, freq: 0.5)\nrender bar(width: wave)');
+  assert.equal(result.errors.length, 0, 'Valid render bar DSL should have no errors');
+  assert.ok(result.graph, 'Should produce a graph');
+  assert.ok(result.graph.render, 'graph should have render config');
+  assert.equal(result.graph.render.type, 'bar', 'render type should be bar');
+}
+
+// Test 15: render point produces graph.render with type point
+{
+  const result = buildPreviewModelFromDsl('t = clock()\nx = sine(t, freq: 0.2)\nrender point(x: x, y: x)');
+  assert.equal(result.errors.length, 0, 'Valid render point DSL should have no errors');
+  assert.ok(result.graph, 'Should produce a graph');
+  assert.ok(result.graph.render, 'graph should have render config');
+  assert.equal(result.graph.render.type, 'point', 'render type should be point');
+}
+
+// Test 16: empty DSL returns null graph with no errors
 {
   const result = buildPreviewModelFromDsl('');
   assert.equal(result.errors.length, 0, 'Empty DSL should have no errors');
-  assert.equal(result.renderPreview.items.length, 0, 'Should have no render items');
-  assert.equal(result.renderPreview.unsupported.length, 0, 'Should have no unsupported items');
+  assert.equal(result.graph, null, 'Empty DSL should return null graph');
 }
 
-// Test 18: multiple render statements produce multiple items
+// Test 17: metadata-annotated DSL produces graph
 {
-  const result = buildPreviewModelFromDsl(`
-    render circle(x: 100, y: 100)
-    render rect(x: 200, y: 200)
-    render text(text: "hi")
-  `);
-  assert.equal(result.errors.length, 0, 'Valid DSL should have no errors');
-  assert.equal(result.renderPreview.items.length, 3, 'Should have three render items');
-  assert.equal(result.renderPreview.items[0].kind, 'circle', 'First item should be circle');
-  assert.equal(result.renderPreview.items[1].kind, 'rect', 'Second item should be rect');
-  assert.equal(result.renderPreview.items[2].kind, 'text', 'Third item should be text');
-}
-
-// Test 19: metadata comment付きDSLでも renderPreview が抽出できる
-{
-  const result = buildPreviewModelFromDsl(`
-    render circle(x: 100, y: 100, r: 50)
-
-    # @loomlet.editor {"version":1,"layout":{"nodes":{}}}
-  `);
-  assert.equal(result.errors.length, 0, 'Valid render with metadata should have no errors');
-  assert.equal(result.renderPreview.items.length, 1, 'Should extract render item from DSL with metadata');
-  assert.equal(result.renderPreview.items[0].kind, 'circle', 'Should be a circle');
-}
-
-// Test 20: render with partially literal args
-{
-  const result = buildPreviewModelFromDsl('x = 160\nrender circle(x: x, y: 120, r: 32, color: "#fff")');
-  assert.equal(result.renderPreview.items.length, 0, 'Circle with one non-literal arg should not render');
-  assert.equal(result.renderPreview.unsupported.length, 1, 'Should have one unsupported item');
+  const result = buildPreviewModelFromDsl(`t = clock()\nwave = sine(t)\nrender bar(width: wave)\n\n# @loomlet.editor {"version":1,"layout":{"nodes":{}}}`);
+  assert.equal(result.errors.length, 0, 'DSL with metadata should have no errors');
+  assert.ok(result.graph, 'Should produce a graph with metadata');
+  assert.equal(result.graph.render.type, 'bar', 'render type should be bar');
 }
 
 console.log('All preview-model tests passed!');

--- a/extensions/vscode-loomlet/test/preview-model.test.mjs
+++ b/extensions/vscode-loomlet/test/preview-model.test.mjs
@@ -106,4 +106,108 @@ await ensurePreviewModulesLoaded();
   assert.equal(result.editorModel, null, 'null input should produce null editorModel');
 }
 
+// Test 11: render circle with literal args produces renderPreview item
+{
+  const result = buildPreviewModelFromDsl('render circle(x: 160, y: 120, r: 32, color: "#80ed99")');
+  assert.equal(result.errors.length, 0, 'Valid render should produce no errors');
+  assert.ok(result.renderPreview, 'Should have renderPreview');
+  assert.equal(result.renderPreview.items.length, 1, 'Should have one render item');
+  assert.equal(result.renderPreview.items[0].kind, 'circle', 'Item should be a circle');
+  assert.equal(result.renderPreview.items[0].x, 160, 'Circle x should be 160');
+  assert.equal(result.renderPreview.items[0].y, 120, 'Circle y should be 120');
+  assert.equal(result.renderPreview.items[0].r, 32, 'Circle r should be 32');
+  assert.equal(result.renderPreview.items[0].color, '#80ed99', 'Circle color should match');
+}
+
+// Test 12: render rect with literal args produces renderPreview item
+{
+  const result = buildPreviewModelFromDsl('render rect(x: 40, y: 180, width: 180, height: 48, color: "#70d6ff")');
+  assert.equal(result.errors.length, 0, 'Valid render should produce no errors');
+  assert.equal(result.renderPreview.items.length, 1, 'Should have one render item');
+  assert.equal(result.renderPreview.items[0].kind, 'rect', 'Item should be a rect');
+  assert.equal(result.renderPreview.items[0].x, 40, 'Rect x should be 40');
+  assert.equal(result.renderPreview.items[0].width, 180, 'Rect width should be 180');
+  assert.equal(result.renderPreview.items[0].height, 48, 'Rect height should be 48');
+}
+
+// Test 13: render bar with value clamps to 0-1
+{
+  const result1 = buildPreviewModelFromDsl('render bar(value: 1.5)');
+  assert.equal(result1.renderPreview.items[0].value, 1, 'Value > 1 should be clamped to 1');
+
+  const result2 = buildPreviewModelFromDsl('render bar(value: -0.5)');
+  assert.equal(result2.renderPreview.items[0].value, 0, 'Value < 0 should be clamped to 0');
+
+  const result3 = buildPreviewModelFromDsl('render bar(value: 0.7)');
+  assert.equal(result3.renderPreview.items[0].value, 0.7, 'Value 0.7 should be 0.7');
+}
+
+// Test 14: render text extracts text string
+{
+  const result = buildPreviewModelFromDsl('render text(x: 40, y: 70, text: "Hello Loomlet", color: "#ffffff")');
+  assert.equal(result.errors.length, 0, 'Valid render should produce no errors');
+  assert.equal(result.renderPreview.items.length, 1, 'Should have one render item');
+  assert.equal(result.renderPreview.items[0].kind, 'text', 'Item should be text');
+  assert.equal(result.renderPreview.items[0].text, 'Hello Loomlet', 'Text should match');
+  assert.equal(result.renderPreview.items[0].color, '#ffffff', 'Color should match');
+}
+
+// Test 15: render with identifier arg becomes unsupported
+{
+  const result = buildPreviewModelFromDsl('x = 160\nrender circle(x: x, y: 120, r: 32)');
+  assert.equal(result.errors.length, 0, 'Valid DSL should produce no errors');
+  assert.equal(result.renderPreview.items.length, 0, 'Circle with identifier x should not be in items');
+  assert.equal(result.renderPreview.unsupported.length, 1, 'Should have one unsupported item');
+  assert.equal(result.renderPreview.unsupported[0].kind, 'circle', 'Unsupported kind should be circle');
+  assert.ok(result.renderPreview.unsupported[0].reason.includes('x'), 'Reason should mention x');
+}
+
+// Test 16: invalid DSL returns errors and no renderPreview items
+{
+  const result = buildPreviewModelFromDsl('invalid syntax here');
+  assert.ok(result.errors.length > 0, 'Should have parse errors');
+  assert.equal(result.renderPreview.items.length, 0, 'Should have no render items on error');
+}
+
+// Test 17: empty DSL returns empty renderPreview
+{
+  const result = buildPreviewModelFromDsl('');
+  assert.equal(result.errors.length, 0, 'Empty DSL should have no errors');
+  assert.equal(result.renderPreview.items.length, 0, 'Should have no render items');
+  assert.equal(result.renderPreview.unsupported.length, 0, 'Should have no unsupported items');
+}
+
+// Test 18: multiple render statements produce multiple items
+{
+  const result = buildPreviewModelFromDsl(`
+    render circle(x: 100, y: 100)
+    render rect(x: 200, y: 200)
+    render text(text: "hi")
+  `);
+  assert.equal(result.errors.length, 0, 'Valid DSL should have no errors');
+  assert.equal(result.renderPreview.items.length, 3, 'Should have three render items');
+  assert.equal(result.renderPreview.items[0].kind, 'circle', 'First item should be circle');
+  assert.equal(result.renderPreview.items[1].kind, 'rect', 'Second item should be rect');
+  assert.equal(result.renderPreview.items[2].kind, 'text', 'Third item should be text');
+}
+
+// Test 19: metadata comment付きDSLでも renderPreview が抽出できる
+{
+  const result = buildPreviewModelFromDsl(`
+    render circle(x: 100, y: 100, r: 50)
+
+    # @loomlet.editor {"version":1,"layout":{"nodes":{}}}
+  `);
+  assert.equal(result.errors.length, 0, 'Valid render with metadata should have no errors');
+  assert.equal(result.renderPreview.items.length, 1, 'Should extract render item from DSL with metadata');
+  assert.equal(result.renderPreview.items[0].kind, 'circle', 'Should be a circle');
+}
+
+// Test 20: render with partially literal args
+{
+  const result = buildPreviewModelFromDsl('x = 160\nrender circle(x: x, y: 120, r: 32, color: "#fff")');
+  assert.equal(result.renderPreview.items.length, 0, 'Circle with one non-literal arg should not render');
+  assert.equal(result.renderPreview.unsupported.length, 1, 'Should have one unsupported item');
+}
+
 console.log('All preview-model tests passed!');

--- a/extensions/vscode-loomlet/webview-src/node-editor-webview.js
+++ b/extensions/vscode-loomlet/webview-src/node-editor-webview.js
@@ -1,6 +1,7 @@
 // WebView bundle entry point for the Loomlet Node Preview panel.
 // Bundled by esbuild; runs inside a VS Code WebView (browser context).
 import { NodeEditorView } from '../../../editor-studio/src/node-editor-view.js';
+import { Loom } from '../../../src/loom.js';
 
 const vscode = acquireVsCodeApi();
 let editorView = null;
@@ -9,47 +10,37 @@ let editorView = null;
 
 let editorVisible = true;
 let lastErrors = [];
-let currentRenderPreview = { items: [], unsupported: [] };
 
-// ── Canvas: Render preview ───────────────────────────────────────────────────
+// Loom runtime state
+let loomEngine = null;
+let loomRafId = null;
+let currentGraph = null;  // keeps the full graph including .render config
+
+// ── Canvas: Loom Runtime Preview ─────────────────────────────────────────────
 
 function resizePreviewCanvas() {
   const canvas = document.getElementById('lp-preview-canvas');
   if (!canvas) return;
+  // Use device pixel ratio for sharp rendering
   const dpr = window.devicePixelRatio || 1;
   canvas.width = Math.round(window.innerWidth * dpr);
   canvas.height = Math.round(window.innerHeight * dpr);
-  drawPreviewCanvas(dpr);
-}
-
-function drawPreviewCanvas(dpr) {
-  const canvas = document.getElementById('lp-preview-canvas');
-  if (!canvas) return;
-
-  drawPreviewBackground(canvas, dpr);
-
-  if (currentRenderPreview.items && currentRenderPreview.items.length > 0) {
-    drawRenderItems(canvas, currentRenderPreview.items, dpr);
-  } else {
-    drawPlaceholderText(canvas, dpr);
-  }
-
-  if (currentRenderPreview.unsupported && currentRenderPreview.unsupported.length > 0) {
-    drawUnsupportedHint(canvas, currentRenderPreview.unsupported, dpr);
+  // Redraw placeholder if no runtime is running
+  if (!loomEngine) {
+    drawPlaceholder(canvas, dpr);
   }
 }
 
-function drawPreviewBackground(canvas, dpr) {
+function drawPlaceholder(canvas, dpr) {
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
   const w = canvas.width;
   const h = canvas.height;
 
-  // Dark background
   ctx.fillStyle = '#1a1a1a';
   ctx.fillRect(0, 0, w, h);
 
-  // Subtle dot grid
+  // Dot grid
   const step = 28 * dpr;
   ctx.fillStyle = 'rgba(255,255,255,0.06)';
   for (let x = step; x < w; x += step) {
@@ -59,13 +50,6 @@ function drawPreviewBackground(canvas, dpr) {
       ctx.fill();
     }
   }
-}
-
-function drawPlaceholderText(canvas, dpr) {
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
-  const w = canvas.width;
-  const h = canvas.height;
 
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
@@ -76,97 +60,112 @@ function drawPlaceholderText(canvas, dpr) {
 
   ctx.fillStyle = 'rgba(255,255,255,0.09)';
   ctx.font = `${Math.round(11 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
-  ctx.fillText('render output will appear here', w / 2, h / 2 + Math.round(13 * dpr));
+  ctx.fillText('add render bar() or render point() to see output', w / 2, h / 2 + Math.round(13 * dpr));
 }
 
-function drawRenderItems(canvas, items, dpr) {
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+// ── Loom runtime: resolve & draw ─────────────────────────────────────────────
 
-  for (const item of items) {
-    try {
-      if (item.kind === 'circle') {
-        drawCircle(ctx, item, dpr);
-      } else if (item.kind === 'rect') {
-        drawRect(ctx, item, dpr);
-      } else if (item.kind === 'bar') {
-        drawBar(ctx, item, dpr);
-      } else if (item.kind === 'text') {
-        drawText(ctx, item, dpr);
-      }
-    } catch (e) {
-      console.warn('Failed to draw render item:', item, e);
+/**
+ * Resolve a render config value: either a literal number or a node-output ref
+ * string like "wave.out" that is looked up in the Loom engine.
+ */
+function resolveValue(engine, ref) {
+  if (typeof ref === 'number') return ref;
+  if (ref === null || ref === undefined) return null;
+  const numVal = parseFloat(ref);
+  if (!isNaN(numVal) && String(ref).trim() === String(numVal)) return numVal;
+  return engine.getValue(ref);
+}
+
+function drawFrame() {
+  const canvas = document.getElementById('lp-preview-canvas');
+  if (!canvas || !loomEngine || !currentGraph) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const ctx = canvas.getContext('2d');
+  const w = canvas.width;
+  const h = canvas.height;
+  const renderConfig = currentGraph.render;
+
+  // Trail (partial clear) vs hard clear
+  const trail = renderConfig?.trail !== undefined ? renderConfig.trail : 0.1;
+  if (trail > 0) {
+    ctx.fillStyle = `rgba(0, 0, 0, ${trail})`;
+    ctx.fillRect(0, 0, w, h);
+  } else {
+    ctx.fillStyle = '#1a1a1a';
+    ctx.fillRect(0, 0, w, h);
+  }
+
+  if (renderConfig?.type === 'point') {
+    const x = resolveValue(loomEngine, renderConfig.x);
+    const y = resolveValue(loomEngine, renderConfig.y);
+    const color = renderConfig.color || '#00ff00';
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    if (x !== null && typeof x === 'number' && y !== null && typeof y === 'number') {
+      // Scale from CSS-px space to device-px space
+      ctx.arc(x * dpr, y * dpr, 4 * dpr, 0, Math.PI * 2);
+    } else {
+      ctx.arc(w / 2, h / 2, 4 * dpr, 0, Math.PI * 2);
     }
+    ctx.fill();
+
+  } else if (renderConfig?.type === 'bar') {
+    const width = resolveValue(loomEngine, renderConfig.width);
+    const color = renderConfig.color || '#00ccff';
+    const cssHeight = renderConfig.height !== undefined ? renderConfig.height : 40;
+    const heightPx = cssHeight * dpr;
+    const cssY = renderConfig.y !== undefined
+      ? resolveValue(loomEngine, renderConfig.y)
+      : null;
+    const yPx = cssY !== null && typeof cssY === 'number'
+      ? cssY * dpr
+      : (h - heightPx) / 2;
+
+    if (width !== null && typeof width === 'number') {
+      ctx.fillStyle = color;
+      ctx.fillRect(0, yPx, width * dpr, heightPx);
+    }
+  }
+
+  loomRafId = requestAnimationFrame(drawFrame);
+}
+
+// ── Loom engine lifecycle ─────────────────────────────────────────────────────
+
+function stopLoom() {
+  if (loomRafId !== null) {
+    cancelAnimationFrame(loomRafId);
+    loomRafId = null;
+  }
+  if (loomEngine) {
+    try { loomEngine.stop(); } catch (_) {}
+    loomEngine = null;
   }
 }
 
-function drawCircle(ctx, item, dpr) {
-  const x = (item.x || 100) * dpr;
-  const y = (item.y || 100) * dpr;
-  const r = (item.r || 24) * dpr;
-  const color = item.color || '#80ed99';
+function startLoom(graph) {
+  stopLoom();
+  currentGraph = graph || null;
 
-  ctx.fillStyle = color;
-  ctx.beginPath();
-  ctx.arc(x, y, r, 0, Math.PI * 2);
-  ctx.fill();
-}
+  if (!graph) {
+    const canvas = document.getElementById('lp-preview-canvas');
+    if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
+    return;
+  }
 
-function drawRect(ctx, item, dpr) {
-  const x = (item.x || 80) * dpr;
-  const y = (item.y || 80) * dpr;
-  const width = (item.width || 120) * dpr;
-  const height = (item.height || 80) * dpr;
-  const color = item.color || '#70d6ff';
-
-  ctx.fillStyle = color;
-  ctx.fillRect(x, y, width, height);
-}
-
-function drawBar(ctx, item, dpr) {
-  const x = (item.x || 40) * dpr;
-  const y = (item.y || 120) * dpr;
-  const width = (item.width || 240) * dpr;
-  const height = (item.height || 24) * dpr;
-  const value = Math.max(0, Math.min(1, item.value || 0.5)); // clamp 0-1
-  const color = item.color || '#ffd166';
-  const bgColor = item.backgroundColor || 'rgba(255,255,255,0.12)';
-
-  // Background bar
-  ctx.fillStyle = bgColor;
-  ctx.fillRect(x, y, width, height);
-
-  // Foreground bar (value)
-  ctx.fillStyle = color;
-  ctx.fillRect(x, y, width * value, height);
-}
-
-function drawText(ctx, item, dpr) {
-  const x = (item.x || 40) * dpr;
-  const y = (item.y || 60) * dpr;
-  const text = item.text || 'text';
-  const color = item.color || '#ffffff';
-  const size = item.size || 18;
-
-  ctx.fillStyle = color;
-  ctx.font = `${Math.round(size * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
-  ctx.textAlign = 'left';
-  ctx.textBaseline = 'top';
-  ctx.fillText(text, x, y);
-}
-
-function drawUnsupportedHint(canvas, unsupported, dpr) {
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
-
-  const count = unsupported.length;
-  const hintText = `${count} unsupported render item${count > 1 ? 's' : ''}`;
-
-  ctx.fillStyle = 'rgba(255,150,100,0.4)';
-  ctx.font = `${Math.round(10 * dpr)}px monospace`;
-  ctx.textAlign = 'left';
-  ctx.textBaseline = 'top';
-  ctx.fillText(hintText, Math.round(12 * dpr), Math.round(canvas.height - 24 * dpr));
+  try {
+    const graphForLoom = { nodes: graph.nodes || [], edges: graph.edges || [] };
+    loomEngine = new Loom(graphForLoom);
+    loomEngine.start();
+    loomRafId = requestAnimationFrame(drawFrame);
+  } catch (e) {
+    console.error('[loomlet-preview] Loom engine start failed:', e);
+    stopLoom();
+    const canvas = document.getElementById('lp-preview-canvas');
+    if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
+  }
 }
 
 // ── Status & error helpers ────────────────────────────────────────────────────
@@ -184,29 +183,6 @@ function setStatus(text, isError) {
   }
 }
 
-function buildStatusText(editorModel, errors, renderPreview) {
-  let status = '';
-
-  if (editorModel && renderPreview) {
-    status = 'Synced';
-
-    // Add render item count
-    if (renderPreview.items && renderPreview.items.length > 0) {
-      status += ` · ${renderPreview.items.length} render item${renderPreview.items.length > 1 ? 's' : ''}`;
-    }
-
-    // Add unsupported count
-    if (renderPreview.unsupported && renderPreview.unsupported.length > 0) {
-      status += ` · ${renderPreview.unsupported.length} unsupported`;
-    }
-  } else {
-    status = 'Empty';
-  }
-
-  status += ' · Read-only Node Preview';
-  return status;
-}
-
 function setErrors(errors) {
   lastErrors = errors || [];
   _renderErrors();
@@ -215,7 +191,6 @@ function setErrors(errors) {
 function _renderErrors() {
   const el = document.getElementById('lp-errors');
   if (!el) return;
-  // Hide errors when editor panel is collapsed or there are none
   if (!editorVisible || lastErrors.length === 0) {
     el.style.display = 'none';
     el.innerHTML = '';
@@ -246,16 +221,14 @@ function toggleEditor() {
 
   if (editorVisible) {
     if (container) container.style.display = '';
-    // Restore full-height flex to the panel
     if (panel) panel.style.flex = '1';
     if (btn) btn.textContent = 'Hide Editor';
     _renderErrors();
   } else {
     if (container) container.style.display = 'none';
-    // Collapse panel to toolbar height only
     if (panel) panel.style.flex = '0 0 auto';
     if (btn) btn.textContent = 'Show Editor';
-    _renderErrors(); // hides errors too
+    _renderErrors();
   }
 }
 
@@ -283,25 +256,22 @@ window.addEventListener('message', async (event) => {
   const message = event.data;
   if (!message || message.type !== 'setModel') return;
 
-  const { editorModel, errors, renderPreview } = message;
+  const { editorModel, graph, errors } = message;
 
   if (errors && errors.length > 0) {
     setStatus('DSL has errors · Read-only Node Preview', true);
     setErrors(errors);
-    // Leave the previous node editor state visible (do not touch editorView)
+    // Keep the previous node editor and Loom runtime running as-is
     return;
   }
 
   setErrors([]);
 
-  // Update render preview
-  if (renderPreview) {
-    currentRenderPreview = renderPreview;
-    resizePreviewCanvas(); // Redraw with new render preview
-  }
+  // Start/restart the Loom runtime with the new graph
+  startLoom(graph || null);
 
   if (!editorModel) {
-    setStatus(buildStatusText(null, [], renderPreview), false);
+    setStatus('Empty · Read-only Node Preview', false);
     return;
   }
 
@@ -309,7 +279,7 @@ window.addEventListener('message', async (event) => {
 
   try {
     await editorView.renderModel(editorModel);
-    setStatus(buildStatusText(editorModel, [], renderPreview), false);
+    setStatus('Synced · Read-only Node Preview', false);
   } catch (e) {
     console.error('[loomlet-preview] renderModel failed:', e);
     setStatus('Render error · Read-only Node Preview', true);

--- a/extensions/vscode-loomlet/webview-src/node-editor-webview.js
+++ b/extensions/vscode-loomlet/webview-src/node-editor-webview.js
@@ -9,8 +9,9 @@ let editorView = null;
 
 let editorVisible = true;
 let lastErrors = [];
+let currentRenderPreview = { items: [], unsupported: [] };
 
-// ── Canvas: Runtime Preview placeholder ──────────────────────────────────────
+// ── Canvas: Render preview ───────────────────────────────────────────────────
 
 function resizePreviewCanvas() {
   const canvas = document.getElementById('lp-preview-canvas');
@@ -18,10 +19,27 @@ function resizePreviewCanvas() {
   const dpr = window.devicePixelRatio || 1;
   canvas.width = Math.round(window.innerWidth * dpr);
   canvas.height = Math.round(window.innerHeight * dpr);
-  drawPreviewPlaceholder(canvas, dpr);
+  drawPreviewCanvas(dpr);
 }
 
-function drawPreviewPlaceholder(canvas, dpr) {
+function drawPreviewCanvas(dpr) {
+  const canvas = document.getElementById('lp-preview-canvas');
+  if (!canvas) return;
+
+  drawPreviewBackground(canvas, dpr);
+
+  if (currentRenderPreview.items && currentRenderPreview.items.length > 0) {
+    drawRenderItems(canvas, currentRenderPreview.items, dpr);
+  } else {
+    drawPlaceholderText(canvas, dpr);
+  }
+
+  if (currentRenderPreview.unsupported && currentRenderPreview.unsupported.length > 0) {
+    drawUnsupportedHint(canvas, currentRenderPreview.unsupported, dpr);
+  }
+}
+
+function drawPreviewBackground(canvas, dpr) {
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
   const w = canvas.width;
@@ -41,8 +59,14 @@ function drawPreviewPlaceholder(canvas, dpr) {
       ctx.fill();
     }
   }
+}
 
-  // Centered label
+function drawPlaceholderText(canvas, dpr) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const w = canvas.width;
+  const h = canvas.height;
+
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -53,6 +77,96 @@ function drawPreviewPlaceholder(canvas, dpr) {
   ctx.fillStyle = 'rgba(255,255,255,0.09)';
   ctx.font = `${Math.round(11 * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
   ctx.fillText('render output will appear here', w / 2, h / 2 + Math.round(13 * dpr));
+}
+
+function drawRenderItems(canvas, items, dpr) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  for (const item of items) {
+    try {
+      if (item.kind === 'circle') {
+        drawCircle(ctx, item, dpr);
+      } else if (item.kind === 'rect') {
+        drawRect(ctx, item, dpr);
+      } else if (item.kind === 'bar') {
+        drawBar(ctx, item, dpr);
+      } else if (item.kind === 'text') {
+        drawText(ctx, item, dpr);
+      }
+    } catch (e) {
+      console.warn('Failed to draw render item:', item, e);
+    }
+  }
+}
+
+function drawCircle(ctx, item, dpr) {
+  const x = (item.x || 100) * dpr;
+  const y = (item.y || 100) * dpr;
+  const r = (item.r || 24) * dpr;
+  const color = item.color || '#80ed99';
+
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawRect(ctx, item, dpr) {
+  const x = (item.x || 80) * dpr;
+  const y = (item.y || 80) * dpr;
+  const width = (item.width || 120) * dpr;
+  const height = (item.height || 80) * dpr;
+  const color = item.color || '#70d6ff';
+
+  ctx.fillStyle = color;
+  ctx.fillRect(x, y, width, height);
+}
+
+function drawBar(ctx, item, dpr) {
+  const x = (item.x || 40) * dpr;
+  const y = (item.y || 120) * dpr;
+  const width = (item.width || 240) * dpr;
+  const height = (item.height || 24) * dpr;
+  const value = Math.max(0, Math.min(1, item.value || 0.5)); // clamp 0-1
+  const color = item.color || '#ffd166';
+  const bgColor = item.backgroundColor || 'rgba(255,255,255,0.12)';
+
+  // Background bar
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(x, y, width, height);
+
+  // Foreground bar (value)
+  ctx.fillStyle = color;
+  ctx.fillRect(x, y, width * value, height);
+}
+
+function drawText(ctx, item, dpr) {
+  const x = (item.x || 40) * dpr;
+  const y = (item.y || 60) * dpr;
+  const text = item.text || 'text';
+  const color = item.color || '#ffffff';
+  const size = item.size || 18;
+
+  ctx.fillStyle = color;
+  ctx.font = `${Math.round(size * dpr)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillText(text, x, y);
+}
+
+function drawUnsupportedHint(canvas, unsupported, dpr) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const count = unsupported.length;
+  const hintText = `${count} unsupported render item${count > 1 ? 's' : ''}`;
+
+  ctx.fillStyle = 'rgba(255,150,100,0.4)';
+  ctx.font = `${Math.round(10 * dpr)}px monospace`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillText(hintText, Math.round(12 * dpr), Math.round(canvas.height - 24 * dpr));
 }
 
 // ── Status & error helpers ────────────────────────────────────────────────────
@@ -68,6 +182,29 @@ function setStatus(text, isError) {
     el.style.borderLeftColor = '#4a90e2';
     el.style.color = '#9cdcfe';
   }
+}
+
+function buildStatusText(editorModel, errors, renderPreview) {
+  let status = '';
+
+  if (editorModel && renderPreview) {
+    status = 'Synced';
+
+    // Add render item count
+    if (renderPreview.items && renderPreview.items.length > 0) {
+      status += ` · ${renderPreview.items.length} render item${renderPreview.items.length > 1 ? 's' : ''}`;
+    }
+
+    // Add unsupported count
+    if (renderPreview.unsupported && renderPreview.unsupported.length > 0) {
+      status += ` · ${renderPreview.unsupported.length} unsupported`;
+    }
+  } else {
+    status = 'Empty';
+  }
+
+  status += ' · Read-only Node Preview';
+  return status;
 }
 
 function setErrors(errors) {
@@ -146,7 +283,7 @@ window.addEventListener('message', async (event) => {
   const message = event.data;
   if (!message || message.type !== 'setModel') return;
 
-  const { editorModel, errors } = message;
+  const { editorModel, errors, renderPreview } = message;
 
   if (errors && errors.length > 0) {
     setStatus('DSL has errors · Read-only Node Preview', true);
@@ -157,8 +294,14 @@ window.addEventListener('message', async (event) => {
 
   setErrors([]);
 
+  // Update render preview
+  if (renderPreview) {
+    currentRenderPreview = renderPreview;
+    resizePreviewCanvas(); // Redraw with new render preview
+  }
+
   if (!editorModel) {
-    setStatus('Empty · Read-only Node Preview', false);
+    setStatus(buildStatusText(null, [], renderPreview), false);
     return;
   }
 
@@ -166,7 +309,7 @@ window.addEventListener('message', async (event) => {
 
   try {
     await editorView.renderModel(editorModel);
-    setStatus('Synced · Read-only Node Preview', false);
+    setStatus(buildStatusText(editorModel, [], renderPreview), false);
   } catch (e) {
     console.error('[loomlet-preview] renderModel failed:', e);
     setStatus('Render error · Read-only Node Preview', true);


### PR DESCRIPTION
## Summary
This PR adds the ability to extract and display render statements (circle, rect, bar, text) from the DSL as a static preview, even when the full compilation fails. The preview is extracted directly from the AST and rendered on the canvas without requiring successful graph compilation.

## Key Changes

- **Preview Model (`preview-model.js`)**
  - Added `extractRenderPreview(ast)` to extract render statements from AST into a static payload with `items` and `unsupported` arrays
  - Added `extractRenderItem(kind, args)` to process individual render calls with literal arguments only
  - Added `extractLiteralValue(node)` to safely extract literal values (numbers, strings, booleans) from AST nodes
  - Added `getRenderDefaults(kind)` and `getRenderRequired(kind)` helper functions for render configuration
  - Modified `buildPreviewModelFromDsl()` to always return `renderPreview` object alongside `editorModel` and `errors`
  - Filters out "Unknown render function" compile errors to allow static rendering of unsupported render types

- **Webview (`node-editor-webview.js`)**
  - Refactored canvas drawing from `drawPreviewPlaceholder()` into modular functions:
    - `drawPreviewCanvas()` - main orchestrator
    - `drawPreviewBackground()` - grid background
    - `drawPlaceholderText()` - fallback text
    - `drawRenderItems()` - renders extracted items
    - `drawCircle()`, `drawRect()`, `drawBar()`, `drawText()` - individual shape renderers
  - Added `drawUnsupportedHint()` to display count of unsupported render items
  - Added `buildStatusText()` to show render item counts in status bar
  - Updated message handler to receive and display `renderPreview` data
  - Canvas redraws whenever render preview updates

- **Tests (`preview-model.test.mjs`)**
  - Added 10 new test cases covering:
    - Literal argument extraction for circle, rect, bar, text
    - Value clamping for bar renders (0-1 range)
    - Identifier arguments marked as unsupported
    - Multiple render statements
    - Metadata preservation
    - Partial literal arguments

- **Extension (`extension.js`)**
  - Added `previousRenderPreview` state tracking
  - Updated `sendDocumentToPreview()` to pass `renderPreview` to webview

## Implementation Details

- Only render statements with **literal arguments** are extracted; identifiers and expressions are marked as unsupported
- Bar values are automatically clamped to 0-1 range
- All render kinds have sensible defaults, allowing minimal argument specifications
- Unsupported renders are tracked separately and displayed as a hint on the canvas
- Status bar now shows counts of rendered items and unsupported items
- The preview updates independently of graph compilation success, improving user feedback

https://claude.ai/code/session_01Xg4VqLWvB5vFv1fZ6ZTpML