### PR TITLE
Add pause/resume and reset controls to runtime preview

### DIFF
--- a/extensions/vscode-loomlet/media/node-editor-webview.js
+++ b/extensions/vscode-loomlet/media/node-editor-webview.js
@@ -16208,7 +16208,9 @@ var LoomletPreview = (() => {
   var loomRafId = null;
   var currentGraph = null;
   var runtimeStartTimestampMs = null;
-  var lastFrameTimestampMs = null;
+  var isRuntimePaused = false;
+  var pausedAtTimestampMs = null;
+  var accumulatedPausedMs = 0;
   function resizePreviewCanvas() {
     const canvas = document.getElementById("lp-preview-canvas");
     if (!canvas) return;
@@ -16254,11 +16256,14 @@ var LoomletPreview = (() => {
   function drawFrame(timestamp) {
     const canvas = document.getElementById("lp-preview-canvas");
     if (!canvas || !loomEngine || !currentGraph) return;
+    if (isRuntimePaused) {
+      return;
+    }
     try {
       if (runtimeStartTimestampMs === null) {
         runtimeStartTimestampMs = timestamp;
       }
-      const elapsedSeconds = (timestamp - runtimeStartTimestampMs) / 1e3;
+      const elapsedSeconds = (timestamp - runtimeStartTimestampMs - accumulatedPausedMs) / 1e3;
       loomEngine.evaluateAt(elapsedSeconds, timestamp);
       drawRuntimeCanvas(timestamp);
     } catch (error) {
@@ -16312,6 +16317,7 @@ var LoomletPreview = (() => {
   function handleRuntimeError(error) {
     setStatus("Runtime error \xB7 Read-only Node Preview", true);
     stopLoom();
+    updateControlStates();
     const canvas = document.getElementById("lp-preview-canvas");
     if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
   }
@@ -16328,7 +16334,9 @@ var LoomletPreview = (() => {
       loomEngine = null;
     }
     runtimeStartTimestampMs = null;
-    lastFrameTimestampMs = null;
+    isRuntimePaused = false;
+    pausedAtTimestampMs = null;
+    accumulatedPausedMs = 0;
   }
   function startLoom(graph) {
     stopLoom();
@@ -16336,14 +16344,18 @@ var LoomletPreview = (() => {
     if (!graph || !graph.render) {
       const canvas = document.getElementById("lp-preview-canvas");
       if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
+      updateControlStates();
       return;
     }
     try {
       const graphForLoom = { nodes: graph.nodes || [], edges: graph.edges || [] };
       loomEngine = new Loom(graphForLoom);
       runtimeStartTimestampMs = null;
-      lastFrameTimestampMs = null;
+      isRuntimePaused = false;
+      pausedAtTimestampMs = null;
+      accumulatedPausedMs = 0;
       loomRafId = requestAnimationFrame(drawFrame);
+      updateControlStates();
     } catch (e) {
       console.error("[loomlet-preview] Loom engine initialization failed:", e);
       handleRuntimeError(e);
@@ -16379,6 +16391,63 @@ var LoomletPreview = (() => {
   function escapeHtml(str) {
     return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
   }
+  function togglePauseResume() {
+    if (!loomEngine || !currentGraph || !currentGraph.render) return;
+    if (isRuntimePaused) {
+      const now = performance.now();
+      if (pausedAtTimestampMs !== null) {
+        accumulatedPausedMs += now - pausedAtTimestampMs;
+        pausedAtTimestampMs = null;
+      }
+      isRuntimePaused = false;
+      updateControlStates();
+      updateStatus();
+      loomRafId = requestAnimationFrame(drawFrame);
+    } else {
+      pausedAtTimestampMs = performance.now();
+      isRuntimePaused = true;
+      updateControlStates();
+      updateStatus();
+    }
+  }
+  function resetRuntime() {
+    if (!loomEngine || !currentGraph || !currentGraph.render) return;
+    runtimeStartTimestampMs = null;
+    accumulatedPausedMs = 0;
+    isRuntimePaused = false;
+    pausedAtTimestampMs = null;
+    try {
+      loomEngine.evaluateAt(0, performance.now());
+      drawRuntimeCanvas(performance.now());
+    } catch (e) {
+      console.error("[loomlet-preview] Error during reset:", e);
+    }
+    updateControlStates();
+    updateStatus();
+    if (loomRafId !== null) {
+      cancelAnimationFrame(loomRafId);
+    }
+    loomRafId = requestAnimationFrame(drawFrame);
+  }
+  function updateControlStates() {
+    const canControl = loomEngine && currentGraph && currentGraph.render;
+    const toggleBtn = document.getElementById("lp-toggle-runtime");
+    const resetBtn = document.getElementById("lp-reset-runtime");
+    if (toggleBtn) {
+      toggleBtn.disabled = !canControl;
+      toggleBtn.textContent = isRuntimePaused ? "Resume" : "Pause";
+    }
+    if (resetBtn) {
+      resetBtn.disabled = !canControl;
+    }
+  }
+  function updateStatus() {
+    if (isRuntimePaused) {
+      setStatus("Paused \xB7 Runtime Preview \xB7 Read-only Node Preview", false);
+    } else if (loomEngine && currentGraph && currentGraph.render) {
+      setStatus("Running \xB7 Runtime Preview \xB7 Read-only Node Preview", false);
+    }
+  }
   function toggleEditor() {
     editorVisible = !editorVisible;
     const panel = document.getElementById("lp-panel");
@@ -16396,9 +16465,13 @@ var LoomletPreview = (() => {
       _renderErrors();
     }
   }
-  function initToggleButton() {
-    const btn = document.getElementById("lp-toggle-editor");
-    if (btn) btn.addEventListener("click", toggleEditor);
+  function initControlButtons() {
+    const toggleEditorBtn = document.getElementById("lp-toggle-editor");
+    if (toggleEditorBtn) toggleEditorBtn.addEventListener("click", toggleEditor);
+    const toggleRuntimeBtn = document.getElementById("lp-toggle-runtime");
+    if (toggleRuntimeBtn) toggleRuntimeBtn.addEventListener("click", togglePauseResume);
+    const resetRuntimeBtn = document.getElementById("lp-reset-runtime");
+    if (resetRuntimeBtn) resetRuntimeBtn.addEventListener("click", resetRuntime);
   }
   function initEditorView() {
     if (editorView) return;
@@ -16426,12 +16499,14 @@ var LoomletPreview = (() => {
     startLoom(graph || null);
     if (!editorModel) {
       setStatus("Empty \xB7 Read-only Node Preview", false);
+      updateControlStates();
       return;
     }
     initEditorView();
     try {
       await editorView.renderModel(editorModel);
-      setStatus("Synced \xB7 Read-only Node Preview", false);
+      updateStatus();
+      updateControlStates();
     } catch (e) {
       console.error("[loomlet-preview] renderModel failed:", e);
       setStatus("Render error \xB7 Read-only Node Preview", true);
@@ -16439,7 +16514,7 @@ var LoomletPreview = (() => {
   });
   resizePreviewCanvas();
   window.addEventListener("resize", resizePreviewCanvas);
-  initToggleButton();
+  initControlButtons();
   vscode.postMessage({ type: "ready" });
 })();
 /*! Bundled license information:

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -263,7 +263,7 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
       padding-left: 8px;
       line-height: 1.6;
     }
-    #lp-toggle-editor {
+    .lp-control-btn {
       flex-shrink: 0;
       padding: 2px 10px;
       font-size: 11px;
@@ -275,9 +275,13 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
       cursor: pointer;
       line-height: 1.6;
     }
-    #lp-toggle-editor:hover {
+    .lp-control-btn:hover:not(:disabled) {
       background: rgba(255,255,255,0.11);
       color: #eee;
+    }
+    .lp-control-btn:disabled {
+      opacity: 0.4;
+      cursor: default;
     }
     /* ── Errors ── */
     #lp-errors {
@@ -316,7 +320,9 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
     <div id="lp-panel">
       <div id="lp-toolbar">
         <div id="lp-status">Waiting for graph...</div>
-        <button id="lp-toggle-editor">Hide Editor</button>
+        <button id="lp-toggle-runtime" class="lp-control-btn" disabled>Pause</button>
+        <button id="lp-reset-runtime" class="lp-control-btn" disabled>Reset</button>
+        <button id="lp-toggle-editor" class="lp-control-btn">Hide Editor</button>
       </div>
       <div id="lp-errors"></div>
       <div id="lp-editor-container"></div>

--- a/extensions/vscode-loomlet/webview-src/node-editor-webview.js
+++ b/extensions/vscode-loomlet/webview-src/node-editor-webview.js
@@ -89,6 +89,7 @@ function drawFrame(timestamp) {
 
   // If paused, don't update; just keep the current frame
   if (isRuntimePaused) {
+    loomRafId = null;
     return;
   }
 
@@ -253,7 +254,7 @@ function _renderErrors() {
   }
   el.style.display = 'block';
   el.innerHTML = lastErrors
-    .map(e => `<div class="lp-error-item">${escapeHtml(e.message || String(e))}</div>`)
+    .map(e => `<div class=\"lp-error-item\">${escapeHtml(e.message || String(e))}</div>`)
     .join('');
 }
 
@@ -262,7 +263,7 @@ function escapeHtml(str) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/\"/g, '&quot;');
 }
 
 // ── Runtime controls ──────────────────────────────────────────────────────────
@@ -281,11 +282,17 @@ function togglePauseResume() {
     updateControlStates();
     updateStatus();
     // Resume the RAF loop
-    loomRafId = requestAnimationFrame(drawFrame);
+    if (loomRafId === null) {
+      loomRafId = requestAnimationFrame(drawFrame);
+    }
   } else {
-    // Pause: record the current time
+    // Pause: record the current time and cancel any scheduled frame
     pausedAtTimestampMs = performance.now();
     isRuntimePaused = true;
+    if (loomRafId !== null) {
+      cancelAnimationFrame(loomRafId);
+      loomRafId = null;
+    }
     updateControlStates();
     updateStatus();
   }
@@ -314,6 +321,7 @@ function resetRuntime() {
   // Schedule next frame to continue
   if (loomRafId !== null) {
     cancelAnimationFrame(loomRafId);
+    loomRafId = null;
   }
   loomRafId = requestAnimationFrame(drawFrame);
 }

--- a/extensions/vscode-loomlet/webview-src/node-editor-webview.js
+++ b/extensions/vscode-loomlet/webview-src/node-editor-webview.js
@@ -16,7 +16,11 @@ let loomEngine = null;
 let loomRafId = null;
 let currentGraph = null;  // keeps the full graph including .render config
 let runtimeStartTimestampMs = null;  // timestamp when runtime started
-let lastFrameTimestampMs = null;  // last frame timestamp for delta calc
+
+// Pause/Resume state
+let isRuntimePaused = false;
+let pausedAtTimestampMs = null;
+let accumulatedPausedMs = 0;
 
 // ── Canvas: Loom Runtime Preview ─────────────────────────────────────────────
 
@@ -83,12 +87,17 @@ function drawFrame(timestamp) {
   const canvas = document.getElementById('lp-preview-canvas');
   if (!canvas || !loomEngine || !currentGraph) return;
 
+  // If paused, don't update; just keep the current frame
+  if (isRuntimePaused) {
+    return;
+  }
+
   try {
-    // Calculate elapsed time from runtime start
+    // Calculate elapsed time from runtime start, excluding accumulated paused time
     if (runtimeStartTimestampMs === null) {
       runtimeStartTimestampMs = timestamp;
     }
-    const elapsedSeconds = (timestamp - runtimeStartTimestampMs) / 1000;
+    const elapsedSeconds = (timestamp - runtimeStartTimestampMs - accumulatedPausedMs) / 1000;
 
     // Evaluate the Loom graph at this time
     loomEngine.evaluateAt(elapsedSeconds, timestamp);
@@ -163,6 +172,7 @@ function drawRuntimeCanvas(timestamp) {
 function handleRuntimeError(error) {
   setStatus('Runtime error · Read-only Node Preview', true);
   stopLoom();
+  updateControlStates();
   const canvas = document.getElementById('lp-preview-canvas');
   if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
 }
@@ -180,7 +190,9 @@ function stopLoom() {
   }
   // Reset time tracking state
   runtimeStartTimestampMs = null;
-  lastFrameTimestampMs = null;
+  isRuntimePaused = false;
+  pausedAtTimestampMs = null;
+  accumulatedPausedMs = 0;
 }
 
 function startLoom(graph) {
@@ -190,6 +202,7 @@ function startLoom(graph) {
   if (!graph || !graph.render) {
     const canvas = document.getElementById('lp-preview-canvas');
     if (canvas) drawPlaceholder(canvas, window.devicePixelRatio || 1);
+    updateControlStates();
     return;
   }
 
@@ -198,9 +211,12 @@ function startLoom(graph) {
     loomEngine = new Loom(graphForLoom);
     // Reset time tracking for this runtime
     runtimeStartTimestampMs = null;
-    lastFrameTimestampMs = null;
+    isRuntimePaused = false;
+    pausedAtTimestampMs = null;
+    accumulatedPausedMs = 0;
     // Start the RAF loop - do NOT call loomEngine.start()
     loomRafId = requestAnimationFrame(drawFrame);
+    updateControlStates();
   } catch (e) {
     console.error('[loomlet-preview] Loom engine initialization failed:', e);
     handleRuntimeError(e);
@@ -249,6 +265,81 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
+// ── Runtime controls ──────────────────────────────────────────────────────────
+
+function togglePauseResume() {
+  if (!loomEngine || !currentGraph || !currentGraph.render) return;
+
+  if (isRuntimePaused) {
+    // Resume: add paused time to accumulated paused time
+    const now = performance.now();
+    if (pausedAtTimestampMs !== null) {
+      accumulatedPausedMs += (now - pausedAtTimestampMs);
+      pausedAtTimestampMs = null;
+    }
+    isRuntimePaused = false;
+    updateControlStates();
+    updateStatus();
+    // Resume the RAF loop
+    loomRafId = requestAnimationFrame(drawFrame);
+  } else {
+    // Pause: record the current time
+    pausedAtTimestampMs = performance.now();
+    isRuntimePaused = true;
+    updateControlStates();
+    updateStatus();
+  }
+}
+
+function resetRuntime() {
+  if (!loomEngine || !currentGraph || !currentGraph.render) return;
+
+  // Reset time tracking
+  runtimeStartTimestampMs = null;
+  accumulatedPausedMs = 0;
+  isRuntimePaused = false;
+  pausedAtTimestampMs = null;
+
+  try {
+    // Reset the engine to t=0
+    loomEngine.evaluateAt(0, performance.now());
+    drawRuntimeCanvas(performance.now());
+  } catch (e) {
+    console.error('[loomlet-preview] Error during reset:', e);
+  }
+
+  updateControlStates();
+  updateStatus();
+
+  // Schedule next frame to continue
+  if (loomRafId !== null) {
+    cancelAnimationFrame(loomRafId);
+  }
+  loomRafId = requestAnimationFrame(drawFrame);
+}
+
+function updateControlStates() {
+  const canControl = loomEngine && currentGraph && currentGraph.render;
+  const toggleBtn = document.getElementById('lp-toggle-runtime');
+  const resetBtn = document.getElementById('lp-reset-runtime');
+
+  if (toggleBtn) {
+    toggleBtn.disabled = !canControl;
+    toggleBtn.textContent = isRuntimePaused ? 'Resume' : 'Pause';
+  }
+  if (resetBtn) {
+    resetBtn.disabled = !canControl;
+  }
+}
+
+function updateStatus() {
+  if (isRuntimePaused) {
+    setStatus('Paused · Runtime Preview · Read-only Node Preview', false);
+  } else if (loomEngine && currentGraph && currentGraph.render) {
+    setStatus('Running · Runtime Preview · Read-only Node Preview', false);
+  }
+}
+
 // ── Hide / Show toggle ────────────────────────────────────────────────────────
 
 function toggleEditor() {
@@ -271,9 +362,15 @@ function toggleEditor() {
   }
 }
 
-function initToggleButton() {
-  const btn = document.getElementById('lp-toggle-editor');
-  if (btn) btn.addEventListener('click', toggleEditor);
+function initControlButtons() {
+  const toggleEditorBtn = document.getElementById('lp-toggle-editor');
+  if (toggleEditorBtn) toggleEditorBtn.addEventListener('click', toggleEditor);
+
+  const toggleRuntimeBtn = document.getElementById('lp-toggle-runtime');
+  if (toggleRuntimeBtn) toggleRuntimeBtn.addEventListener('click', togglePauseResume);
+
+  const resetRuntimeBtn = document.getElementById('lp-reset-runtime');
+  if (resetRuntimeBtn) resetRuntimeBtn.addEventListener('click', resetRuntime);
 }
 
 // ── Node Editor lifecycle ─────────────────────────────────────────────────────
@@ -311,6 +408,7 @@ window.addEventListener('message', async (event) => {
 
   if (!editorModel) {
     setStatus('Empty · Read-only Node Preview', false);
+    updateControlStates();
     return;
   }
 
@@ -318,7 +416,8 @@ window.addEventListener('message', async (event) => {
 
   try {
     await editorView.renderModel(editorModel);
-    setStatus('Synced · Read-only Node Preview', false);
+    updateStatus();
+    updateControlStates();
   } catch (e) {
     console.error('[loomlet-preview] renderModel failed:', e);
     setStatus('Render error · Read-only Node Preview', true);
@@ -329,7 +428,7 @@ window.addEventListener('message', async (event) => {
 
 resizePreviewCanvas();
 window.addEventListener('resize', resizePreviewCanvas);
-initToggleButton();
+initControlButtons();
 
 // Notify the extension that the webview is ready
 vscode.postMessage({ type: 'ready' });


### PR DESCRIPTION
## Summary
This PR adds pause/resume and reset functionality to the Loom runtime preview in the VSCode extension, allowing users to control playback of node graph animations.

## Key Changes
- **Pause/Resume Control**: Added `togglePauseResume()` function that pauses the animation frame loop and tracks accumulated paused time to maintain correct elapsed time calculations when resumed
- **Reset Control**: Added `resetRuntime()` function that resets the animation to t=0 and restarts the playback loop
- **Time Tracking**: Replaced `lastFrameTimestampMs` with a more robust pause state system using:
  - `isRuntimePaused`: Boolean flag for pause state
  - `pausedAtTimestampMs`: Timestamp when pause was initiated
  - `accumulatedPausedMs`: Total milliseconds spent paused (subtracted from elapsed time calculations)
- **UI Controls**: Added two new buttons (Pause/Resume and Reset) to the toolbar with proper disabled states
- **Control State Management**: Implemented `updateControlStates()` to enable/disable buttons based on runtime availability and `updateStatus()` to reflect current runtime state in the status bar
- **Button Initialization**: Renamed `initToggleButton()` to `initControlButtons()` to handle all control button event listeners
- **Status Updates**: Enhanced status messages to show "Running" or "Paused" states during runtime execution

## Implementation Details
- Pause state is checked at the start of `drawFrame()` to prevent frame updates while paused
- Elapsed time calculation now subtracts `accumulatedPausedMs` to ensure smooth resumption without time jumps
- Control buttons are disabled when no valid graph is loaded or rendering
- The pause button text dynamically updates to show "Pause" or "Resume" based on current state
- Changes applied to both source (`webview-src/`) and bundled (`media/`) versions of the webview script

https://claude.ai/code/session_01SFEUnBQjpUTs8cT6FDHcff