### PR TITLE
Add VS Code runtime preview examples

### DIFF
--- a/examples/vscode/01-bouncing-bar.loom
+++ b/examples/vscode/01-bouncing-bar.loom
@@ -1,0 +1,12 @@
+# VS Code Runtime Preview example: Bouncing Bar
+# Open this file with Loomlet: Open Node Preview to the Side.
+# The background canvas should show a moving bar.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+
+t = clock()
+wave = sine(t, freq: 0.8)
+width = map(wave, inMin: -1, inMax: 1, outMin: 40, outMax: 320)
+
+render bar(width: width, height: 48, color: "#80ed99")

--- a/examples/vscode/02-orbit-point.loom
+++ b/examples/vscode/02-orbit-point.loom
@@ -1,0 +1,15 @@
+# VS Code Runtime Preview example: Orbit Point
+# Open this file with Loomlet: Open Node Preview to the Side.
+# The background canvas should show a point moving in a circle.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+
+t = clock()
+xWave = sine(t, freq: 0.4)
+yWave = cosine(t, freq: 0.4)
+
+x = map(xWave, inMin: -1, inMax: 1, outMin: 80, outMax: 320)
+y = map(yWave, inMin: -1, inMax: 1, outMin: 80, outMax: 240)
+
+render point(x: x, y: y, color: "#ff70a6", trail: 0.08)

--- a/examples/vscode/03-lissajous-point.loom
+++ b/examples/vscode/03-lissajous-point.loom
@@ -1,0 +1,15 @@
+# VS Code Runtime Preview example: Lissajous Point
+# Open this file with Loomlet: Open Node Preview to the Side.
+# The background canvas should show a looping Lissajous-like path.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+
+t = clock()
+xWave = sine(t, freq: 0.7)
+yWave = cosine(t, freq: 1.1)
+
+x = map(xWave, inMin: -1, inMax: 1, outMin: 60, outMax: 360)
+y = map(yWave, inMin: -1, inMax: 1, outMin: 60, outMax: 260)
+
+render point(x: x, y: y, color: "#70d6ff", trail: 0.04)

--- a/examples/vscode/04-pulse-bar.loom
+++ b/examples/vscode/04-pulse-bar.loom
@@ -1,0 +1,13 @@
+# VS Code Runtime Preview example: Pulse Bar
+# Open this file with Loomlet: Open Node Preview to the Side.
+# The background canvas should show a bar changing width and vertical position.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+
+t = clock()
+wave = sine(t, freq: 1.2)
+width = map(wave, inMin: -1, inMax: 1, outMin: 20, outMax: 360)
+y = map(wave, inMin: -1, inMax: 1, outMin: 100, outMax: 180)
+
+render bar(width: width, y: y, height: 32, color: "#ffd166")

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stdlib-baseline.test.mjs",
     "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",

--- a/test/vscode-examples.test.mjs
+++ b/test/vscode-examples.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseDSLToAST, compileToGraph } from '../src/loom-dsl.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const examplesRoot = path.join(projectRoot, 'examples', 'vscode');
+
+function walkLoomFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const nextPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkLoomFiles(nextPath));
+    } else if (entry.isFile() && entry.name.endsWith('.loom')) {
+      files.push(nextPath);
+    }
+  }
+  return files;
+}
+
+test('VS Code runtime preview examples compile to visible render outputs', () => {
+  const files = walkLoomFiles(examplesRoot);
+  assert.ok(files.length > 0, 'Expected VS Code examples to exist');
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    const relativeFile = path.relative(projectRoot, file).replace(/\\/g, '/');
+
+    const { ast, errors: parseErrors } = parseDSLToAST(source);
+    assert.deepEqual(parseErrors, [], `${relativeFile} parse errors`);
+
+    const { graph, errors: compileErrors } = compileToGraph(ast);
+    assert.deepEqual(compileErrors, [], `${relativeFile} compile errors`);
+
+    assert.ok(graph.render, `${relativeFile} should define graph.render`);
+    assert.ok(
+      graph.render.type === 'bar' || graph.render.type === 'point',
+      `${relativeFile} render type should be bar or point, got ${graph.render.type}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Adds a small set of `.loom` examples that are intentionally visible in the VS Code Node Preview Runtime Canvas.

These examples use only the render outputs currently supported by the VS Code runtime preview:

- `render bar(...)`
- `render point(...)`

## Added examples

- `examples/vscode/01-bouncing-bar.loom`
- `examples/vscode/02-orbit-point.loom`
- `examples/vscode/03-lissajous-point.loom`
- `examples/vscode/04-pulse-bar.loom`

## Validation

Adds `test/vscode-examples.test.mjs` and wires it into `npm run test:unit`.

The test verifies that every `examples/vscode/*.loom` file:

- parses successfully
- compiles successfully
- defines `graph.render`
- uses only `bar` or `point` render types

## Notes

This does not change runtime behavior or add console output yet. `console.log(...)` examples still need a separate VS Code Output Channel / WebView console task.