### PR TITLE
Improve VS Code preview output feedback

### DIFF
--- a/examples/vscode/console-log.loom
+++ b/examples/vscode/console-log.loom
@@ -1,0 +1,14 @@
+# VS Code Output Channel demo
+# Open this file, then run: Loomlet: Open Node Preview to the Side
+# The moving bar renders in the WebView background, while console.log writes to
+# View > Output > Loomlet.
+
+import console
+import math
+
+t = clock()
+wave = math.sine(t, freq: 0.5)
+width = math.map(wave, inMin: -1, inMax: 1, outMin: 80, outMax: 520)
+
+console.log(width)
+render bar(width: width, height: 36, y: 180, color: "#4ec9b0", trail: 0.12)

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -12,11 +12,16 @@ let nodePreviewPanel = null;
 let currentPreviewDocument = null;
 let previousEditorModel = null;
 let previewDebounceTimer = null;
+let loomletOutput = null;
+let runtimeOutputShown = false;
 const PREVIEW_DEBOUNCE_MS = 300;
 
 const pendingValidationTimers = new Map();
 
 async function activate(context) {
+  loomletOutput = vscode.window.createOutputChannel('Loomlet');
+  context.subscriptions.push(loomletOutput);
+
   try {
     await ensureModulesLoaded();
   } catch (err) {
@@ -154,6 +159,11 @@ function openNodePreviewToSide(context) {
   const readySub = nodePreviewPanel.webview.onDidReceiveMessage((message) => {
     if (message.type === 'ready' && currentPreviewDocument) {
       sendDocumentToPreview(currentPreviewDocument);
+      return;
+    }
+
+    if (message.type === 'runtimeEffects') {
+      appendRuntimeEffects(message.effects);
     }
   });
   context.subscriptions.push(readySub);
@@ -191,6 +201,61 @@ function sendDocumentToPreview(document) {
     graph: errors.length === 0 ? graph : null,
     errors
   });
+}
+
+function appendRuntimeEffects(effects) {
+  if (!loomletOutput || !Array.isArray(effects) || effects.length === 0) return;
+
+  const consoleEffects = effects.filter(isConsoleEffect);
+  if (consoleEffects.length === 0) return;
+
+  if (!runtimeOutputShown) {
+    runtimeOutputShown = true;
+    loomletOutput.show(true);
+  }
+
+  for (const effect of consoleEffects) {
+    const now = new Date().toLocaleTimeString();
+    const level = getConsoleEffectLevel(effect);
+    loomletOutput.appendLine(`[${now}] ${level}: ${formatConsoleEffectValue(effect)}`);
+  }
+}
+
+function isConsoleEffect(effect) {
+  if (!effect || typeof effect !== 'object') return false;
+  const type = String(effect.type || effect.kind || effect.name || '');
+  const target = String(effect.target || '');
+  return type === 'console'
+    || type === 'console.log'
+    || type === 'console.warn'
+    || type === 'console.error'
+    || target === 'console';
+}
+
+function getConsoleEffectLevel(effect) {
+  const type = String(effect.type || effect.kind || effect.name || '');
+  const method = String(effect.method || effect.level || '');
+  if (type.endsWith('.warn') || method === 'warn') return 'warn';
+  if (type.endsWith('.error') || method === 'error') return 'error';
+  return 'log';
+}
+
+function formatConsoleEffectValue(effect) {
+  const value = effect.args ?? effect.values ?? effect.value ?? effect.message ?? effect.payload ?? effect;
+  if (Array.isArray(value)) {
+    return value.map(formatValue).join(' ');
+  }
+  return formatValue(value);
+}
+
+function formatValue(value) {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || value == null) return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch (_) {
+    return String(value);
+  }
 }
 
 function getWebviewContent(scriptUri, nonce, cspSource) {
@@ -305,8 +370,6 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
       position: relative;
       overflow: hidden;
       background: rgba(30, 30, 30, 0.80);
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
       min-height: 0;
     }
   </style>

--- a/extensions/vscode-loomlet/webview-src/node-editor-webview.js
+++ b/extensions/vscode-loomlet/webview-src/node-editor-webview.js
@@ -22,6 +22,10 @@ let isRuntimePaused = false;
 let pausedAtTimestampMs = null;
 let accumulatedPausedMs = 0;
 
+// Console effect forwarding state
+let lastEffectsPostMs = 0;
+const EFFECTS_POST_INTERVAL_MS = 100;
+
 // ── Canvas: Loom Runtime Preview ─────────────────────────────────────────────
 
 function resizePreviewCanvas() {
@@ -102,6 +106,7 @@ function drawFrame(timestamp) {
 
     // Evaluate the Loom graph at this time
     loomEngine.evaluateAt(elapsedSeconds, timestamp);
+    postRuntimeEffects(timestamp);
 
     // Draw the canvas
     drawRuntimeCanvas(timestamp);
@@ -113,6 +118,32 @@ function drawFrame(timestamp) {
 
   // Schedule next frame
   loomRafId = requestAnimationFrame(drawFrame);
+}
+
+function postRuntimeEffects(timestamp) {
+  if (!loomEngine || typeof loomEngine.getEffects !== 'function') return;
+  if (timestamp - lastEffectsPostMs < EFFECTS_POST_INTERVAL_MS) return;
+
+  const effects = loomEngine.getEffects() || [];
+  const consoleEffects = effects.filter(isConsoleEffect);
+  if (consoleEffects.length === 0) return;
+
+  lastEffectsPostMs = timestamp;
+  vscode.postMessage({
+    type: 'runtimeEffects',
+    effects: consoleEffects
+  });
+}
+
+function isConsoleEffect(effect) {
+  if (!effect || typeof effect !== 'object') return false;
+  const type = String(effect.type || effect.kind || effect.name || '');
+  const target = String(effect.target || '');
+  return type === 'console'
+    || type === 'console.log'
+    || type === 'console.warn'
+    || type === 'console.error'
+    || target === 'console';
 }
 
 function drawRuntimeCanvas(timestamp) {
@@ -194,6 +225,7 @@ function stopLoom() {
   isRuntimePaused = false;
   pausedAtTimestampMs = null;
   accumulatedPausedMs = 0;
+  lastEffectsPostMs = 0;
 }
 
 function startLoom(graph) {
@@ -215,6 +247,7 @@ function startLoom(graph) {
     isRuntimePaused = false;
     pausedAtTimestampMs = null;
     accumulatedPausedMs = 0;
+    lastEffectsPostMs = 0;
     // Start the RAF loop - do NOT call loomEngine.start()
     loomRafId = requestAnimationFrame(drawFrame);
     updateControlStates();
@@ -306,6 +339,7 @@ function resetRuntime() {
   accumulatedPausedMs = 0;
   isRuntimePaused = false;
   pausedAtTimestampMs = null;
+  lastEffectsPostMs = 0;
 
   try {
     // Reset the engine to t=0


### PR DESCRIPTION
## Summary

- remove the Node Preview overlay blur from the WebView HTML/CSS
- forward Loomlet console runtime effects from the WebView to the VS Code `Loomlet` Output Channel
- add `examples/vscode/console-log.loom` as a demo that renders a moving bar and writes values to Output > Loomlet

## Notes

- This changes the WebView source entrypoint and extension source.
- Please run the VS Code extension build before packaging/release so `extensions/vscode-loomlet/media/node-editor-webview.js` is regenerated from `webview-src/node-editor-webview.js`.

## Verification

- Not run here.