### PR TITLE
Make VS Code node preview canvas fully visible

### DIFF
--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -369,7 +369,7 @@ function getWebviewContent(scriptUri, nonce, cspSource) {
       flex: 1;
       position: relative;
       overflow: hidden;
-      background: rgba(30, 30, 30, 0.80);
+      background: transparent;
       min-height: 0;
     }
   </style>


### PR DESCRIPTION
## Summary

Makes the VS Code Node Preview editor container transparent so the runtime preview canvas remains visible behind the node graph.

Previous PR #139 removed `backdrop-filter`, but `#lp-editor-container` still used `background: rgba(30, 30, 30, 0.80)`, which visually behaved like a dark overlay panel. This changes it to `background: transparent`.

## Verification

- Not run here.
- Please rebuild the VS Code WebView bundle before packaging/release if needed:
  - `cd extensions/vscode-loomlet && npm run build:webview`