### PR TITLE
Add VS Code Insert Example command

### DIFF
--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -15,7 +15,8 @@
     "onLanguage:loomlet",
     "onCommand:loomlet.runCurrentFile",
     "onCommand:loomlet.sceneSyncDevCurrentFile",
-    "onCommand:loomlet.openNodePreviewToSide"
+    "onCommand:loomlet.openNodePreviewToSide",
+    "onCommand:loomlet.insertExample"
   ],
   "contributes": {
     "languages": [
@@ -50,6 +51,10 @@
       {
         "command": "loomlet.openNodePreviewToSide",
         "title": "Loomlet: Open Node Preview to the Side"
+      },
+      {
+        "command": "loomlet.insertExample",
+        "title": "Loomlet: Insert Example"
       }
     ],
     "configuration": {
@@ -64,7 +69,7 @@
     }
   },
   "scripts": {
-    "test": "node test/completion-context.test.mjs && node test/completion-engine.test.mjs && node test/diagnostics.test.mjs && node test/preview-model.test.mjs",
+    "test": "node test/completion-context.test.mjs && node test/completion-engine.test.mjs && node test/diagnostics.test.mjs && node test/preview-model.test.mjs && node test/examples.test.mjs",
     "build:webview": "node scripts/build-webview.mjs",
     "build": "npm run build:webview"
   },

--- a/extensions/vscode-loomlet/src/examples.js
+++ b/extensions/vscode-loomlet/src/examples.js
@@ -1,0 +1,91 @@
+const VSCODE_EXAMPLES = [
+  {
+    id: 'bouncing-bar',
+    label: 'Bouncing Bar',
+    description: 'render bar',
+    detail: 'A simple bar whose width moves with a sine wave.',
+    source: `# Bouncing Bar
+# The background canvas shows a moving bar.
+
+t = clock()
+wave = sine(t, freq: 0.8)
+width = map(wave, inMin: -1, inMax: 1, outMin: 40, outMax: 320)
+
+render bar(width: width, height: 48, color: "#80ed99")
+`
+  },
+  {
+    id: 'orbit-point',
+    label: 'Orbit Point',
+    description: 'render point',
+    detail: 'A point moving around a circular path.',
+    source: `# Orbit Point
+# The background canvas shows a point moving in a circle.
+
+t = clock()
+xWave = sine(t, freq: 0.4)
+yWave = cosine(t, freq: 0.4)
+
+x = map(xWave, inMin: -1, inMax: 1, outMin: 80, outMax: 320)
+y = map(yWave, inMin: -1, inMax: 1, outMin: 80, outMax: 240)
+
+render point(x: x, y: y, color: "#ff70a6", trail: 0.08)
+`
+  },
+  {
+    id: 'lissajous-point',
+    label: 'Lissajous Point',
+    description: 'render point',
+    detail: 'A looping point trail made from two different signal frequencies.',
+    source: `# Lissajous Point
+# The background canvas shows a looping path.
+
+t = clock()
+xWave = sine(t, freq: 0.7)
+yWave = cosine(t, freq: 1.1)
+
+x = map(xWave, inMin: -1, inMax: 1, outMin: 60, outMax: 360)
+y = map(yWave, inMin: -1, inMax: 1, outMin: 60, outMax: 260)
+
+render point(x: x, y: y, color: "#70d6ff", trail: 0.04)
+`
+  },
+  {
+    id: 'pulse-bar',
+    label: 'Pulse Bar',
+    description: 'render bar',
+    detail: 'A bar that changes width and vertical position over time.',
+    source: `# Pulse Bar
+# The background canvas shows a bar changing width and position.
+
+t = clock()
+wave = sine(t, freq: 1.2)
+width = map(wave, inMin: -1, inMax: 1, outMin: 20, outMax: 360)
+y = map(wave, inMin: -1, inMax: 1, outMin: 100, outMax: 180)
+
+render bar(width: width, y: y, height: 32, color: "#ffd166")
+`
+  },
+  {
+    id: 'console-log',
+    label: 'Console Log',
+    description: 'Output Channel + render bar',
+    detail: 'Renders a moving bar and writes values to Output > Loomlet.',
+    source: `# Console Log
+# The moving bar renders in the WebView background.
+# Values are written to View > Output > Loomlet.
+
+import console
+import math
+
+t = clock()
+wave = math.sine(t, freq: 0.5)
+width = math.map(wave, inMin: -1, inMax: 1, outMin: 80, outMax: 520)
+
+console.log(width)
+render bar(width: width, height: 36, y: 180, color: "#4ec9b0", trail: 0.12)
+`
+  }
+];
+
+module.exports = { VSCODE_EXAMPLES };

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -4,6 +4,7 @@ const crypto = require('node:crypto');
 const vscode = require('vscode');
 const { getCompletionContext } = require('./completion-context');
 const { buildCompletions: buildRawCompletions, getIncludePlanned } = require('./completion-engine');
+const { VSCODE_EXAMPLES } = require('./examples.js');
 const { isLoomletDocument, normalizeLoomletErrorLocation, collectLoomletDiagnosticItems, ensureModulesLoaded } = require('./diagnostics.js');
 const { clampCoordinates } = require('./range-utils.js');
 const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('./preview-model.js');
@@ -56,6 +57,7 @@ async function activate(context) {
     vscode.commands.registerCommand('loomlet.runCurrentFile', () => runCurrentFile('run')),
     vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev')),
     vscode.commands.registerCommand('loomlet.openNodePreviewToSide', () => openNodePreviewToSide(context)),
+    vscode.commands.registerCommand('loomlet.insertExample', () => insertExample()),
     vscode.workspace.onDidChangeTextDocument((event) => {
       scheduleValidation(event.document, diagnosticCollection);
       if (nodePreviewPanel && currentPreviewDocument && event.document.uri.toString() === currentPreviewDocument.uri.toString()) {
@@ -104,6 +106,54 @@ function deactivate() {
   if (nodePreviewPanel) {
     nodePreviewPanel.dispose();
   }
+}
+
+async function insertExample() {
+  const selected = await vscode.window.showQuickPick(
+    VSCODE_EXAMPLES.map((example) => ({
+      label: example.label,
+      description: example.description,
+      detail: example.detail,
+      example
+    })),
+    {
+      title: 'Loomlet: Insert Example',
+      placeHolder: 'Choose a Loomlet example to insert'
+    }
+  );
+
+  if (!selected) return;
+
+  const source = ensureTrailingNewline(selected.example.source);
+  const editor = vscode.window.activeTextEditor;
+  const activeDocument = editor?.document;
+  const canInsertIntoActiveDocument = editor && isEditorInsertTarget(activeDocument);
+
+  if (canInsertIntoActiveDocument) {
+    await editor.edit((editBuilder) => {
+      for (const selection of editor.selections) {
+        editBuilder.replace(selection, source);
+      }
+    });
+    return;
+  }
+
+  const document = await vscode.workspace.openTextDocument({
+    language: 'loomlet',
+    content: source
+  });
+  await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
+}
+
+function ensureTrailingNewline(value) {
+  return value.endsWith('\n') ? value : `${value}\n`;
+}
+
+function isEditorInsertTarget(document) {
+  if (!document) return false;
+  return document.languageId === 'loomlet'
+    || document.languageId === 'loom'
+    || document.fileName.endsWith('.loom');
 }
 
 function openNodePreviewToSide(context) {

--- a/extensions/vscode-loomlet/test/examples.test.mjs
+++ b/extensions/vscode-loomlet/test/examples.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { VSCODE_EXAMPLES } = require('../src/examples.js');
+const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('../src/preview-model.js');
+
+await ensurePreviewModulesLoaded();
+
+assert.ok(Array.isArray(VSCODE_EXAMPLES), 'VSCODE_EXAMPLES should be an array');
+assert.ok(VSCODE_EXAMPLES.length > 0, 'Expected at least one insertable example');
+
+for (const example of VSCODE_EXAMPLES) {
+  assert.ok(example.id, 'Example should have an id');
+  assert.ok(example.label, `${example.id} should have a label`);
+  assert.ok(example.source, `${example.id} should have source`);
+
+  const result = buildPreviewModelFromDsl(example.source);
+  assert.equal(result.errors.length, 0, `${example.id} should parse and compile without errors`);
+  assert.ok(result.graph, `${example.id} should produce a graph`);
+  assert.ok(
+    result.graph.render || result.graph.nodes.some((node) => String(node.type).startsWith('console.')),
+    `${example.id} should produce a visible render or console output`
+  );
+}
+
+console.log('All insertable example tests passed!');


### PR DESCRIPTION
## Summary

Adds `Loomlet: Insert Example` to the VS Code extension.

The command shows a QuickPick of runnable starter examples and inserts the selected DSL into the active `.loom` editor. If the active editor is not a Loomlet document, it opens a new unsaved Loomlet document with the example content.

## Examples included

- Bouncing Bar
- Orbit Point
- Lissajous Point
- Pulse Bar
- Console Log

## Notes

The examples are defined in `extensions/vscode-loomlet/src/examples.js` so the command does not depend on workspace file paths.

## Validation

Adds `extensions/vscode-loomlet/test/examples.test.mjs` and wires it into the VS Code extension test script. The test verifies every insertable example parses/compiles and produces either a render output or console effect.

Not run here.