### PR TITLE
Add VS Code learning help commands

### DIFF
--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -16,7 +16,9 @@
     "onCommand:loomlet.runCurrentFile",
     "onCommand:loomlet.sceneSyncDevCurrentFile",
     "onCommand:loomlet.openNodePreviewToSide",
-    "onCommand:loomlet.insertExample"
+    "onCommand:loomlet.insertExample",
+    "onCommand:loomlet.openLibraryReference",
+    "onCommand:loomlet.clearOutput"
   ],
   "contributes": {
     "languages": [
@@ -55,6 +57,14 @@
       {
         "command": "loomlet.insertExample",
         "title": "Loomlet: Insert Example"
+      },
+      {
+        "command": "loomlet.openLibraryReference",
+        "title": "Loomlet: Open Library Reference"
+      },
+      {
+        "command": "loomlet.clearOutput",
+        "title": "Loomlet: Clear Output"
       }
     ],
     "configuration": {
@@ -64,12 +74,17 @@
           "type": "boolean",
           "default": false,
           "description": "Include planned Loomlet libraries/functions in completion suggestions."
+        },
+        "loomlet.examples.openPreviewAfterInsert": {
+          "type": "boolean",
+          "default": true,
+          "description": "Open the Node Preview automatically after inserting a Loomlet example."
         }
       }
     }
   },
   "scripts": {
-    "test": "node test/completion-context.test.mjs && node test/completion-engine.test.mjs && node test/diagnostics.test.mjs && node test/preview-model.test.mjs && node test/examples.test.mjs",
+    "test": "node test/completion-context.test.mjs && node test/completion-engine.test.mjs && node test/diagnostics.test.mjs && node test/preview-model.test.mjs && node test/examples.test.mjs && node test/library-reference.test.mjs",
     "build:webview": "node scripts/build-webview.mjs",
     "build": "npm run build:webview"
   },

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -5,6 +5,7 @@ const vscode = require('vscode');
 const { getCompletionContext } = require('./completion-context');
 const { buildCompletions: buildRawCompletions, getIncludePlanned } = require('./completion-engine');
 const { VSCODE_EXAMPLES } = require('./examples.js');
+const { LIBRARY_REFERENCE, getLibraryReference } = require('./library-reference.js');
 const { isLoomletDocument, normalizeLoomletErrorLocation, collectLoomletDiagnosticItems, ensureModulesLoaded } = require('./diagnostics.js');
 const { clampCoordinates } = require('./range-utils.js');
 const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('./preview-model.js');
@@ -15,11 +16,13 @@ let previousEditorModel = null;
 let previewDebounceTimer = null;
 let loomletOutput = null;
 let runtimeOutputShown = false;
+let extensionContext = null;
 const PREVIEW_DEBOUNCE_MS = 300;
 
 const pendingValidationTimers = new Map();
 
 async function activate(context) {
+  extensionContext = context;
   loomletOutput = vscode.window.createOutputChannel('Loomlet');
   context.subscriptions.push(loomletOutput);
 
@@ -49,8 +52,15 @@ async function activate(context) {
     }
   };
 
+  const hoverProvider = {
+    provideHover(document, position) {
+      return provideLoomletHover(document, position);
+    }
+  };
+
   context.subscriptions.push(
-    vscode.languages.registerCompletionItemProvider({ language: 'loomlet', scheme: 'file' }, provider, '.', '(', ':')
+    vscode.languages.registerCompletionItemProvider({ language: 'loomlet', scheme: 'file' }, provider, '.', '(', ':'),
+    vscode.languages.registerHoverProvider({ language: 'loomlet', scheme: 'file' }, hoverProvider)
   );
 
   context.subscriptions.push(
@@ -58,6 +68,8 @@ async function activate(context) {
     vscode.commands.registerCommand('loomlet.sceneSyncDevCurrentFile', () => runCurrentFile('scenesync dev')),
     vscode.commands.registerCommand('loomlet.openNodePreviewToSide', () => openNodePreviewToSide(context)),
     vscode.commands.registerCommand('loomlet.insertExample', () => insertExample()),
+    vscode.commands.registerCommand('loomlet.openLibraryReference', () => openLibraryReference()),
+    vscode.commands.registerCommand('loomlet.clearOutput', () => clearLoomletOutput()),
     vscode.workspace.onDidChangeTextDocument((event) => {
       scheduleValidation(event.document, diagnosticCollection);
       if (nodePreviewPanel && currentPreviewDocument && event.document.uri.toString() === currentPreviewDocument.uri.toString()) {
@@ -128,6 +140,7 @@ async function insertExample() {
   const editor = vscode.window.activeTextEditor;
   const activeDocument = editor?.document;
   const canInsertIntoActiveDocument = editor && isEditorInsertTarget(activeDocument);
+  let targetEditor = editor;
 
   if (canInsertIntoActiveDocument) {
     await editor.edit((editBuilder) => {
@@ -135,14 +148,19 @@ async function insertExample() {
         editBuilder.replace(selection, source);
       }
     });
-    return;
+  } else {
+    const document = await vscode.workspace.openTextDocument({
+      language: 'loomlet',
+      content: source
+    });
+    targetEditor = await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
   }
 
-  const document = await vscode.workspace.openTextDocument({
-    language: 'loomlet',
-    content: source
-  });
-  await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
+  const openPreview = vscode.workspace.getConfiguration().get('loomlet.examples.openPreviewAfterInsert', true);
+  if (openPreview && targetEditor?.document && extensionContext) {
+    currentPreviewDocument = targetEditor.document;
+    openNodePreviewToSide(extensionContext);
+  }
 }
 
 function ensureTrailingNewline(value) {
@@ -154,6 +172,86 @@ function isEditorInsertTarget(document) {
   return document.languageId === 'loomlet'
     || document.languageId === 'loom'
     || document.fileName.endsWith('.loom');
+}
+
+async function openLibraryReference() {
+  const selected = await vscode.window.showQuickPick(
+    LIBRARY_REFERENCE.map((entry) => ({
+      label: entry.label,
+      description: entry.signature,
+      detail: entry.description,
+      entry
+    })),
+    {
+      title: 'Loomlet: Library Reference',
+      placeHolder: 'Choose a Loomlet function or output'
+    }
+  );
+
+  if (!selected) return;
+
+  const document = await vscode.workspace.openTextDocument({
+    language: 'markdown',
+    content: formatReferenceMarkdown(selected.entry)
+  });
+  await vscode.window.showTextDocument(document, vscode.ViewColumn.Beside, true);
+}
+
+function clearLoomletOutput() {
+  if (!loomletOutput) return;
+  loomletOutput.clear();
+  runtimeOutputShown = false;
+}
+
+function provideLoomletHover(document, position) {
+  const range = getLoomletHoverRange(document, position);
+  if (!range) return null;
+
+  const name = document.getText(range);
+  const reference = getLibraryReference(name);
+  if (!reference) return null;
+
+  const markdown = new vscode.MarkdownString(undefined, true);
+  markdown.isTrusted = false;
+  markdown.appendCodeblock(reference.signature, 'loom');
+  markdown.appendMarkdown(`${reference.description}\n\n`);
+  if (reference.example) {
+    markdown.appendMarkdown('Example:\n');
+    markdown.appendCodeblock(reference.example, 'loom');
+  }
+  return new vscode.Hover(markdown, range);
+}
+
+function getLoomletHoverRange(document, position) {
+  const text = document.getText();
+  const offset = document.offsetAt(position);
+  const candidates = Array.from(new Set(
+    LIBRARY_REFERENCE.flatMap((entry) => entry.names)
+      .sort((a, b) => b.length - a.length)
+  ));
+
+  for (const name of candidates) {
+    const minStart = Math.max(0, offset - name.length + 1);
+    for (let start = minStart; start <= offset; start += 1) {
+      const end = start + name.length;
+      if (end < offset) continue;
+      if (text.slice(start, end) !== name) continue;
+      if (!isNameBoundary(text[start - 1]) || !isNameBoundary(text[end])) continue;
+      return new vscode.Range(document.positionAt(start), document.positionAt(end));
+    }
+  }
+
+  const fallback = document.getWordRangeAtPosition(position, /[A-Za-z_][A-Za-z0-9_.]*/);
+  if (!fallback) return null;
+  return getLibraryReference(document.getText(fallback)) ? fallback : null;
+}
+
+function isNameBoundary(char) {
+  return char === undefined || !/[A-Za-z0-9_.]/.test(char);
+}
+
+function formatReferenceMarkdown(entry) {
+  return `# ${entry.label}\n\n\`\`\`loom\n${entry.signature}\n\`\`\`\n\n${entry.description}\n\n## Example\n\n\`\`\`loom\n${entry.example || ''}\n\`\`\`\n`;
 }
 
 function openNodePreviewToSide(context) {
@@ -623,5 +721,6 @@ module.exports = {
   activate,
   deactivate,
   findLoomletCli,
-  buildCompletions
+  buildCompletions,
+  getLoomletHoverRange
 };

--- a/extensions/vscode-loomlet/src/library-reference.js
+++ b/extensions/vscode-loomlet/src/library-reference.js
@@ -1,0 +1,67 @@
+const LIBRARY_REFERENCE = [
+  {
+    names: ['clock'],
+    label: 'clock',
+    signature: 'clock() -> number',
+    description: 'A time source. In the VS Code Runtime Preview, it advances with the preview animation time.',
+    example: 't = clock()'
+  },
+  {
+    names: ['sine', 'math.sine'],
+    label: 'sine',
+    signature: 'sine(value, freq: number = 1, amplitude: number = 1) -> number',
+    description: 'Returns a sine wave for the input value. Use freq to control the speed and amplitude to control the range.',
+    example: 't = clock()\nwave = sine(t, freq: 0.8)'
+  },
+  {
+    names: ['cosine', 'math.cosine'],
+    label: 'cosine',
+    signature: 'cosine(value, freq: number = 1, amplitude: number = 1) -> number',
+    description: 'Returns a cosine wave for the input value. It is useful for circular and orbital motion when paired with sine.',
+    example: 't = clock()\nx = sine(t, freq: 0.4)\ny = cosine(t, freq: 0.4)'
+  },
+  {
+    names: ['map', 'math.map'],
+    label: 'map',
+    signature: 'map(value, inMin, inMax, outMin, outMax) -> number',
+    description: 'Remaps a value from one numeric range to another. Commonly used to convert -1..1 waves into screen coordinates or sizes.',
+    example: 'width = map(wave, inMin: -1, inMax: 1, outMin: 40, outMax: 320)'
+  },
+  {
+    names: ['console.log'],
+    label: 'console.log',
+    signature: 'console.log(value)',
+    description: 'Writes a value to the host output. In VS Code, values appear in View > Output > Loomlet.',
+    example: 'console.log(width)'
+  },
+  {
+    names: ['render bar', 'bar'],
+    label: 'render bar',
+    signature: 'render bar(width, height?: number, y?: number, color?: string, trail?: number)',
+    description: 'Draws a horizontal bar in the VS Code Runtime Preview canvas.',
+    example: 'render bar(width: width, height: 48, color: "#80ed99")'
+  },
+  {
+    names: ['render point', 'point'],
+    label: 'render point',
+    signature: 'render point(x, y, color?: string, trail?: number)',
+    description: 'Draws a point in the VS Code Runtime Preview canvas. Add trail to leave motion traces.',
+    example: 'render point(x: x, y: y, color: "#70d6ff", trail: 0.04)'
+  }
+];
+
+const ALIAS_TO_REFERENCE = new Map();
+for (const entry of LIBRARY_REFERENCE) {
+  for (const name of entry.names) {
+    ALIAS_TO_REFERENCE.set(name, entry);
+  }
+}
+
+function getLibraryReference(name) {
+  return ALIAS_TO_REFERENCE.get(name) || null;
+}
+
+module.exports = {
+  LIBRARY_REFERENCE,
+  getLibraryReference
+};

--- a/extensions/vscode-loomlet/test/library-reference.test.mjs
+++ b/extensions/vscode-loomlet/test/library-reference.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { LIBRARY_REFERENCE, getLibraryReference } = require('../src/library-reference.js');
+
+assert.ok(Array.isArray(LIBRARY_REFERENCE), 'LIBRARY_REFERENCE should be an array');
+assert.ok(LIBRARY_REFERENCE.length > 0, 'Expected library reference entries');
+
+for (const entry of LIBRARY_REFERENCE) {
+  assert.ok(entry.label, 'Reference entry should have a label');
+  assert.ok(entry.signature, `${entry.label} should have a signature`);
+  assert.ok(entry.description, `${entry.label} should have a description`);
+  assert.ok(Array.isArray(entry.names), `${entry.label} should have names`);
+  assert.ok(entry.names.length > 0, `${entry.label} should have at least one name`);
+
+  for (const name of entry.names) {
+    assert.equal(getLibraryReference(name), entry, `${name} should resolve to its reference entry`);
+  }
+}
+
+assert.equal(getLibraryReference('__missing__'), null, 'missing reference should return null');
+
+console.log('All library reference tests passed!');


### PR DESCRIPTION
## Summary

Adds a small learning/discovery layer to the VS Code Loomlet extension, rebased cleanly on current `main`.

- Adds hover help for core functions and render outputs used by the examples:
  - `clock`
  - `sine` / `math.sine`
  - `cosine` / `math.cosine`
  - `map` / `math.map`
  - `console.log`
  - `render bar`
  - `render point`
- Adds `Loomlet: Open Library Reference`
  - QuickPick list of reference entries
  - opens a short Markdown reference document beside the editor
- Adds `Loomlet: Clear Output`
  - clears the `Loomlet` Output Channel
- Adds setting:
  - `loomlet.examples.openPreviewAfterInsert`, default `true`
- Updates `Loomlet: Insert Example` so it opens Node Preview automatically when the setting is enabled

## Tests

Adds:

- `extensions/vscode-loomlet/test/library-reference.test.mjs`

and wires it into the existing VS Code extension `npm test` script.

## Notes

This PR intentionally keeps the existing `examples.js` from `main` and does not modify the WebView bundle.