### PR TITLE
Document VS Code interactive preview helpers

### DIFF
--- a/examples/vscode/03-mouse-follower.loom
+++ b/examples/vscode/03-mouse-follower.loom
@@ -1,6 +1,10 @@
-# Mouse Follower
-# VS Code Node Preview example.
+# VS Code Runtime Preview example: Mouse Follower
+# Open this file with Loomlet: Open Node Preview to the Side.
 # Move the mouse over the preview canvas; the point follows it.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+# Note: input.mouseX/input.mouseY are currently VS Code Preview host inputs.
 
 import input
 

--- a/examples/vscode/04-mouse-paint.loom
+++ b/examples/vscode/04-mouse-paint.loom
@@ -1,7 +1,11 @@
-# Mouse Paint
-# VS Code Node Preview example.
+# VS Code Runtime Preview example: Mouse Paint
+# Open this file with Loomlet: Open Node Preview to the Side.
 # Hold the mouse button down and draw on the preview canvas.
 # Press Reset in the preview toolbar to clear the drawing.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+# Note: input.mouseDown and render point(enabled: ...) are currently VS Code Preview host features.
 
 import input
 

--- a/examples/vscode/05-key-visualizer.loom
+++ b/examples/vscode/05-key-visualizer.loom
@@ -1,7 +1,11 @@
-# Key Visualizer
-# VS Code Node Preview example.
+# VS Code Runtime Preview example: Key Visualizer
+# Open this file with Loomlet: Open Node Preview to the Side.
 # Click the preview canvas, then press Space or Arrow keys.
 # Key states are shown on the canvas and written to View > Output > Loomlet.
+
+# Status: runnable
+# Host: vscode-runtime-preview
+# Note: input.key and render keys are currently VS Code Preview host features.
 
 import input
 import console

--- a/examples/vscode/README.md
+++ b/examples/vscode/README.md
@@ -1,0 +1,48 @@
+# VS Code Runtime Preview Examples
+
+These examples are intended for the Loomlet VS Code extension.
+
+Open a `.loom` file in this directory, then run:
+
+```text
+Loomlet: Open Node Preview to the Side
+```
+
+The Node Preview shows the node graph as an overlay and uses the background canvas as a small runtime host.
+
+## Examples
+
+| File | What to try |
+| --- | --- |
+| `01-bouncing-bar.loom` | A simple animated bar rendered to the preview canvas. |
+| `console-log.loom` | Writes values to `View > Output > Loomlet` while rendering a bar. |
+| `03-mouse-follower.loom` | Move the mouse over the preview canvas. |
+| `04-mouse-paint.loom` | Hold the mouse button down and draw. Press Reset to clear the canvas. |
+| `05-key-visualizer.loom` | Click the preview canvas, then press Space or Arrow keys. |
+
+## Host-specific capabilities
+
+The following helpers are currently provided by the VS Code Runtime Preview host:
+
+- `input.mouseX()`
+- `input.mouseY()`
+- `input.mouseDown()`
+- `input.key("Space")` and other `KeyboardEvent.code` values
+- `render point(..., enabled: ...)`
+- `render keys(...)`
+
+These are useful for learning and interactive previews, but they are not yet a shared contract across every Loomlet host. Other hosts may ignore or reject them until they are promoted into the common runtime/host specification.
+
+## Output
+
+`console.log(...)` writes to:
+
+```text
+View > Output > Loomlet
+```
+
+Use the command below to clear it:
+
+```text
+Loomlet: Clear Output
+```

--- a/extensions/vscode-loomlet/src/library-reference.js
+++ b/extensions/vscode-loomlet/src/library-reference.js
@@ -1,3 +1,5 @@
+const PREVIEW_HOST_NOTE = 'Currently supported by the VS Code Runtime Preview host. Other hosts may ignore or reject this until the capability is promoted into the shared runtime contract.';
+
 const LIBRARY_REFERENCE = [
   {
     names: ['clock'],
@@ -35,6 +37,34 @@ const LIBRARY_REFERENCE = [
     example: 'console.log(width)'
   },
   {
+    names: ['input.mouseX', 'mouseX'],
+    label: 'input.mouseX',
+    signature: 'input.mouseX() -> number',
+    description: `Returns the current mouse X coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nx = input.mouseX()\nrender point(x: x, y: 120, radius: 7)'
+  },
+  {
+    names: ['input.mouseY', 'mouseY'],
+    label: 'input.mouseY',
+    signature: 'input.mouseY() -> number',
+    description: `Returns the current mouse Y coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\ny = input.mouseY()\nrender point(x: 120, y: y, radius: 7)'
+  },
+  {
+    names: ['input.mouseDown', 'mouseDown'],
+    label: 'input.mouseDown',
+    signature: 'input.mouseDown() -> boolean',
+    description: `Returns true while the primary mouse button is pressed in the VS Code Runtime Preview. Use it with render point enabled to make simple drawing tools. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nx = input.mouseX()\ny = input.mouseY()\ndown = input.mouseDown()\nrender point(x: x, y: y, enabled: down, trail: 0)'
+  },
+  {
+    names: ['input.key', 'key'],
+    label: 'input.key',
+    signature: 'input.key(code: string) -> boolean',
+    description: `Returns true while a key is pressed in the VS Code Runtime Preview. Use KeyboardEvent.code values such as "Space", "ArrowLeft", "ArrowRight", "ArrowUp", and "ArrowDown". ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nspace = input.key("Space")\nconsole.log(space)'
+  },
+  {
     names: ['render bar', 'bar'],
     label: 'render bar',
     signature: 'render bar(width, height?: number, y?: number, color?: string, trail?: number)',
@@ -44,9 +74,16 @@ const LIBRARY_REFERENCE = [
   {
     names: ['render point', 'point'],
     label: 'render point',
-    signature: 'render point(x, y, color?: string, trail?: number)',
-    description: 'Draws a point in the VS Code Runtime Preview canvas. Add trail to leave motion traces.',
-    example: 'render point(x: x, y: y, color: "#70d6ff", trail: 0.04)'
+    signature: 'render point(x, y, radius?: number, color?: string, trail?: number, enabled?: boolean)',
+    description: 'Draws a point in the VS Code Runtime Preview canvas. Add trail to leave motion traces. Set enabled to false to skip drawing for the current frame.',
+    example: 'render point(x: x, y: y, radius: 7, color: "#70d6ff", trail: 0.04)'
+  },
+  {
+    names: ['render keys', 'keys'],
+    label: 'render keys',
+    signature: 'render keys(space?: boolean, left?: boolean, right?: boolean, up?: boolean, down?: boolean, trail?: number)',
+    description: `Draws a simple Space/Arrow key state visualizer in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nspace = input.key("Space")\nleft = input.key("ArrowLeft")\nright = input.key("ArrowRight")\nup = input.key("ArrowUp")\ndown = input.key("ArrowDown")\nrender keys(space: space, left: left, right: right, up: up, down: down)'
   }
 ];
 

--- a/test/vscode-examples.test.mjs
+++ b/test/vscode-examples.test.mjs
@@ -3,7 +3,13 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseDSLToAST, compileToGraph } from '../src/loom-dsl.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  ensurePreviewModulesLoaded,
+  buildPreviewModelFromDsl
+} = require('../extensions/vscode-loomlet/src/preview-model.js');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
@@ -23,7 +29,9 @@ function walkLoomFiles(dir) {
   return files;
 }
 
-test('VS Code runtime preview examples compile to visible render outputs', () => {
+test('VS Code runtime preview examples compile to visible render outputs', async () => {
+  await ensurePreviewModulesLoaded();
+
   const files = walkLoomFiles(examplesRoot);
   assert.ok(files.length > 0, 'Expected VS Code examples to exist');
 
@@ -31,16 +39,13 @@ test('VS Code runtime preview examples compile to visible render outputs', () =>
     const source = fs.readFileSync(file, 'utf8');
     const relativeFile = path.relative(projectRoot, file).replace(/\\/g, '/');
 
-    const { ast, errors: parseErrors } = parseDSLToAST(source);
-    assert.deepEqual(parseErrors, [], `${relativeFile} parse errors`);
+    const { graph, errors } = buildPreviewModelFromDsl(source);
+    assert.deepEqual(errors, [], `${relativeFile} preview model errors`);
 
-    const { graph, errors: compileErrors } = compileToGraph(ast);
-    assert.deepEqual(compileErrors, [], `${relativeFile} compile errors`);
-
-    assert.ok(graph.render, `${relativeFile} should define graph.render`);
+    assert.ok(graph?.render, `${relativeFile} should define graph.render`);
     assert.ok(
-      graph.render.type === 'bar' || graph.render.type === 'point',
-      `${relativeFile} render type should be bar or point, got ${graph.render.type}`
+      graph.render.type === 'bar' || graph.render.type === 'point' || graph.render.type === 'keys',
+      `${relativeFile} render type should be bar, point, or keys, got ${graph.render.type}`
     );
   }
 });


### PR DESCRIPTION
## Summary

- Add Library Reference / Hover Help entries for VS Code Preview interactive helpers:
  - `input.mouseX()`
  - `input.mouseY()`
  - `input.mouseDown()`
  - `input.key(...)`
  - `render point(..., enabled: ...)`
  - `render keys(...)`
- Clarify that these interactive helpers are currently VS Code Runtime Preview host features.
- Add `examples/vscode/README.md` explaining how to open the examples, where console output appears, and which helpers are host-specific.
- Normalize the interactive example headers with `Status` / `Host` notes.

## Notes

This PR intentionally documents the current behavior without promoting the VS Code Preview helpers into the shared Loomlet runtime contract yet. That keeps the fun interactive examples usable while preserving room to define the common host API later.

## Test plan

- Run `cd extensions/vscode-loomlet && npm test`
- Open `examples/vscode/03-mouse-follower.loom`, `04-mouse-paint.loom`, and `05-key-visualizer.loom`
- Run `Loomlet: Open Node Preview to the Side`
- Hover over `input.mouseX`, `input.mouseDown`, `input.key`, `render point`, and `render keys`
- Run `Loomlet: Open Library Reference` and confirm the same entries are discoverable