### PR TITLE
Add Scene Sync panel for broadcasting behavior graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,34 @@ npm run test:browser   # Browser tests
 
 詳細は `editor-studio/src/` の実装と `test/*.test.html` のブラウザテスト、および `npm run test:browser` を参照してください。
 
+**Scene Sync prototype**
+
+The Node Editor can send the current Loomlet graph to a Scene Sync room as a Behavior Graph.
+
+1. Open the Node Editor.
+2. Create or edit a Loomlet behavior.
+3. Open the `Scene Sync` tab in the bottom panel.
+4. Enter the endpoint and room id.
+5. Choose `Object Behavior Graph` or `Scene Behavior Graph`.
+6. For object scope, enter an object id such as `sample-cube`.
+7. Click `Compile Payload` to preview the payload.
+8. Click `Apply Behavior` to broadcast `scene-graph-set`.
+9. Click `Clear Behavior` to broadcast `scene-graph-clear`.
+
+Default endpoint:
+
+```text
+https://afjk.jp/presence
+```
+
+Prototype note:
+
+This panel uses REST broadcast only. It does not join the Scene Sync room and does not integrate with Scene Sync undo/redo, object selection, or history.
+
+Position note:
+
+`sceneSetPosition` currently writes absolute world positions. Use explicit base values in your graph if you want to keep the object near its current location.
+
 ## デモの確認方法
 
 GitHub Pages で公開されているデモを、ブラウザから直接確認できます。

--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -84,6 +84,7 @@
             <button class="tab-btn" data-tab="nodes">Nodes</button>
             <button class="tab-btn" data-tab="palette">Palette</button>
             <button class="tab-btn" data-tab="output">Output</button>
+            <button class="tab-btn" data-tab="scene-sync">Scene Sync</button>
           </div>
           <button id="bottom-panel-collapse-btn" class="bottom-panel-collapse-btn" title="Collapse bottom panel">Collapse</button>
         </div>
@@ -130,6 +131,57 @@
                 <button id="clear-output-btn" class="btn">Clear</button>
               </div>
               <pre id="output-log" class="output-log"></pre>
+            </div>
+          </div>
+          <div id="scene-sync-tab" class="tab-pane">
+            <div class="scene-sync-panel">
+              <div class="scene-sync-form-grid">
+                <label>
+                  Endpoint
+                  <input id="sceneSyncEndpoint" type="url" />
+                </label>
+
+                <label>
+                  Room
+                  <input id="sceneSyncRoom" type="text" placeholder="Scene Sync room id" />
+                </label>
+
+                <label>
+                  Scope
+                  <select id="sceneSyncScope">
+                    <option value="object">Object Behavior Graph</option>
+                    <option value="scene">Scene Behavior Graph</option>
+                  </select>
+                </label>
+
+                <label>
+                  Object ID
+                  <input id="sceneSyncObjectId" type="text" placeholder="sample-cube" />
+                </label>
+
+                <label>
+                  Nickname
+                  <input id="sceneSyncNickname" type="text" placeholder="Loomlet Editor" />
+                </label>
+              </div>
+
+              <div class="scene-sync-actions">
+                <button id="compileSceneSyncPayloadBtn" type="button" class="btn">Compile Payload</button>
+                <button id="applySceneSyncBehaviorBtn" type="button" class="btn btn-primary">Apply Behavior</button>
+                <button id="clearSceneSyncBehaviorBtn" type="button" class="btn btn-danger">Clear Behavior</button>
+              </div>
+
+              <p class="scene-sync-note">
+                Prototype: this panel sends Scene Sync Behavior Graph payloads by REST broadcast.
+                It does not integrate with Scene Sync undo/redo or object selection yet.
+              </p>
+
+              <p class="scene-sync-note">
+                Note: sceneSetPosition currently writes absolute world positions.
+                Use explicit base values in your graph if you want to keep the object near its current location.
+              </p>
+
+              <pre id="sceneSyncPayloadPreview" class="scene-sync-payload-preview"></pre>
             </div>
           </div>
         </div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -9,6 +9,8 @@ import { forceLinting } from '@codemirror/lint';
 import { Loom, NODE_TYPES } from '../../src/loom.js';
 import { loomletDslExtensions } from './loomlet-codemirror.js';
 import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
+import { compileLoomToSceneSyncGraph } from '../../src/scenesync/graph-adapter.js';
+import { createSceneGraphSetPayload, createSceneGraphClearPayload } from '../../src/scenesync/graphs.js';
 import {
   graphToEditorModel,
   editorModelToGraph,
@@ -50,6 +52,14 @@ const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';
 const ACTIVE_BOTTOM_TAB_KEY = 'loomlet.editorStudio.activeBottomTab';
 const AUTO_APPLY_DSL_KEY = 'loomlet.editorStudio.autoApplyDslEnabled';
 const EDITOR_MAXIMIZE_MODE_KEY = 'loomlet.editorStudio.editorMaximizeMode';
+
+const SCENE_SYNC_STORAGE_KEYS = {
+  endpoint: 'loomlet.editorStudio.sceneSync.endpoint',
+  room: 'loomlet.editorStudio.sceneSync.room',
+  scope: 'loomlet.editorStudio.sceneSync.scope',
+  objectId: 'loomlet.editorStudio.sceneSync.objectId',
+  nickname: 'loomlet.editorStudio.sceneSync.nickname'
+};
 
 const MAX_HISTORY_ENTRIES = 100;
 const MOVE_HISTORY_COALESCE_MS = 250;
@@ -140,7 +150,16 @@ const elements = {
   autoApplyStatusPill: document.getElementById('auto-apply-status-pill'),
   autoSyncStatusPill: document.getElementById('auto-sync-status-pill'),
   outputLog: document.getElementById('output-log'),
-  clearOutputBtn: document.getElementById('clear-output-btn')
+  clearOutputBtn: document.getElementById('clear-output-btn'),
+  sceneSyncEndpoint: document.getElementById('sceneSyncEndpoint'),
+  sceneSyncRoom: document.getElementById('sceneSyncRoom'),
+  sceneSyncScope: document.getElementById('sceneSyncScope'),
+  sceneSyncObjectId: document.getElementById('sceneSyncObjectId'),
+  sceneSyncNickname: document.getElementById('sceneSyncNickname'),
+  compileSceneSyncPayloadBtn: document.getElementById('compileSceneSyncPayloadBtn'),
+  applySceneSyncBehaviorBtn: document.getElementById('applySceneSyncBehaviorBtn'),
+  clearSceneSyncBehaviorBtn: document.getElementById('clearSceneSyncBehaviorBtn'),
+  sceneSyncPayloadPreview: document.getElementById('sceneSyncPayloadPreview')
 };
 
 function setPanelsVisible(visible) {
@@ -1092,6 +1111,240 @@ function setEditorError(message) {
     errors: [{ code: 'EDITOR_ERROR', message }]
   });
   renderErrors();
+}
+
+/* Scene Sync panel functions */
+
+function loadSceneSyncSettings() {
+  elements.sceneSyncEndpoint.value =
+    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.endpoint) || 'https://afjk.jp/presence';
+
+  elements.sceneSyncRoom.value =
+    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.room) || '';
+
+  elements.sceneSyncScope.value =
+    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.scope) || 'object';
+
+  elements.sceneSyncObjectId.value =
+    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.objectId) || 'sample-cube';
+
+  elements.sceneSyncNickname.value =
+    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.nickname) || 'Loomlet Editor';
+
+  updateSceneSyncScopeUi();
+}
+
+function saveSceneSyncSettings() {
+  localStorage.setItem(
+    SCENE_SYNC_STORAGE_KEYS.endpoint,
+    elements.sceneSyncEndpoint.value.trim()
+  );
+  localStorage.setItem(
+    SCENE_SYNC_STORAGE_KEYS.room,
+    elements.sceneSyncRoom.value.trim()
+  );
+  localStorage.setItem(
+    SCENE_SYNC_STORAGE_KEYS.scope,
+    elements.sceneSyncScope.value
+  );
+  localStorage.setItem(
+    SCENE_SYNC_STORAGE_KEYS.objectId,
+    elements.sceneSyncObjectId.value.trim()
+  );
+  localStorage.setItem(
+    SCENE_SYNC_STORAGE_KEYS.nickname,
+    elements.sceneSyncNickname.value.trim()
+  );
+}
+
+function updateSceneSyncScopeUi() {
+  const isObjectScope = elements.sceneSyncScope.value === 'object';
+  elements.sceneSyncObjectId.disabled = !isObjectScope;
+}
+
+function getCurrentSceneSyncSourceText() {
+  const state = store.getState();
+
+  if (!hasUnsyncedDslText && state.editorModel) {
+    return generateCanonicalDslFromState();
+  }
+
+  return getDslText();
+}
+
+function getSceneSyncScopeFromUi() {
+  const scope = elements.sceneSyncScope.value;
+
+  if (scope === 'scene') {
+    return 'scene';
+  }
+
+  const objectId = elements.sceneSyncObjectId.value.trim();
+
+  if (!objectId) {
+    throw new Error('Object ID is required for Object Behavior Graph.');
+  }
+
+  return { object: objectId };
+}
+
+function compileCurrentSceneSyncPayload() {
+  const source = getCurrentSceneSyncSourceText();
+  const scope = getSceneSyncScopeFromUi();
+
+  const result = compileLoomToSceneSyncGraph(source, { scope });
+
+  return createSceneGraphSetPayload(result.scope || scope, result.graph);
+}
+
+function createCurrentSceneSyncClearPayload() {
+  const scope = getSceneSyncScopeFromUi();
+  return createSceneGraphClearPayload(scope);
+}
+
+function normalizeSceneSyncEndpoint(endpoint) {
+  return String(endpoint || '').trim().replace(/\/+$/, '');
+}
+
+function createSceneSyncBroadcastUrl({ endpoint, room, nickname }) {
+  const base = normalizeSceneSyncEndpoint(endpoint);
+  const encodedRoom = encodeURIComponent(room);
+  const url = new URL(`${base}/api/room/${encodedRoom}/broadcast`);
+
+  if (nickname) {
+    url.searchParams.set('name', nickname);
+  }
+
+  return url.toString();
+}
+
+async function broadcastSceneSyncPayload(payload) {
+  const endpoint = elements.sceneSyncEndpoint.value.trim();
+  const room = elements.sceneSyncRoom.value.trim();
+  const nickname = elements.sceneSyncNickname.value.trim() || 'Loomlet Editor';
+
+  if (!endpoint) {
+    throw new Error('Endpoint is required.');
+  }
+
+  if (!room) {
+    throw new Error('Room is required.');
+  }
+
+  const url = createSceneSyncBroadcastUrl({ endpoint, room, nickname });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const text = await response.text();
+
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Scene Sync broadcast failed: ${response.status} ${response.statusText} ${
+        body ? JSON.stringify(body) : ''
+      }`
+    );
+  }
+
+  return body;
+}
+
+function renderSceneSyncPayloadPreview(payload) {
+  if (!elements.sceneSyncPayloadPreview) {
+    return;
+  }
+
+  elements.sceneSyncPayloadPreview.textContent = payload
+    ? JSON.stringify(payload, null, 2)
+    : '';
+}
+
+async function handleCompileSceneSyncPayload() {
+  try {
+    saveSceneSyncSettings();
+
+    const payload = compileCurrentSceneSyncPayload();
+
+    renderSceneSyncPayloadPreview(payload);
+
+    const state = store.getState();
+    const source = (!hasUnsyncedDslText && state.editorModel)
+      ? 'graph'
+      : 'DSL editor';
+
+    appendOutput({
+      level: 'info',
+      message: `Compiled Scene Sync payload from ${source}.`
+    });
+  } catch (error) {
+    renderSceneSyncPayloadPreview(null);
+
+    appendOutput({
+      level: 'error',
+      message: `Scene Sync compile failed: ${error.message}`
+    });
+  }
+}
+
+async function handleApplySceneSyncBehavior() {
+  try {
+    saveSceneSyncSettings();
+
+    const payload = compileCurrentSceneSyncPayload();
+
+    renderSceneSyncPayloadPreview(payload);
+
+    const state = store.getState();
+    const source = (!hasUnsyncedDslText && state.editorModel)
+      ? 'graph'
+      : 'DSL editor';
+
+    const result = await broadcastSceneSyncPayload(payload);
+
+    appendOutput({
+      level: 'info',
+      message: `Applied Scene Sync Behavior from ${source}.\n${JSON.stringify(result, null, 2)}`
+    });
+  } catch (error) {
+    appendOutput({
+      level: 'error',
+      message: `Apply Scene Sync Behavior failed: ${error.message}`
+    });
+  }
+}
+
+async function handleClearSceneSyncBehavior() {
+  try {
+    saveSceneSyncSettings();
+
+    const payload = createCurrentSceneSyncClearPayload();
+
+    renderSceneSyncPayloadPreview(payload);
+
+    const result = await broadcastSceneSyncPayload(payload);
+
+    appendOutput({
+      level: 'info',
+      message: `Cleared Scene Sync Behavior.\n${JSON.stringify(result, null, 2)}`
+    });
+  } catch (error) {
+    appendOutput({
+      level: 'error',
+      message: `Clear Scene Sync Behavior failed: ${error.message}`
+    });
+  }
 }
 
 function renderConnectionItem(edge) {
@@ -2193,6 +2446,21 @@ function setupEventListeners() {
 
   elements.clearOutputBtn?.addEventListener('click', clearOutput);
 
+  // Scene Sync event listeners
+  elements.sceneSyncEndpoint?.addEventListener('input', saveSceneSyncSettings);
+  elements.sceneSyncRoom?.addEventListener('input', saveSceneSyncSettings);
+  elements.sceneSyncObjectId?.addEventListener('input', saveSceneSyncSettings);
+  elements.sceneSyncNickname?.addEventListener('input', saveSceneSyncSettings);
+
+  elements.sceneSyncScope?.addEventListener('change', () => {
+    updateSceneSyncScopeUi();
+    saveSceneSyncSettings();
+  });
+
+  elements.compileSceneSyncPayloadBtn?.addEventListener('click', handleCompileSceneSyncPayload);
+  elements.applySceneSyncBehaviorBtn?.addEventListener('click', handleApplySceneSyncBehavior);
+  elements.clearSceneSyncBehaviorBtn?.addEventListener('click', handleClearSceneSyncBehavior);
+
   elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
 
@@ -2318,6 +2586,7 @@ async function init() {
   loadActiveBottomTab();
   loadAutoApplyDslSetting();
   loadEditorMaximizeMode();
+  loadSceneSyncSettings();
   renderFileStatus();
   renderDirtyStatus();
   renderAutoApplyStatus();

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1047,3 +1047,78 @@ button:disabled:hover,
 .output-log.is-empty {
   color: rgba(255, 255, 255, 0.48);
 }
+
+/* Scene Sync panel */
+.scene-sync-panel {
+  height: 100%;
+  display: grid;
+  gap: 12px;
+  grid-template-rows: auto auto auto auto 1fr;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+}
+
+.scene-sync-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.scene-sync-form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.scene-sync-form-grid input,
+.scene-sync-form-grid select {
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.86);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.scene-sync-form-grid input:focus,
+.scene-sync-form-grid select:focus {
+  outline: none;
+  border-color: rgba(74, 144, 226, 0.5);
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.scene-sync-form-grid input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.scene-sync-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.scene-sync-note {
+  margin: 0;
+  opacity: 0.75;
+  font-size: 0.9em;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.scene-sync-payload-preview {
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  padding: 8px;
+  color: rgba(255, 255, 255, 0.7);
+}


### PR DESCRIPTION
## Summary

This PR adds a new Scene Sync panel to the editor studio that enables users to compile and broadcast Loomlet behavior graphs to a Scene Sync room via REST API.

## Key Changes

- **New Scene Sync Panel UI**: Added a new tab in the bottom panel with form inputs for:
  - Endpoint URL (defaults to `https://afjk.jp/presence`)
  - Room ID
  - Scope selection (Object or Scene behavior graph)
  - Object ID (for object-scoped graphs)
  - Nickname for the broadcast sender

- **Scene Sync Compilation & Broadcasting**: Implemented core functionality to:
  - Compile the current DSL to a Scene Sync graph payload using `compileLoomToSceneSyncGraph`
  - Create set/clear payloads using `createSceneGraphSetPayload` and `createSceneGraphClearPayload`
  - Broadcast payloads to the Scene Sync room via REST POST to `/api/room/{room}/broadcast`
  - Display compiled payload preview in JSON format

- **Settings Persistence**: Scene Sync configuration (endpoint, room, scope, object ID, nickname) is automatically saved to localStorage and restored on page load

- **Event Handling**: Added three action buttons:
  - "Compile Payload" - validates settings and shows the generated payload
  - "Apply Behavior" - compiles and broadcasts a scene-graph-set payload
  - "Clear Behavior" - broadcasts a scene-graph-clear payload

- **Styling**: Added CSS for the Scene Sync panel with form grid layout, action buttons, and payload preview display

- **Documentation**: Updated README with Scene Sync usage instructions and prototype notes

## Implementation Details

- Scene Sync settings are stored under `loomlet.editorStudio.sceneSync.*` keys in localStorage
- The Object ID field is conditionally disabled when Scene scope is selected
- Broadcast URL is constructed with optional nickname as a query parameter
- All operations log results to the output panel for user feedback
- Error handling provides clear messages for missing required fields or failed broadcasts

https://claude.ai/code/session_012dQaUKGr8QrEDtiPqBLeFT