### PR TITLE
Add scene.offsetPosition function for relative object positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ CLI-safe library nodes:
 - `text.upper`, `text.lower`, `text.trim`, `text.replace`
 - `json.parse`, `json.stringify`
 - `console.log`, `console.warn`, `console.error`
-- `scene.setPosition`, `scene.setRotation`, `scene.setScale`
+- `scene.setPosition`, `scene.offsetPosition`, `scene.setRotation`, `scene.setScale`
 
 ### REPL
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -552,6 +552,34 @@ scene.setScale("sample-cube", x: 2, y: 2, z: 2)
 
 オブジェクト ID と均一なスケール (x, y, z) を指定します。
 
+### scene.offsetPosition — オブジェクトの位置をオフセット
+
+```loom
+import scene
+
+scene.offsetPosition("sample-cube", x: 1, y: 0.5, z: 0)
+```
+
+オブジェクト ID と相対位置オフセット (x, y, z) を指定します。Behavior Graph が始まったときのオブジェクト位置を基準とした相対移動を指定します。
+
+Object-scoped Behavior Graph では、オブジェクト ID を省略できます：
+
+```loom
+import time
+import math
+import scene
+
+t = time.serverClock()
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition(y: dy)
+```
+
+`scene.setPosition` との違い：
+
+- `scene.setPosition`: ワールド座標の絶対位置を設定します。
+- `scene.offsetPosition`: Behavior Graph 開始時のオブジェクト位置を基準とした相対オフセットです。
+
 ### まとめた例
 
 ```loom

--- a/examples/scene-offset-circle.loom
+++ b/examples/scene-offset-circle.loom
@@ -1,0 +1,10 @@
+import time
+import math
+import scene
+
+t = time.serverClock()
+
+dx = math.cosine(t, freq: 0.2, amplitude: 1.5)
+dz = math.sine(t, freq: 0.2, amplitude: 1.5)
+
+scene.offsetPosition(x: dx, z: dz)

--- a/examples/scene-offset-position.loom
+++ b/examples/scene-offset-position.loom
@@ -1,0 +1,9 @@
+import time
+import math
+import scene
+
+t = time.serverClock()
+
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition(y: dy)

--- a/src/loom.js
+++ b/src/loom.js
@@ -1449,6 +1449,33 @@ export const NODE_TYPES = {
     }
   },
 
+  'scene.offsetPosition': {
+    category: 'sink',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'x', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'y', type: 'number', default: 0, kind: 'behavior' },
+      { name: 'z', type: 'number', default: 0, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'x', type: 'number', default: 0 },
+      { name: 'y', type: 'number', default: 0 },
+      { name: 'z', type: 'number', default: 0 }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.offsetPosition',
+        objectId: inputs.objectId,
+        offset: [inputs.x, inputs.y, inputs.z],
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  },
+
   // DOM シンクノード
   setText: {
     category: 'sink',

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -108,7 +108,15 @@ function normalizeScope(options = {}) {
 }
 
 function pickParams(nodeType, params = {}) {
-  if (nodeType === 'scene.setPosition' || nodeType === 'scene.offsetPosition' || nodeType === 'scene.setScale') {
+  if (nodeType === 'scene.offsetPosition') {
+    return {
+      ...(params.objectId ? { target: params.objectId } : {}),
+      ...(params.x !== undefined ? { x: params.x } : {}),
+      ...(params.y !== undefined ? { y: params.y } : {}),
+      ...(params.z !== undefined ? { z: params.z } : {})
+    };
+  }
+  if (nodeType === 'scene.setPosition' || nodeType === 'scene.setScale') {
     return { ...(params.x !== undefined ? { x: params.x } : {}), ...(params.y !== undefined ? { y: params.y } : {}), ...(params.z !== undefined ? { z: params.z } : {}) };
   }
   if (nodeType === 'scene.setRotation') {

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -7,6 +7,7 @@ const SUPPORTED_NODES = new Set([
   'math.add',
   'math.multiply',
   'scene.setPosition',
+  'scene.offsetPosition',
   'scene.setRotation',
   'scene.setScale',
   'scene.setColor',
@@ -20,6 +21,7 @@ const NODE_TYPE_MAPPING = {
   'math.add': 'add',
   'math.multiply': 'multiply',
   'scene.setPosition': 'sceneSetPosition',
+  'scene.offsetPosition': 'sceneOffsetPosition',
   'scene.setRotation': 'sceneSetRotation',
   'scene.setScale': 'sceneSetScale',
   'scene.setColor': 'sceneSetColor',
@@ -39,6 +41,8 @@ const OUTPUT_PORT_MAPPING = {
   'multiply': 'out',
   'scene.setPosition': undefined,
   'sceneSetPosition': undefined,
+  'scene.offsetPosition': undefined,
+  'sceneOffsetPosition': undefined,
   'scene.setRotation': undefined,
   'sceneSetRotation': undefined,
   'scene.setScale': undefined,
@@ -57,6 +61,7 @@ function generateStableNodeBase(nodeType) {
   if (mapped === 'add') return 'add';
   if (mapped === 'multiply') return 'multiply';
   if (mapped === 'sceneSetPosition') return 'pos';
+  if (mapped === 'sceneOffsetPosition') return 'offset';
   if (mapped === 'sceneSetRotation') return 'rot';
   if (mapped === 'sceneSetScale') return 'scale';
   if (mapped === 'sceneSetColor') return 'color';
@@ -103,7 +108,7 @@ function normalizeScope(options = {}) {
 }
 
 function pickParams(nodeType, params = {}) {
-  if (nodeType === 'scene.setPosition' || nodeType === 'scene.setScale') {
+  if (nodeType === 'scene.setPosition' || nodeType === 'scene.offsetPosition' || nodeType === 'scene.setScale') {
     return { ...(params.x !== undefined ? { x: params.x } : {}), ...(params.y !== undefined ? { y: params.y } : {}), ...(params.z !== undefined ? { z: params.z } : {}) };
   }
   if (nodeType === 'scene.setRotation') {
@@ -164,7 +169,7 @@ export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
   let scope = normalizeScope(options);
   if (!scope) {
     for (const node of loomGraph.nodes) {
-      if (node.type.startsWith('scene.set') && node.params?.objectId) {
+      if ((node.type.startsWith('scene.set') || node.type === 'scene.offsetPosition') && node.params?.objectId) {
         scope = { object: node.params.objectId };
         break;
       }

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -328,6 +328,42 @@ export const LIBRARY_METADATA = {
         examples: [
           'scene.setScale("sample-cube", x: 2, y: 2, z: 2)'
         ]
+      },
+      offsetPosition: {
+        name: 'offsetPosition',
+        signature: 'scene.offsetPosition(objectId: "...", x: 0, y: 0, z: 0)',
+        description: 'Offsets the position of a scene object relative to its starting position.',
+        args: [
+          {
+            name: 'objectId',
+            type: 'string',
+            positional: true,
+            description: 'ID of the object.'
+          },
+          {
+            name: 'x',
+            type: 'number',
+            positional: false,
+            description: 'X offset.'
+          },
+          {
+            name: 'y',
+            type: 'number',
+            positional: false,
+            description: 'Y offset.'
+          },
+          {
+            name: 'z',
+            type: 'number',
+            positional: false,
+            description: 'Z offset.'
+          }
+        ],
+        returns: 'void',
+        targets: LIBRARY_COMPATIBILITY.scene.targets,
+        examples: [
+          'scene.offsetPosition("sample-cube", x: 1, y: 0.5, z: 0)'
+        ]
       }
     }
   },

--- a/test/loom-cli.test.mjs
+++ b/test/loom-cli.test.mjs
@@ -632,6 +632,31 @@ test('scenesync behavior compile with --scene --json outputs payload JSON', () =
   assert(!Object.hasOwn(payload, 'payload'));
 });
 
+test('scenesync behavior compile with offsetPosition example outputs scene-graph-set payload', () => {
+  const result = runCli(['scenesync', 'behavior', 'compile', 'examples/scene-offset-position.loom', '--object', 'sample-cube', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.type, 'scene-graph-set');
+  assert.deepEqual(payload.scope, { object: 'sample-cube' });
+  assert.ok(Array.isArray(payload.graph.nodes));
+  assert.ok(payload.graph.nodes.some((n) => n.type === 'sceneOffsetPosition'));
+  assert.ok(payload.graph.nodes.some((n) => n.type === 'sine'));
+  assert.ok(payload.graph.nodes.some((n) => n.type === 'serverClock'));
+});
+
+test('scenesync behavior compile with circle offsetPosition example outputs multiple nodes', () => {
+  const result = runCli(['scenesync', 'behavior', 'compile', 'examples/scene-offset-circle.loom', '--object', 'sample-cube', '--json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.type, 'scene-graph-set');
+  assert.deepEqual(payload.scope, { object: 'sample-cube' });
+  assert.ok(payload.graph.nodes.some((n) => n.type === 'sceneOffsetPosition'));
+  assert.ok(payload.graph.nodes.some((n) => n.type === 'cosine'));
+  assert.ok(payload.graph.nodes.some((n) => n.type === 'sine'));
+});
+
 test('scenesync behavior set outputs payload JSON by default', () => {
   const result = runCli(['scenesync', 'behavior', 'set', 'examples/lissajous.loom', '--object', 'sample-cube']);
 

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -265,3 +265,68 @@ scene.setPosition("sample-cube", x: 0, y: y, z: 0)
   assert.ok(result.graph.nodes.some((n) => n.type === 'cosine'));
   assert.ok(result.graph.nodes.some((n) => n.type === 'sceneSetPosition'));
 });
+
+test('scene.offsetPosition compiles without target to sceneOffsetPosition', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition(y: dy)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneOffsetPosition'));
+  const offsetNode = result.graph.nodes.find((n) => n.type === 'sceneOffsetPosition');
+  assert.ok(offsetNode);
+  assert.ok(!offsetNode.params?.target);
+  assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'y'));
+});
+
+test('scene.offsetPosition with explicit target includes target in params', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition("sample-cube", y: dy)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneOffsetPosition'));
+  const offsetNode = result.graph.nodes.find((n) => n.type === 'sceneOffsetPosition');
+  assert.ok(offsetNode);
+  assert.deepEqual(result.scope, { object: 'sample-cube' });
+  assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'y'));
+});
+
+test('scene.offsetPosition with x and z offsets creates edges to both', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+dx = math.cosine(t, freq: 0.2, amplitude: 1.5)
+dz = math.sine(t, freq: 0.2, amplitude: 1.5)
+
+scene.offsetPosition(x: dx, z: dz)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+
+  assert.ok(result.graph.nodes.some((n) => n.type === 'cosine'));
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sine'));
+  assert.ok(result.graph.nodes.some((n) => n.type === 'sceneOffsetPosition'));
+  const offsetNode = result.graph.nodes.find((n) => n.type === 'sceneOffsetPosition');
+  assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'x'));
+  assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'z'));
+});

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -287,7 +287,7 @@ scene.offsetPosition(y: dy)
   assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'y'));
 });
 
-test('scene.offsetPosition with explicit target includes target in params', () => {
+test('scene.offsetPosition explicit target maps to sceneOffsetPosition target param', () => {
   const source = `
 import time
 import math
@@ -304,6 +304,7 @@ scene.offsetPosition("sample-cube", y: dy)
   assert.ok(result.graph.nodes.some((n) => n.type === 'sceneOffsetPosition'));
   const offsetNode = result.graph.nodes.find((n) => n.type === 'sceneOffsetPosition');
   assert.ok(offsetNode);
+  assert.equal(offsetNode.params?.target, 'sample-cube');
   assert.deepEqual(result.scope, { object: 'sample-cube' });
   assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'y'));
 });
@@ -329,4 +330,25 @@ scene.offsetPosition(x: dx, z: dz)
   const offsetNode = result.graph.nodes.find((n) => n.type === 'sceneOffsetPosition');
   assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'x'));
   assert.ok(result.graph.edges.some((e) => e.to.split('.')[0] === offsetNode.id && e.to.split('.')[1] === 'z'));
+});
+
+test('scene.offsetPosition explicit target works with scene scope', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition("sample-cube", y: dy)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source, { scope: 'scene' });
+
+  assert.equal(result.scope, 'scene');
+
+  const offsetNode = result.graph.nodes.find((n) => n.type === 'sceneOffsetPosition');
+  assert.ok(offsetNode);
+  assert.equal(offsetNode.params?.target, 'sample-cube');
 });


### PR DESCRIPTION
## Summary
This PR adds support for the `scene.offsetPosition` function, which allows offsetting an object's position relative to its starting position (when the Behavior Graph began). This complements the existing `scene.setPosition` function which sets absolute world coordinates.

## Key Changes

- **Core Implementation**: Added `scene.offsetPosition` node type to the Loom DSL with support for x, y, z offset parameters and optional objectId
- **SceneSync Graph Adapter**: Extended the graph adapter to recognize and map `scene.offsetPosition` to `sceneOffsetPosition` graph nodes, with proper parameter handling
- **Library Metadata**: Documented the new function with signature, description, parameters, and examples in the library metadata
- **Documentation**: Added comprehensive documentation in DSL.md explaining the function, its usage in both global and object-scoped contexts, and the distinction from `scene.setPosition`
- **Examples**: Added two example files demonstrating practical use cases:
  - `scene-offset-position.loom`: Simple vertical oscillation
  - `scene-offset-circle.loom`: Circular motion using cosine and sine offsets
- **Tests**: Added comprehensive test coverage including:
  - Compilation without explicit target
  - Compilation with explicit target
  - Multiple offset parameters (x and z)
  - CLI integration tests for both example files

## Implementation Details

- The function signature mirrors `scene.setPosition` but semantically represents relative offsets from the initial position
- When used in object-scoped Behavior Graphs, the objectId parameter can be omitted
- The graph adapter generates stable node IDs using the 'offset' base for `sceneOffsetPosition` nodes
- Parameter picking logic was extended to handle the new node type alongside existing position/scale operations

https://claude.ai/code/session_017sEYRd9M8EHbXYPmj58YT1