### PR TITLE
Add Scene Sync graph filtering and preset examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ loomlet scenesync graph-compile examples/lissajous.loom
 
 This outputs a Scene Sync graph JSON containing `serverClock`, `sine`, and `sceneSetPosition` nodes.
 
+**Scene Sync preview presets**: Editor Studio includes sample presets that combine `render point(...)` for 2D preview with `scene.offsetPosition(...)` for Scene Sync behavior. When compiling to Scene Sync, the compiler ignores preview-only `render` nodes and sends only the Scene Sync behavior dependencies. This enables the workflow: (1) write motion DSL with both preview and behavior, (2) confirm motion in 2D preview, (3) apply the same graph to Scene Sync objects.
+
 ### Run a Loomlet behavior graph on a Scene Sync object
 
 Loomlet DSL graphs can be compiled and sent to Scene Sync objects using `graph-run`:

--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -171,6 +171,11 @@
                 <button id="clearSceneSyncBehaviorBtn" type="button" class="btn btn-danger">Clear Behavior</button>
               </div>
 
+              <div class="scene-sync-preset-actions">
+                <button id="loadSceneSyncJumpPresetBtn" type="button" class="btn">Load Jump Preview</button>
+                <button id="loadSceneSyncCirclePresetBtn" type="button" class="btn">Load Circle Preview</button>
+              </div>
+
               <p class="scene-sync-note">
                 Prototype: this panel sends Scene Sync Behavior Graph payloads by REST broadcast.
                 It does not integrate with Scene Sync undo/redo or object selection yet.

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -46,6 +46,37 @@ logged = log(smooth, label: "wave")
 render bar(width: width, color: "#80ed99", height: 48)
 `;
 
+// Scene Sync Presets
+const SCENE_SYNC_JUMP_PRESET = `import time
+import math
+import scene
+
+t = time.serverClock()
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition(y: dy)
+
+previewY = math.add(200, math.multiply(dy, -120))
+render point(x: 300, y: previewY, radius: 8, color: "#ff70a6", trail: 0.08)
+`;
+
+const SCENE_SYNC_CIRCLE_PRESET = `import time
+import math
+import scene
+
+t = time.serverClock()
+
+dx = math.cosine(t, freq: 0.2, amplitude: 1.5)
+dz = math.sine(t, freq: 0.2, amplitude: 1.5)
+
+scene.offsetPosition(x: dx, z: dz)
+
+previewX = math.add(300, math.multiply(dx, 80))
+previewY = math.add(200, math.multiply(dz, 80))
+
+render point(x: previewX, y: previewY, radius: 8, color: "#80ed99", trail: 0.08)
+`;
+
 const BOTTOM_PANEL_HEIGHT_KEY = 'loomlet.editorStudio.bottomPanelHeight';
 const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
 const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -190,7 +190,9 @@ const elements = {
   compileSceneSyncPayloadBtn: document.getElementById('compileSceneSyncPayloadBtn'),
   applySceneSyncBehaviorBtn: document.getElementById('applySceneSyncBehaviorBtn'),
   clearSceneSyncBehaviorBtn: document.getElementById('clearSceneSyncBehaviorBtn'),
-  sceneSyncPayloadPreview: document.getElementById('sceneSyncPayloadPreview')
+  sceneSyncPayloadPreview: document.getElementById('sceneSyncPayloadPreview'),
+  loadSceneSyncJumpPresetBtn: document.getElementById('loadSceneSyncJumpPresetBtn'),
+  loadSceneSyncCirclePresetBtn: document.getElementById('loadSceneSyncCirclePresetBtn')
 };
 
 function setPanelsVisible(visible) {
@@ -1861,6 +1863,32 @@ async function resetSample() {
   clearEditorHistory();
 }
 
+function loadSceneSyncPreset(name, source) {
+  const currentText = getDslText();
+
+  if (currentText.trim()) {
+    const ok = window.confirm(
+      `Loading "${name}" will replace the DSL editor content. Continue?`
+    );
+
+    if (!ok) {
+      appendOutput({
+        level: 'info',
+        message: `Canceled loading Scene Sync preset: ${name}.`
+      });
+      return;
+    }
+  }
+
+  setDslText(source);
+  hasUnsyncedDslText = true;
+
+  appendOutput({
+    level: 'info',
+    message: `Loaded Scene Sync preset: ${name}. Apply DSL to preview it, then use Scene Sync Apply Behavior.`
+  });
+}
+
 function renderNodeListItem(node) {
   const isSelected = selectedNodeId === node.id;
   const selectedClass = isSelected ? ' selected' : '';
@@ -2491,6 +2519,14 @@ function setupEventListeners() {
   elements.compileSceneSyncPayloadBtn?.addEventListener('click', handleCompileSceneSyncPayload);
   elements.applySceneSyncBehaviorBtn?.addEventListener('click', handleApplySceneSyncBehavior);
   elements.clearSceneSyncBehaviorBtn?.addEventListener('click', handleClearSceneSyncBehavior);
+
+  elements.loadSceneSyncJumpPresetBtn?.addEventListener('click', () => {
+    loadSceneSyncPreset('Jump Preview', SCENE_SYNC_JUMP_PRESET);
+  });
+
+  elements.loadSceneSyncCirclePresetBtn?.addEventListener('click', () => {
+    loadSceneSyncPreset('Circle Preview', SCENE_SYNC_CIRCLE_PRESET);
+  });
 
   elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1102,6 +1102,13 @@ button:disabled:hover,
   gap: 8px;
 }
 
+.scene-sync-preset-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
 .scene-sync-note {
   margin: 0;
   opacity: 0.75;

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -176,7 +176,7 @@ export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
         if (toNodeId === nodeId) {
           const [fromNodeId] = edge.from.split('.');
           const fromNode = loomGraph.nodes.find(n => n.id === fromNodeId);
-          if (fromNode && SUPPORTED_NODES.has(fromNode.type)) {
+          if (fromNode) {
             findDependencies(fromNodeId, visited);
           }
         }

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -151,13 +151,63 @@ export function compileLoomToSceneSyncGraph(source, options = {}) {
 
 export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
   if (!loomGraph || !loomGraph.nodes || !loomGraph.edges) throw new Error('loomGraph must have nodes and edges arrays');
+
+  // Phase 1: Find all Scene Sync sink nodes (scene.* nodes)
+  const sinkNodeIds = new Set();
+  let sceneSyncNodeIds = new Set();
+
+  // Find all scene.* sink nodes
+  for (const node of loomGraph.nodes) {
+    if (node.type.startsWith('scene.')) {
+      sinkNodeIds.add(node.id);
+      sceneSyncNodeIds.add(node.id);
+    }
+  }
+
+  // Phase 2: If scene.* nodes found, recursively find their dependencies
+  if (sinkNodeIds.size > 0) {
+    function findDependencies(nodeId, visited = new Set()) {
+      if (visited.has(nodeId)) return;
+      visited.add(nodeId);
+      sceneSyncNodeIds.add(nodeId);
+
+      for (const edge of loomGraph.edges) {
+        const [toNodeId] = edge.to.split('.');
+        if (toNodeId === nodeId) {
+          const [fromNodeId] = edge.from.split('.');
+          const fromNode = loomGraph.nodes.find(n => n.id === fromNodeId);
+          if (fromNode && SUPPORTED_NODES.has(fromNode.type)) {
+            findDependencies(fromNodeId, visited);
+          }
+        }
+      }
+    }
+
+    for (const sinkId of sinkNodeIds) {
+      findDependencies(sinkId);
+    }
+  } else {
+    // No scene.* nodes found: include all supported nodes (backwards compatibility)
+    for (const node of loomGraph.nodes) {
+      sceneSyncNodeIds.add(node.id);
+    }
+  }
+
+  // Phase 3: Validate that all included nodes are supported
+  for (const node of loomGraph.nodes) {
+    if (sceneSyncNodeIds.has(node.id) && !SUPPORTED_NODES.has(node.type)) {
+      throw new Error(`Unsupported Scene Sync graph node: ${node.type}`);
+    }
+  }
+
+  // Phase 4: Build Scene Sync graph with only the identified nodes
   const nodes = [];
   const edges = [];
   const nodeIdMap = new Map();
   const usedIds = new Set();
 
   for (const node of loomGraph.nodes) {
-    if (!SUPPORTED_NODES.has(node.type)) throw new Error(`Unsupported Scene Sync graph node: ${node.type}`);
+    if (!sceneSyncNodeIds.has(node.id)) continue;
     const sceneSyncType = NODE_TYPE_MAPPING[node.type];
     const baseId = (node.id && !node.id.startsWith('_')) ? node.id : generateStableNodeBase(node.type);
     const newId = makeUniqueId(baseId, usedIds);
@@ -169,6 +219,7 @@ export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
   for (const edge of loomGraph.edges) {
     const [fromNodeId, fromPort] = edge.from.split('.');
     const [toNodeId, toPort] = edge.to.split('.');
+    if (!sceneSyncNodeIds.has(fromNodeId) || !sceneSyncNodeIds.has(toNodeId)) continue;
     const newFromId = nodeIdMap.get(fromNodeId);
     const newToId = nodeIdMap.get(toNodeId);
     if (newFromId && newToId) edges.push({ from: `${newFromId}.${fromPort}`, to: `${newToId}.${toPort}` });

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -352,3 +352,105 @@ scene.offsetPosition("sample-cube", y: dy)
   assert.ok(offsetNode);
   assert.equal(offsetNode.params?.target, 'sample-cube');
 });
+
+test('render point with scene.offsetPosition compiles without preview nodes', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+dy = math.sine(t, freq: 0.8, amplitude: 0.5)
+
+scene.offsetPosition(y: dy)
+
+previewY = math.add(200, math.multiply(dy, -120))
+render point(x: 300, y: previewY, radius: 8, color: "#ff70a6", trail: 0.08)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+
+  const nodeTypes = result.graph.nodes.map((node) => node.type);
+
+  assert.ok(nodeTypes.includes('sceneOffsetPosition'));
+  assert.ok(nodeTypes.includes('serverClock'));
+  assert.ok(nodeTypes.includes('sine'));
+
+  // Verify preview-only nodes are NOT included
+  assert.equal(nodeTypes.includes('render'), false);
+  assert.equal(nodeTypes.includes('point'), false);
+  // Preview calculation nodes should not be included
+  assert.equal(result.graph.nodes.some((n) => n.id === 'previewY'), false);
+});
+
+test('circle preview DSL includes only Scene Sync dependencies', () => {
+  const source = `
+import time
+import math
+import scene
+
+t = time.serverClock()
+
+dx = math.cosine(t, freq: 0.2, amplitude: 1.5)
+dz = math.sine(t, freq: 0.2, amplitude: 1.5)
+
+scene.offsetPosition(x: dx, z: dz)
+
+previewX = math.add(300, math.multiply(dx, 80))
+previewY = math.add(200, math.multiply(dz, 80))
+
+render point(x: previewX, y: previewY, radius: 8, color: "#80ed99", trail: 0.08)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+
+  const offsetNode = result.graph.nodes.find((node) => node.type === 'sceneOffsetPosition');
+  assert.ok(offsetNode);
+
+  const edgeTargets = result.graph.edges.map((edge) => edge.to);
+  assert.ok(edgeTargets.some((to) => to.endsWith('.x')));
+  assert.ok(edgeTargets.some((to) => to.endsWith('.z')));
+
+  // Verify preview nodes are NOT included
+  assert.equal(result.graph.nodes.some((n) => n.id === 'previewX'), false);
+  assert.equal(result.graph.nodes.some((n) => n.id === 'previewY'), false);
+
+  // Verify only necessary computation nodes are included
+  const nodeTypes = result.graph.nodes.map((n) => n.type);
+  assert.ok(nodeTypes.includes('cosine'));
+  assert.ok(nodeTypes.includes('sine'));
+  assert.ok(nodeTypes.includes('serverClock'));
+  assert.ok(nodeTypes.includes('sceneOffsetPosition'));
+
+  // Preview-only add and multiply nodes should not be included
+  const nodeCount = result.graph.nodes.length;
+  assert.equal(nodeCount, 4); // t, dx, dz, offset
+});
+
+test('scene sink depending on unsupported node throws error', () => {
+  const loomGraph = {
+    nodes: [
+      {
+        id: 'source',
+        type: 'unsupportedNode',
+        params: {}
+      },
+      {
+        id: 'offset',
+        type: 'scene.offsetPosition',
+        params: {}
+      }
+    ],
+    edges: [
+      {
+        from: 'source.out',
+        to: 'offset.y'
+      }
+    ]
+  };
+
+  assert.throws(
+    () => loomGraphToSceneSyncGraph(loomGraph, { scope: { object: 'sample-cube' } }),
+    /Unsupported Scene Sync graph node: unsupportedNode/
+  );
+});


### PR DESCRIPTION
## Summary
This PR enhances the Scene Sync graph compilation by implementing intelligent graph filtering based on scene sink nodes, and adds example presets demonstrating Scene Sync capabilities.

## Key Changes

### Graph Adapter (`src/scenesync/graph-adapter.js`)
- **Implemented 4-phase graph processing** in `loomGraphToSceneSyncGraph()`:
  1. **Phase 1**: Identify all `scene.*` sink nodes that define the graph's outputs
  2. **Phase 2**: Recursively trace dependencies backward to find all nodes required by scene sinks
  3. **Phase 3**: Validate that all included nodes are supported types
  4. **Phase 4**: Build the Scene Sync graph with only the identified nodes and their connections

- **Backwards compatibility**: When no `scene.*` nodes are present, all supported nodes are included (preserving existing behavior)
- **Dependency filtering**: Only nodes that are dependencies of scene sinks (or all nodes if no sinks exist) are included in the output graph
- **Edge filtering**: Edges are now filtered to only include connections between nodes that are part of the Scene Sync graph

### Editor Studio (`editor-studio/src/main.js`)
- Added two Scene Sync preset examples:
  - **SCENE_SYNC_JUMP_PRESET**: Demonstrates vertical position offset using sine wave animation
  - **SCENE_SYNC_CIRCLE_PRESET**: Demonstrates circular motion using cosine/sine waves for x and z offsets
- Both presets include visual preview points to show the calculated transformations

## Implementation Details
- The dependency resolution uses a recursive `findDependencies()` function that traverses edges backward from sink nodes
- A `visited` set prevents infinite loops during recursive traversal
- Node type validation occurs after dependency resolution to provide clear error messages for unsupported nodes in the dependency chain

https://claude.ai/code/session_01SfKnNQzkkUiVEspG9dMeGS