### PR TITLE
Disable auto-sync and improve canonical DSL generation UX

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -25,14 +25,15 @@
         Redo
       </button>
       <button id="applyDslBtn" class="btn btn-primary">Apply DSL → Node</button>
-      <button id="generateDslBtn" class="btn btn-primary">Generate DSL ← Node</button>
+      <button id="generateDslBtn" class="btn btn-primary">Generate Canonical DSL</button>
       <label class="toolbar-toggle">
         <input id="autoApplyDslToggle" type="checkbox" />
         <span>Auto Apply DSL</span>
       </label>
       <label class="toolbar-toggle">
-        <input id="autoSyncGraphToDslToggle" type="checkbox" checked />
+        <input id="autoSyncGraphToDslToggle" type="checkbox" />
         <span>Auto Sync DSL</span>
+        <span class="toolbar-help" title="Rewrites DSL as canonical text and may remove comments and formatting.">ⓘ</span>
       </label>
       <div class="toolbar-status" aria-label="Editor status">
         <span id="dirty-status" class="status-pill">Saved</span>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -92,7 +92,7 @@ let isDirty = false;
 let isApplyingProgrammaticDslChange = false;
 let hasUnsyncedDslText = false;
 let autoApplyDslEnabled = false;
-let autoSyncGraphToDslEnabled = true;
+let autoSyncGraphToDslEnabled = false;
 let autoApplyTimer = null;
 let autoApplyDelayMs = 500;
 let autoApplyRequestId = 0;
@@ -641,27 +641,12 @@ function createDslTextForSave(baseDslText) {
 }
 
 function getCurrentSavePayload() {
-  const state = store.getState();
-  let text = '';
-  let source = '';
-
-  if (hasUnsyncedDslText) {
-    text = getDslText();
-    source = 'dsl';
-  } else if (state.editorModel) {
-    const graph = editorModelToGraph(state.editorModel, state.graph);
-    text = graphToCanonicalDSL(graph);
-    source = 'graph';
-  } else {
-    text = getDslText();
-    source = 'dsl';
-  }
-
+  const text = getDslText();
   const textWithMetadata = createDslTextForSave(text);
 
   return {
     text: textWithMetadata,
-    source
+    source: 'dsl'
   };
 }
 
@@ -931,6 +916,15 @@ async function applyDsl({ markDirty = true, logOutput = true } = {}) {
   return result;
 }
 
+function hasUserDslComments(text) {
+  return String(text || '')
+    .split('\n')
+    .some((line) => {
+      const trimmed = line.trim();
+      return trimmed.startsWith('#') && !trimmed.startsWith('# @loomlet.editor');
+    });
+}
+
 function generateCanonicalDslFromState() {
   const state = store.getState();
 
@@ -970,6 +964,21 @@ function generateDsl() {
   finishMoveHistoryGroup();
   finishParamHistoryGroup();
   cancelPendingAutoApplyDsl();
+
+  const currentText = getDslText();
+  if (hasUserDslComments(currentText)) {
+    const confirmed = window.confirm(
+      'Generating canonical DSL will overwrite the DSL editor and may remove comments and formatting. Continue?'
+    );
+    if (!confirmed) {
+      appendOutput({
+        level: 'info',
+        message: 'Canceled canonical DSL generation.'
+      });
+      return;
+    }
+  }
+
   const dsl = syncGraphToDslEditor({ markDirty: true, force: true });
   if (!dsl) return;
   renderAutoApplyStatus(autoApplyDslEnabled ? 'ok' : null);

--- a/test/editor-metadata.test.html
+++ b/test/editor-metadata.test.html
@@ -441,6 +441,27 @@ render bar(width: wave)`;
       assert(!('unknown' in result.nodesById), 'unknown node should not be created');
     });
 
+    // Test for user comment preservation during save
+    test('stripEditorMetadataFromDsl + appendEditorMetadataToDsl: preserves user comments', () => {
+      const originalDsl = `# Scene Sync behavior
+scene.offsetPosition(y: dy)
+
+# 2D preview
+render point(x: 300, y: previewY)`;
+      const metadata = { version: 1, layout: { nodes: { scene: { x: 100, y: 50 } } } };
+
+      const stripped = stripEditorMetadataFromDsl(originalDsl);
+      const result = appendEditorMetadataToDsl(stripped, metadata);
+
+      assert(result.includes('# Scene Sync behavior'), 'should preserve Scene Sync comment');
+      assert(result.includes('# 2D preview'), 'should preserve 2D preview comment');
+      assert(result.includes('scene.offsetPosition'), 'should preserve scene code');
+      assert(result.includes('render point'), 'should preserve render code');
+      assert(result.includes('# @loomlet.editor'), 'should include metadata marker');
+      const metadataCount = (result.match(/# @loomlet.editor/g) || []).length;
+      assert(metadataCount === 1, 'metadata should appear exactly once');
+    });
+
     async function run() {
       let pass = 0; let fail = 0; const failures = [];
       for (const t of results) {


### PR DESCRIPTION
## Summary
This PR disables automatic DSL synchronization by default and improves the user experience when generating canonical DSL by warning users about potential loss of comments and formatting.

## Key Changes
- **Disabled auto-sync by default**: Changed `autoSyncGraphToDslEnabled` from `true` to `false` to prevent automatic rewrites of DSL text
- **Simplified save payload logic**: Removed complex conditional logic in `getCurrentSavePayload()` to always use DSL text as the source, eliminating the graph-to-DSL conversion during saves
- **Added user comment detection**: Implemented `hasUserDslComments()` function to identify user-written comments (excluding editor metadata comments)
- **Added confirmation dialog**: When generating canonical DSL, users are now prompted to confirm if their DSL contains comments, warning them that formatting and comments may be removed
- **Updated UI labels and help text**: 
  - Changed button label from "Generate DSL ← Node" to "Generate Canonical DSL" for clarity
  - Unchecked the "Auto Sync DSL" toggle by default
  - Added help icon with tooltip explaining that auto-sync rewrites DSL and may remove comments
- **Added test coverage**: New test verifies that user comments are preserved through the metadata strip/append cycle

## Implementation Details
- The `hasUserDslComments()` function distinguishes user comments from editor metadata by checking if lines starting with `#` don't begin with `# @loomlet.editor`
- The confirmation dialog in `generateDsl()` only appears if user comments are detected, reducing friction for DSL without comments
- The save payload now consistently uses DSL text as the source, simplifying the data flow and preventing unintended graph-to-DSL conversions

https://claude.ai/code/session_015J2kbPp1myskX8xFuiBBYD