### PR TITLE
chore: Clean up VS Code extension packaging warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ npm install -g @afjk/loomlet
 loomlet --help
 
 # Or via npx
-npx @afjk/loomlet compile examples/cli-basic.loom
-npx @afjk/loomlet run examples/cli-basic.loom
+npx -p @afjk/loomlet loomlet --help
+echo 'x = 1' > hello.loom
+npx -p @afjk/loomlet loomlet compile hello.loom
 ```
 
 ### VS Code Extension

--- a/extensions/vscode-loomlet/.vscodeignore
+++ b/extensions/vscode-loomlet/.vscodeignore
@@ -1,0 +1,8 @@
+test/**
+scripts/**
+webview-src/**
+*.vsix
+node_modules/.cache/**
+.vscode/**
+.DS_Store
+*.log

--- a/extensions/vscode-loomlet/LICENSE
+++ b/extensions/vscode-loomlet/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 afjk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -4,6 +4,12 @@
   "description": "VS Code support for Loomlet language files and Scene Sync workflows",
   "version": "0.0.1",
   "publisher": "afjk",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/afjk/loomlet.git",
+    "directory": "extensions/vscode-loomlet"
+  },
   "engines": {
     "vscode": "^1.90.0"
   },


### PR DESCRIPTION
## Summary

Clean up vsce packaging warnings by adding repository metadata, LICENSE file, and .vscodeignore.

## Changes

- **package.json**: Add repository and license fields
- **LICENSE**: Copy from root for VSIX inclusion  
- **.vscodeignore**: Exclude dev/test/build files (test/, scripts/, webview-src/)
- **README.md**: Fix npx examples to use -p flag and avoid examples/ references

## Verification

✅ No vsce warnings:
- Repository metadata recognized
- LICENSE included in VSIX
- .vscodeignore properly configured

✅ VSIX validated (232.97 KB, 51 files):
- Includes @afjk/loomlet in node_modules
- Excludes test/ and webview-src/
- All necessary runtime files present

✅ Tests passing:
- All extension tests pass
- VSIX builds cleanly