### PR TITLE
Add manual workflow to publish VS Code extension

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,0 +1,40 @@
+name: Publish VS Code Extension
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: extensions/vscode-loomlet
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: extensions/vscode-loomlet/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run extension tests
+        run: npm test
+
+      - name: Package extension
+        run: npx @vscode/vsce package
+
+      - name: Publish extension
+        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/extensions/vscode-loomlet/README.md
+++ b/extensions/vscode-loomlet/README.md
@@ -24,6 +24,20 @@ The extension depends on the [`@afjk/loomlet`](https://www.npmjs.com/package/@af
 
 Open this folder in VS Code and press F5 to launch an Extension Development Host.
 
+## Publishing the VS Code extension
+
+The VS Code extension can be published through GitHub Actions.
+
+1. Ensure `extensions/vscode-loomlet/package.json` has a new version.
+2. Ensure the repository secret `VSCE_PAT` is configured.
+3. Run the `Publish VS Code Extension` workflow manually from GitHub Actions.
+
+The workflow:
+- installs extension dependencies
+- runs extension tests
+- packages the VSIX
+- publishes to Visual Studio Marketplace using `VSCE_PAT`
+
 ## Commands
 
 ### Loomlet: Run Current File


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow to publish extensions/vscode-loomlet
- run install, tests, VSIX packaging, and vsce publish with VSCE_PAT
- add concise maintainer docs for the publish flow in the extension README

## Notes
- this workflow does not publish the @afjk/loomlet npm package
- trigger is workflow_dispatch only for safety