### PR TITLE
Include examples directory in GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,10 +36,12 @@ jobs:
         run: |
           mkdir -p dist-pages/node-editor
           mkdir -p dist-pages/editor
+          mkdir -p dist-pages/examples
           # The simple editor imports ../src/*.js directly, so src/ must be included in the Pages artifact.
           mkdir -p dist-pages/src
           cp -R editor-studio/dist/* dist-pages/node-editor/
           cp -R editor/* dist-pages/editor/
+          cp -R examples/* dist-pages/examples/
           cp -R src/* dist-pages/src/
 
       - name: Add index page
@@ -57,6 +59,7 @@ jobs:
               <ul>
                 <li><a href="./editor/">Simple Editor</a></li>
                 <li><a href="./node-editor/">Node Editor</a></li>
+                <li><a href="./examples/01-basic.html">Example: Basic Browser Demo</a></li>
               </ul>
             </body>
           </html>


### PR DESCRIPTION
## Summary
- add examples/ directory to GitHub Pages artifact so browser HTML demos are accessible
- examples will be deployed to https://afjk.github.io/loomlet/examples/
- add example link to generated index.html

## Changes
- Prepare Pages artifact step now includes examples/ copy
- index.html includes link to examples/01-basic.html

## Validation
- npm test passes
- No changes to runtime code or package publishing