### PR TITLE
docs: clarify node definition schema

### DIFF
--- a/docs/NODE_DEFINITION_SCHEMA.md
+++ b/docs/NODE_DEFINITION_SCHEMA.md
@@ -1,0 +1,325 @@
+# Node Definition Schema
+
+Node definition metadata describes the available function nodes in Loomlet. This document explains the current intended model, terminology, and constraints.
+
+## Purpose
+
+Node definition metadata is intended to become the shared source for:
+
+- Compiler validation (argument names, types, arity)
+- Runtime documentation (signatures, descriptions, examples)
+- Editor UI (node palettes, port labels, tooltips)
+- VS Code completion and hover information
+- Node Editor port generation
+- Future external package metadata
+
+However, today the metadata is still **partially descriptive rather than prescriptive**. It documents current behavior but is not yet the single source of truth for the parser, compiler, or runtime. The metadata and runtime implementation can still drift.
+
+A future phase will promote metadata to be the primary source, with tests to ensure that implementation behavior matches the declared metadata at all boundaries.
+
+## Terminology
+
+### Library
+
+A namespace that groups related functions.
+
+Examples: `math`, `logic`, `scene`, `text`, `list`, `json`, `console`.
+
+Each library has:
+- A name
+- A description
+- A list of target runtimes (`cli`, `web`, `scenesync`, `unity`)
+- A collection of functions
+
+### Function
+
+A callable item inside a library.
+
+Example in DSL:
+
+```loom
+value = math.add(a: 1, b: 2)
+```
+
+This declares a call to the function `add` in the library `math`.
+
+### Node type
+
+The fully qualified call identity: `${library}.${function}`.
+
+Examples:
+- `math.add`
+- `logic.select`
+- `scene.setPosition`
+- `text.upper`
+
+### Argument slot
+
+A declared source-level argument accepted by a function. Argument slots define the shape of the function's call surface.
+
+Example:
+
+```js
+{
+  name: 'x',
+  type: 'number',
+  positional: false,
+  description: 'X coordinate.'
+}
+```
+
+Each argument slot has:
+- `name`: identifier within the function
+- `type`: type hint (e.g., `number`, `string`, `array`, `any`)
+- `positional`: whether the source syntax may fill this slot without naming it
+- `description`: human-readable explanation
+
+### Positional argument
+
+An argument slot where `positional: true`, meaning the source syntax may fill this slot without explicitly naming it.
+
+**Important clarification:** `positional: true` does not mean "this is a runtime input." It means "the source syntax may fill this slot by position."
+
+Examples that may conceptually target the same positional slot:
+
+```loom
+text.upper("hello")
+```
+
+and
+
+```loom
+text.upper(value: "hello")
+```
+
+Both call the same function. The first uses positional syntax, the second uses named syntax.
+
+### Param
+
+A compiled graph value that is literal/static at compile time. Params are constant expressions determined during compilation.
+
+Example:
+
+```loom
+value = math.add(a: 1, b: 2)
+```
+
+When compiled, the values `1` and `2` become params because they are literal constants.
+
+In the compiled graph, a node instance might have:
+- `a.param = 1`
+- `b.param = 2`
+
+### Input (edge)
+
+A compiled graph connection from another node's output. Inputs represent runtime data flow between nodes.
+
+Example:
+
+```loom
+x = math.add(a: 1, b: 2)
+y = math.multiply(a: x, b: 10)
+```
+
+When compiled:
+- The argument slot `y.a` is filled by an input edge from the output `x.out`.
+- The argument slot `y.b` is filled by a param with value `10`.
+
+### Output
+
+A value produced by a node. Most value nodes currently expose a default output named `out`.
+
+Example:
+
+```loom
+value = math.add(a: 1, b: 2)
+```
+
+The result `value` refers to the node's `out` output.
+
+### Effect
+
+A side effect emitted by a node instead of, or in addition to, a value.
+
+Effects do not produce values that other nodes can consume. Instead, they trigger runtime side effects.
+
+Examples:
+- `scene.setPosition(objectId, x, y, z)` sets an object's position.
+- `console.log(value)` outputs to the console.
+- `debug.trace(value)` outputs debug information.
+
+## Source arguments vs compiled graph
+
+This distinction is fundamental to understanding the schema.
+
+**Argument slots** describe the call surface — the shape of the source syntax.
+
+**Params and inputs** describe how a specific compiled graph instance is wired.
+
+Example:
+
+```loom
+x = math.add(a: 1, b: 2)
+y = math.add(a: x, b: 10)
+```
+
+Both calls use the same argument slots:
+
+```
+a: number
+b: number
+```
+
+But they compile differently:
+
+For node `x`:
+```
+a.param = 1
+b.param = 2
+```
+
+For node `y`:
+```
+a.input = edge from x.out
+b.param = 10
+```
+
+This is the key distinction: the metadata declares **argument slots**, but the compiled graph instance determines **how each slot is filled** (param, input, or default).
+
+## Current metadata shape
+
+This section documents the current minimum metadata shape conservatively.
+
+### Metadata structure
+
+```js
+{
+  name: 'add',
+  signature: 'math.add(a: 0, b: 0)',
+  description: 'Adds two numbers.',
+  args: [
+    {
+      name: 'a',
+      type: 'number',
+      positional: false,
+      description: 'First number.'
+    },
+    {
+      name: 'b',
+      type: 'number',
+      positional: false,
+      description: 'Second number.'
+    }
+  ],
+  returns: 'number',
+  targets: ['cli', 'web', 'scenesync', 'unity'],
+  examples: ['result = math.add(a: 5, b: 3)']
+}
+```
+
+### Metadata fields
+
+#### Library-level fields
+
+- **name**: library identifier (e.g., `math`)
+- **description**: human-readable library description
+- **targets**: list of runtime targets where this library is available
+- **functions**: object mapping function names to function metadata
+
+#### Function-level fields
+
+- **name**: function identifier (e.g., `add`)
+- **signature**: human-readable DSL signature for documentation
+- **description**: human-readable function description
+- **args**: array of argument slot definitions
+- **returns**: return type hint (e.g., `number`, `string`, `void`, `any`)
+- **targets**: list of runtime targets where this function is available
+- **examples**: array of example invocations
+- **status** (optional): implementation status (e.g., `implemented`, `experimental`)
+
+#### Argument slot fields
+
+- **name**: argument identifier (e.g., `value`, `x`, `objectId`)
+- **type**: type hint (e.g., `number`, `string`, `array`, `any`)
+- **positional**: boolean indicating whether positional syntax is allowed
+- **description**: human-readable explanation of the argument
+
+### Known limitations
+
+- Some generated metadata entries have empty `args` arrays.
+- Metadata is not yet complete or fully accurate for all functions.
+- Metadata does not yet fully drive compiler validation (some validation is hard-coded).
+- This schema does not yet capture all relevant type information (e.g., union types, generics).
+- Node Editor port generation is not fully stabilized and may diverge from this schema.
+
+## Stability rules
+
+The following rules help preserve compatibility and gradual improvement:
+
+### Metadata fields
+
+- New metadata fields should be additive where possible.
+- Do not remove or rename existing fields unless absolutely necessary and with clear migration paths.
+
+### Node types
+
+- Do not remove node types without migration documentation.
+- Do not rename node types without providing aliases or deprecation warnings.
+
+### Argument slots
+
+- Do not remove argument slots casually; renaming is also disruptive.
+- Do not change argument names without migration documentation.
+- Do not change `positional` semantics without adding tests.
+
+### Metadata as documentation
+
+- Metadata fields should not be interpreted as runtime guarantees unless explicitly documented.
+- Do not use metadata field order as runtime semantics unless explicitly documented.
+- Editor-only metadata should be clearly separated from semantic metadata in future versions.
+
+## Known gaps
+
+The following gaps prevent using metadata as the single source of truth:
+
+- Some generated metadata entries (especially from `makeFunctionMetadata`) have empty `args` arrays because argument information is not yet available.
+- Metadata for `logic`, `list`, `random`, `debug`, and `output` functions is incomplete.
+- Metadata does not yet fully drive compiler validation. Some argument validation is hard-coded in the parser and compiler.
+- Runtime implementation and metadata can still drift. There are no drift-detection tests yet.
+- Node Editor port generation is not fully stabilized and does not yet use metadata as the authoritative source.
+- Canonical DSL generation and source-preserving edits are not yet part of the schema.
+- The schema does not yet capture all relevant type information (e.g., union types, optional arguments with semantic defaults).
+
+Before treating metadata as the single source of truth:
+
+- Complete argument metadata for all implemented functions.
+- Add metadata-to-runtime drift tests to catch implementation-metadata mismatches.
+- Use metadata as the source for Node Editor port generation.
+- Use metadata for compiler argument validation and error messages.
+- Update `docs/SPEC.md` only after behavior is stable.
+
+## Future promotion path
+
+### Phase 1: Document and test (current)
+
+- Document current intended node definition schema.
+- Add conservative metadata shape tests.
+- Do not yet make metadata the single source of truth.
+- Allow metadata and implementation to coexist as two sources.
+
+### Phase 2: Complete metadata
+
+- Ensure all argument metadata is complete and accurate.
+- Add drift-detection tests between metadata and runtime.
+- Ensure metadata covers all implemented functions.
+
+### Phase 3: Use metadata for generation
+
+- Generate Node Editor ports from metadata.
+- Use metadata for compiler argument validation.
+- Use metadata for VS Code completion and hover information.
+
+### Phase 4: Promote to SPEC
+
+- After behavior is stable and fully tested, promote key aspects to `docs/SPEC.md`.
+- Treat metadata as the single source of truth for all new features.

--- a/docs/STABILIZATION_ROADMAP.md
+++ b/docs/STABILIZATION_ROADMAP.md
@@ -18,6 +18,9 @@ Recommended order:
 2. Formalize behavior/event semantics in `docs/SPEC.md`
 3. Add golden tests for examples
 4. Stabilize node definition schema
+   - Document current node definition schema in `docs/NODE_DEFINITION_SCHEMA.md`
+   - Add conservative metadata shape tests in `test/library-metadata-schema.test.mjs`
+   - Do not yet make metadata the single runtime/compiler source of truth
 5. Clarify input vs param
 6. Clarify runtime registration API
 7. Clarify metadata as shared source for editor/docs/completion
@@ -154,5 +157,8 @@ This is future work and should not be treated as stable yet.
 1. Add a small set of parse/compile fixtures.
 2. Define graph normalization rules for tests.
 3. Add semantic graph snapshot tests.
-4. Later, stabilize `graphToCanonicalDSL`.
-5. Later, add editor round-trip tests.
+4. Add metadata schema tests to verify node definition shape.
+   - Fixture tests cover behavior.
+   - Metadata schema tests cover node definition shape.
+5. Later, stabilize `graphToCanonicalDSL`.
+6. Later, add editor round-trip tests.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stabilization-fixtures.test.mjs && node test/stabilization-invalid-fixtures.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stabilization-fixtures.test.mjs && node test/stabilization-invalid-fixtures.test.mjs && node test/library-metadata-schema.test.mjs && node test/stdlib-baseline.test.mjs",
     "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",

--- a/test/library-metadata-schema.test.mjs
+++ b/test/library-metadata-schema.test.mjs
@@ -1,0 +1,194 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LIBRARY_METADATA, getAllLibraries } from '../src/toolchain/library-metadata.js';
+import { LIBRARY_COMPATIBILITY } from '../src/toolchain/runtime-targets.js';
+
+test('getAllLibraries returns an array of sorted library names', () => {
+  const libraries = getAllLibraries();
+  assert(Array.isArray(libraries), 'getAllLibraries should return an array');
+  assert(libraries.length > 0, 'should have at least one library');
+
+  const sorted = [...libraries].sort();
+  assert.deepEqual(libraries, sorted, 'libraries should be sorted');
+
+  for (const name of libraries) {
+    assert(LIBRARY_METADATA[name], `library "${name}" should exist in LIBRARY_METADATA`);
+  }
+});
+
+test('each library has minimum shape', () => {
+  const libraries = getAllLibraries();
+
+  for (const libraryName of libraries) {
+    const library = LIBRARY_METADATA[libraryName];
+
+    assert.equal(typeof library.name, 'string', `${libraryName}: name should be a string`);
+    assert.equal(library.name, libraryName, `${libraryName}: name should match key`);
+
+    assert.equal(typeof library.description, 'string', `${libraryName}: description should be a string`);
+    assert(library.description.length > 0, `${libraryName}: description should be non-empty`);
+
+    assert(Array.isArray(library.targets), `${libraryName}: targets should be an array`);
+    assert(library.targets.length > 0, `${libraryName}: targets should be non-empty`);
+
+    assert(typeof library.functions === 'object', `${libraryName}: functions should be an object`);
+    assert(library.functions !== null, `${libraryName}: functions should not be null`);
+  }
+});
+
+test('each function has minimum shape', () => {
+  const libraries = getAllLibraries();
+
+  for (const libraryName of libraries) {
+    const library = LIBRARY_METADATA[libraryName];
+    const functions = library.functions || {};
+
+    for (const functionName of Object.keys(functions)) {
+      const fn = functions[functionName];
+
+      assert.equal(typeof fn.name, 'string', `${libraryName}.${functionName}: name should be a string`);
+      assert.equal(fn.name, functionName, `${libraryName}.${functionName}: name should match key`);
+
+      assert.equal(typeof fn.signature, 'string', `${libraryName}.${functionName}: signature should be a string`);
+      assert(fn.signature.length > 0, `${libraryName}.${functionName}: signature should be non-empty`);
+
+      assert.equal(typeof fn.description, 'string', `${libraryName}.${functionName}: description should be a string`);
+      assert(fn.description.length > 0, `${libraryName}.${functionName}: description should be non-empty`);
+
+      assert(Array.isArray(fn.args), `${libraryName}.${functionName}: args should be an array`);
+
+      assert.equal(typeof fn.returns, 'string', `${libraryName}.${functionName}: returns should be a string`);
+      assert(fn.returns.length > 0, `${libraryName}.${functionName}: returns should be non-empty`);
+
+      assert(Array.isArray(fn.targets), `${libraryName}.${functionName}: targets should be an array`);
+      assert(fn.targets.length > 0, `${libraryName}.${functionName}: targets should be non-empty`);
+
+      assert(Array.isArray(fn.examples), `${libraryName}.${functionName}: examples should be an array`);
+    }
+  }
+});
+
+test('each argument entry has minimum shape and no duplicate names', () => {
+  const libraries = getAllLibraries();
+
+  for (const libraryName of libraries) {
+    const library = LIBRARY_METADATA[libraryName];
+    const functions = library.functions || {};
+
+    for (const functionName of Object.keys(functions)) {
+      const fn = functions[functionName];
+      const args = fn.args || [];
+
+      const seenNames = new Set();
+
+      for (const arg of args) {
+        assert.equal(typeof arg.name, 'string', `${libraryName}.${functionName}: arg.name should be a string`);
+        assert(arg.name.length > 0, `${libraryName}.${functionName}: arg.name should be non-empty`);
+
+        assert(!seenNames.has(arg.name), `${libraryName}.${functionName}: duplicate arg name "${arg.name}"`);
+        seenNames.add(arg.name);
+
+        assert.equal(typeof arg.type, 'string', `${libraryName}.${functionName}: arg.type should be a string`);
+        assert(arg.type.length > 0, `${libraryName}.${functionName}: arg.type should be non-empty`);
+
+        assert.equal(typeof arg.positional, 'boolean', `${libraryName}.${functionName}: arg.positional should be a boolean`);
+
+        assert.equal(typeof arg.description, 'string', `${libraryName}.${functionName}: arg.description should be a string`);
+        assert(arg.description.length > 0, `${libraryName}.${functionName}: arg.description should be non-empty`);
+      }
+    }
+  }
+});
+
+test('function targets are compatible with library targets', () => {
+  const libraries = getAllLibraries();
+
+  for (const libraryName of libraries) {
+    const library = LIBRARY_METADATA[libraryName];
+    const libraryTargets = new Set(library.targets);
+    const functions = library.functions || {};
+
+    for (const functionName of Object.keys(functions)) {
+      const fn = functions[functionName];
+
+      for (const target of fn.targets) {
+        assert(libraryTargets.has(target),
+          `${libraryName}.${functionName}: target "${target}" not in library targets ${JSON.stringify(Array.from(libraryTargets))}`);
+      }
+    }
+  }
+});
+
+test('library names exist in runtime compatibility', () => {
+  const libraries = getAllLibraries();
+
+  for (const libraryName of libraries) {
+    assert(LIBRARY_COMPATIBILITY[libraryName],
+      `library "${libraryName}" should exist in LIBRARY_COMPATIBILITY`);
+
+    const libMeta = LIBRARY_METADATA[libraryName];
+    const libCompat = LIBRARY_COMPATIBILITY[libraryName];
+
+    // Check that metadata targets are a subset of compatibility targets
+    const compatTargets = new Set(libCompat.targets);
+    for (const target of libMeta.targets) {
+      assert(compatTargets.has(target),
+        `${libraryName}: metadata target "${target}" not in compatibility targets`);
+    }
+  }
+});
+
+test('explicit schema examples: math.add', () => {
+  const add = LIBRARY_METADATA.math.functions.add;
+  assert(add, 'math.add should exist');
+  assert.equal(add.returns, 'number');
+  assert.deepEqual(add.args.map((arg) => arg.name), ['a', 'b']);
+  assert.deepEqual(add.args.map((arg) => arg.positional), [false, false]);
+});
+
+test('explicit schema examples: text.upper', () => {
+  const upper = LIBRARY_METADATA.text.functions.upper;
+  assert(upper, 'text.upper should exist');
+  assert.deepEqual(upper.args.map((arg) => arg.name), ['value']);
+  assert.equal(upper.args[0].positional, true);
+});
+
+test('explicit schema examples: scene.setPosition', () => {
+  const setPosition = LIBRARY_METADATA.scene.functions.setPosition;
+  assert(setPosition, 'scene.setPosition should exist');
+  assert.deepEqual(setPosition.args.map((arg) => arg.name), ['objectId', 'x', 'y', 'z']);
+  assert.equal(setPosition.args[0].positional, true);
+  assert.deepEqual(setPosition.args.slice(1).map((arg) => arg.positional), [false, false, false]);
+});
+
+test('incomplete generated metadata is documented', () => {
+  // This test acknowledges that some functions have empty args arrays.
+  // These are generated by makeFunctionMetadata and do not yet have full argument documentation.
+  // This is not a failure - it documents a known incomplete state.
+
+  // Find and count functions with empty args
+  const libraries = getAllLibraries();
+  let functionsWithEmptyArgs = 0;
+  const examplesWithEmptyArgs = [];
+
+  for (const libraryName of libraries) {
+    const library = LIBRARY_METADATA[libraryName];
+    const functions = library.functions || {};
+
+    for (const functionName of Object.keys(functions)) {
+      const fn = functions[functionName];
+      if (fn.args && fn.args.length === 0) {
+        functionsWithEmptyArgs++;
+        examplesWithEmptyArgs.push(`${libraryName}.${functionName}`);
+        if (examplesWithEmptyArgs.length >= 3) break;
+      }
+    }
+  }
+
+  if (functionsWithEmptyArgs > 0) {
+    // TODO: Complete generated arg metadata for logic/list/random/debug/output functions
+    // before using LIBRARY_METADATA as the compiler's full argument-validation source.
+    console.log(`  Note: ${functionsWithEmptyArgs} function(s) have empty args arrays.`);
+    console.log(`  Examples: ${examplesWithEmptyArgs.join(', ')}`);
+  }
+});


### PR DESCRIPTION
- Add docs/NODE_DEFINITION_SCHEMA.md to document the current node
  definition schema, including terminology, metadata shape, stability
  rules, known gaps, and future promotion path.
- Add test/library-metadata-schema.test.mjs with conservative metadata
  schema tests covering:
  - library names and sorting
  - library and function minimum shape
  - argument slot validation
  - target compatibility
  - runtime compatibility integration
  - explicit schema examples (math.add, text.upper, scene.setPosition)
  - documentation of incomplete generated metadata
- Update docs/STABILIZATION_ROADMAP.md to note completion of node
  schema documentation and conservative metadata shape tests as part
  of Track A stabilization.
- Update package.json to include metadata schema test in test:unit.

No production behavior changes. Metadata remains descriptive and not
yet the single source of truth for the parser, compiler, or runtime.

https://claude.ai/code/session_01AEocnGi2aziMncZtUjwnPK