### PR TITLE
test: add runtime metadata drift coverage

### DIFF
--- a/docs/NODE_DEFINITION_SCHEMA.md
+++ b/docs/NODE_DEFINITION_SCHEMA.md
@@ -287,7 +287,7 @@ The following gaps prevent using metadata as the single source of truth:
 - Some generated metadata entries (especially from `makeFunctionMetadata`) have empty `args` arrays because argument information is not yet available.
 - Metadata for `logic`, `list`, `random`, `debug`, and `output` functions is incomplete.
 - Metadata does not yet fully drive compiler validation. Some argument validation is hard-coded in the parser and compiler.
-- Runtime implementation and metadata can still drift. There are no drift-detection tests yet.
+- Runtime implementation and metadata can still drift (tracked by `test/runtime-metadata-drift.test.mjs`).
 - Node Editor port generation is not fully stabilized and does not yet use metadata as the authoritative source.
 - Canonical DSL generation and source-preserving edits are not yet part of the schema.
 - The schema does not yet capture all relevant type information (e.g., union types, optional arguments with semantic defaults).
@@ -295,7 +295,7 @@ The following gaps prevent using metadata as the single source of truth:
 Before treating metadata as the single source of truth:
 
 - Complete argument metadata for all implemented functions.
-- Add metadata-to-runtime drift tests to catch implementation-metadata mismatches.
+- Metadata-to-runtime drift is covered by `test/runtime-metadata-drift.test.mjs`.
 - Use metadata as the source for Node Editor port generation.
 - Use metadata for compiler argument validation and error messages.
 - Update `docs/SPEC.md` only after behavior is stable.
@@ -325,3 +325,7 @@ Before treating metadata as the single source of truth:
 
 - After behavior is stable and fully tested, promote key aspects to `docs/SPEC.md`.
 - Treat metadata as the single source of truth for all new features.
+
+## See also
+
+Runtime executable node definitions are currently documented in `docs/RUNTIME_NODE_REGISTRY.md`.

--- a/docs/RUNTIME_NODE_REGISTRY.md
+++ b/docs/RUNTIME_NODE_REGISTRY.md
@@ -1,0 +1,149 @@
+# Runtime Node Registry
+
+## 1. Purpose
+
+`NODE_TYPES` is currently the runtime/compiler registry for executable Loomlet node types.
+
+It defines:
+
+- node type name
+- category
+- inputs
+- params
+- outputs
+- runtime evaluation behavior
+- optional lifecycle hooks such as `onStart` / `onStop`
+
+## 2. Current relationship to metadata
+
+**Key distinction:**
+
+```
+NODE_TYPES describes what can actually run.
+LIBRARY_METADATA describes how nodes are documented, completed, and shown in editors.
+```
+
+Today, metadata is not yet the single source of truth. Node definitions, library metadata, and editor completions are maintained separately. The runtime registry and library metadata are gradually being reconciled through drift detection tests.
+
+## 3. Node type naming
+
+Runtime node type names currently include two categories:
+
+### Legacy/unqualified names
+
+Simple names without dots:
+
+- `add`
+- `multiply`
+- `sine`
+- `clock`
+- `constant`
+
+These are typically basic operators from Phase 0 and Phase 1 development.
+
+### Library-qualified names
+
+Names using `library.function` dot notation:
+
+- `math.add`
+- `logic.select`
+- `scene.setPosition`
+- `text.upper`
+
+These correspond to functions in the standard library and are the preferred form for public APIs going forward.
+
+Legacy names are still present for backward compatibility and will not be removed in this stabilization phase. New public library nodes should use library-qualified names.
+
+## 4. Expected runtime node shape
+
+Each node definition in `NODE_TYPES` should have this minimum shape:
+
+```js
+{
+  category: 'transform',
+  inputs: [
+    { name: 'a', type: 'number', default: 0, kind: 'behavior' }
+  ],
+  params: [
+    { name: 'a', type: 'number', default: 0 }
+  ],
+  outputs: [
+    { name: 'out', type: 'number', kind: 'behavior' }
+  ],
+  evaluate(inputs, params, ctx) {
+    return { out: inputs.a };
+  }
+}
+```
+
+### Fields
+
+- **`category`** (string): Node category for visual organization (e.g., `'source'`, `'transform'`, `'sink'`, `'behavior'`)
+
+- **`inputs`** (array): List of input ports available during compilation. Each input has:
+  - `name` (string): port identifier
+  - `type` (string): Loomlet type (e.g., `'number'`, `'string'`, `'any'`)
+  - `kind` (string, optional): `'behavior'` for continuous inputs, omitted for discrete
+  - `default` (any, optional): default value if not connected
+
+- **`params`** (array): List of static literal parameter ports. Each param has:
+  - `name` (string): parameter identifier
+  - `type` (string): Loomlet type
+  - `default` (any, optional): default value if not specified
+
+- **`outputs`** (array): List of output ports produced by evaluation. Each output has:
+  - `name` (string): port identifier
+  - `type` (string): Loomlet type
+  - `kind` (string, optional): `'behavior'` for continuous outputs
+
+- **`evaluate`** (function): Runtime computation. Signature:
+  ```js
+  evaluate(inputs, params, ctx) -> { [outputName]: value, ... }
+  ```
+  - `inputs`: object mapping input names to current values
+  - `params`: object mapping parameter names to literal values
+  - `ctx`: runtime context (frame time, engine, node ID, etc.)
+  - Return value: object with one key per output
+
+- **`onStart`** (function, optional): Called when the node first enters the graph. Signature: `onStart(ctx) -> void`
+
+- **`onStop`** (function, optional): Called when the node leaves the graph. Signature: `onStop(ctx) -> void`
+
+## 5. Drift policy
+
+The following policy guides reconciliation between `NODE_TYPES` and `LIBRARY_METADATA`:
+
+- **Metadata functions should map to executable runtime nodes** unless explicitly marked otherwise (e.g., as planned/future work).
+
+- **Runtime node input/param names should not casually drift** from metadata argument names. If a metadata function documents argument `x`, the runtime node should also have an input or param named `x`.
+
+- **Runtime-only legacy nodes are allowed** for now but should be documented. These are unqualified names without metadata, kept for backward compatibility.
+
+- **New public library nodes should be library-qualified.** Prefer `library.function` form for new additions.
+
+- **A future PR may introduce a formal `registerNodeType()` API,** but this PR does not implement it. For now, node types are defined in static `NODE_TYPES` object.
+
+## 6. Known gaps
+
+The following are not yet complete but are tracked:
+
+- **Legacy unqualified nodes still exist.** Phase 0 and Phase 1 basic operators (`add`, `multiply`, etc.) are not yet library-qualified.
+
+- **Metadata is not yet generated from runtime definitions.** Updates to runtime signatures require manual metadata updates.
+
+- **Runtime definitions are not yet generated from metadata.** The metadata is currently hand-written alongside runtime code.
+
+- **Some runtime nodes may not yet have complete metadata.** Check `LIBRARY_METADATA` coverage for specific functions.
+
+- **Node Editor port generation is not yet fully driven by the registry.** Port completions are generated but don't yet auto-sync with runtime definitions.
+
+These gaps are documented in test allowlists (`KNOWN_METADATA_ONLY_NODE_TYPES`, `KNOWN_RUNTIME_ONLY_NODE_TYPES`) and will be addressed in future PRs as coverage improves.
+
+---
+
+## See Also
+
+- `src/loom.js` — `NODE_TYPES` runtime registry definition
+- `src/toolchain/library-metadata.js` — `LIBRARY_METADATA` descriptive metadata
+- `test/runtime-node-registry.test.mjs` — Shape and stability tests for `NODE_TYPES`
+- `test/runtime-metadata-drift.test.mjs` — Drift detection between registry and metadata

--- a/docs/STABILIZATION_ROADMAP.md
+++ b/docs/STABILIZATION_ROADMAP.md
@@ -20,6 +20,9 @@ Recommended order:
 4. Stabilize node definition schema
    - Document current node definition schema in `docs/NODE_DEFINITION_SCHEMA.md`
    - Add conservative metadata shape tests in `test/library-metadata-schema.test.mjs`
+   - Document runtime node registry in `docs/RUNTIME_NODE_REGISTRY.md`
+   - Add runtime registry shape tests in `test/runtime-node-registry.test.mjs`
+   - Add metadata/runtime drift tests in `test/runtime-metadata-drift.test.mjs`
    - Do not yet make metadata the single runtime/compiler source of truth
 5. Clarify input vs param (✓ covered by `input-param-*` stabilization fixtures)
 6. Clarify runtime registration API
@@ -160,5 +163,8 @@ This is future work and should not be treated as stable yet.
 4. Add metadata schema tests to verify node definition shape.
    - Fixture tests cover behavior.
    - Metadata schema tests cover node definition shape.
-5. Later, stabilize `graphToCanonicalDSL`.
-6. Later, add editor round-trip tests.
+   - Runtime registry shape is covered by runtime-node-registry tests.
+   - Metadata/runtime drift is covered by runtime-metadata-drift tests.
+5. Next: evaluate whether to introduce a formal runtime registration API after registry/metadata drift tests are stable.
+6. Later, stabilize `graphToCanonicalDSL`.
+7. Later, add editor round-trip tests.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stabilization-fixtures.test.mjs && node test/stabilization-invalid-fixtures.test.mjs && node test/library-metadata-schema.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stabilization-fixtures.test.mjs && node test/stabilization-invalid-fixtures.test.mjs && node test/library-metadata-schema.test.mjs && node test/runtime-node-registry.test.mjs && node test/runtime-metadata-drift.test.mjs && node test/stdlib-baseline.test.mjs",
     "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",

--- a/test/runtime-metadata-drift.test.mjs
+++ b/test/runtime-metadata-drift.test.mjs
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NODE_TYPES } from '../src/loom.js';
+import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
+
+function metadataNodeType(libraryName, functionName) {
+  return `${libraryName}.${functionName}`;
+}
+
+function runtimeSlotNames(def) {
+  return new Set([
+    ...(def.inputs ?? []).map((input) => input.name),
+    ...(def.params ?? []).map((param) => param.name)
+  ]);
+}
+
+test('metadata drift: advertised metadata functions have runtime nodes', () => {
+  const KNOWN_METADATA_ONLY_NODE_TYPES = new Set([
+    // TODO: math library is not yet fully namespaced in runtime
+    'math.negate',
+    'math.abs',
+    'math.clamp',
+    'math.lerp',
+    'math.smoothstep',
+    'math.sqrt',
+    'math.ceiling',
+    'math.floor',
+    'math.round',
+    'math.min',
+    'math.max',
+    // TODO: comparison functions are in logic library, not math
+    'math.greaterThan',
+    'math.lessThan',
+    // TODO: output, random, and state functions not yet in NODE_TYPES
+    'output.log',
+    'random.noise',
+    'random.seeded',
+    'state.delay1',
+    'state.integrate',
+    'state.lowpass',
+    'state.smoothLerp'
+  ]);
+
+  for (const [libraryName, library] of Object.entries(LIBRARY_METADATA)) {
+    for (const functionName of Object.keys(library.functions ?? {})) {
+      const nodeType = metadataNodeType(libraryName, functionName);
+
+      if (!KNOWN_METADATA_ONLY_NODE_TYPES.has(nodeType)) {
+        assert.ok(
+          NODE_TYPES[nodeType],
+          `Metadata advertises ${nodeType}, but NODE_TYPES does not define it`
+        );
+      }
+    }
+  }
+});
+
+test('metadata drift: metadata args exist in runtime inputs or params', () => {
+  const KNOWN_ARG_NAME_MISMATCHES = new Set([
+    // TODO: math.abs runtime uses 'value' but metadata documents 'a'
+    'math.abs:a'
+  ]);
+
+  for (const [libraryName, library] of Object.entries(LIBRARY_METADATA)) {
+    for (const [functionName, fn] of Object.entries(library.functions ?? {})) {
+      const nodeType = metadataNodeType(libraryName, functionName);
+      const runtime = NODE_TYPES[nodeType];
+
+      if (!runtime) {
+        // Skip if node doesn't exist in runtime yet (covered by previous test)
+        continue;
+      }
+
+      const slots = runtimeSlotNames(runtime);
+
+      for (const arg of fn.args ?? []) {
+        const key = `${nodeType}:${arg.name}`;
+        if (KNOWN_ARG_NAME_MISMATCHES.has(key)) {
+          continue; // Skip known mismatches
+        }
+
+        assert.ok(
+          slots.has(arg.name),
+          `${nodeType} metadata arg '${arg.name}' is not present in runtime inputs/params`
+        );
+      }
+    }
+  }
+});
+
+test('metadata drift: non-void metadata functions expose runtime outputs', () => {
+  for (const [libraryName, library] of Object.entries(LIBRARY_METADATA)) {
+    for (const [functionName, fn] of Object.entries(library.functions ?? {})) {
+      const nodeType = metadataNodeType(libraryName, functionName);
+      const runtime = NODE_TYPES[nodeType];
+
+      if (!runtime) {
+        // Skip if node doesn't exist in runtime yet
+        continue;
+      }
+
+      const outputs = runtime.outputs ?? [];
+
+      if (fn.returns !== 'void') {
+        assert.ok(
+          outputs.length > 0,
+          `${nodeType} returns non-void but has no output ports`
+        );
+      }
+    }
+  }
+});
+
+test('metadata drift: namespaced runtime public nodes have metadata', () => {
+  const KNOWN_RUNTIME_ONLY_NODE_TYPES = new Set([
+    // TODO: function library nodes are internal compiler/evaluator support, not yet public
+    'function.literal',
+    'function.call'
+  ]);
+
+  for (const nodeType of Object.keys(NODE_TYPES)) {
+    // Skip unqualified names (legacy phase 0/1 nodes)
+    if (!nodeType.includes('.')) {
+      continue;
+    }
+
+    // Skip known runtime-only nodes
+    if (KNOWN_RUNTIME_ONLY_NODE_TYPES.has(nodeType)) {
+      continue;
+    }
+
+    const [libraryName, functionName] = nodeType.split('.');
+
+    assert.ok(
+      LIBRARY_METADATA[libraryName],
+      `Runtime node ${nodeType} references library "${libraryName}" but it's not in LIBRARY_METADATA`
+    );
+
+    const library = LIBRARY_METADATA[libraryName];
+    assert.ok(
+      library.functions && library.functions[functionName],
+      `Runtime node ${nodeType} is not documented in LIBRARY_METADATA.${libraryName}.functions.${functionName}`
+    );
+  }
+});
+
+test('metadata drift: math.add args match runtime slots', () => {
+  const meta = LIBRARY_METADATA.math.functions.add;
+  const runtime = NODE_TYPES['math.add'];
+
+  assert.deepEqual(meta.args.map((arg) => arg.name), ['a', 'b']);
+  assert.deepEqual(runtime.inputs.map((input) => input.name), ['a', 'b']);
+  assert.deepEqual(runtime.params.map((param) => param.name), ['a', 'b']);
+});
+
+test('metadata drift: scene.setPosition args match runtime slots', () => {
+  const meta = LIBRARY_METADATA.scene.functions.setPosition;
+  const runtime = NODE_TYPES['scene.setPosition'];
+
+  assert.deepEqual(meta.args.map((arg) => arg.name), ['objectId', 'x', 'y', 'z']);
+  assert.deepEqual(runtime.inputs.map((input) => input.name), ['objectId', 'x', 'y', 'z']);
+  assert.deepEqual(runtime.params.map((param) => param.name), ['objectId', 'x', 'y', 'z']);
+});

--- a/test/runtime-node-registry.test.mjs
+++ b/test/runtime-node-registry.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NODE_TYPES } from '../src/loom.js';
+
+function assertNonEmptyString(value, label) {
+  assert.equal(typeof value, 'string', `${label} should be a string`);
+  assert.ok(value.length > 0, `${label} should not be empty`);
+}
+
+function assertUniqueNames(entries, label) {
+  const names = entries.map((entry) => entry.name);
+  assert.deepEqual(
+    names,
+    [...new Set(names)],
+    `${label} should not contain duplicate names`
+  );
+}
+
+function assertPortShape(port, label) {
+  assertNonEmptyString(port.name, `${label}.name`);
+  assertNonEmptyString(port.type, `${label}.type`);
+
+  if ('kind' in port) {
+    assertNonEmptyString(port.kind, `${label}.kind`);
+  }
+}
+
+test('runtime registry: NODE_TYPES exists and is non-empty', () => {
+  assert(typeof NODE_TYPES === 'object', 'NODE_TYPES should be an object');
+  assert(NODE_TYPES !== null, 'NODE_TYPES should not be null');
+  assert(Object.keys(NODE_TYPES).length > 0, 'NODE_TYPES should have at least one key');
+});
+
+test('runtime registry: important nodes are present', () => {
+  const requiredNodes = [
+    'constant',
+    'clock',
+    'math.add',
+    'math.multiply',
+    'logic.select',
+    'scene.setPosition',
+    'text.upper'
+  ];
+
+  for (const nodeType of requiredNodes) {
+    assert(NODE_TYPES[nodeType], `NODE_TYPES should include "${nodeType}"`);
+  }
+});
+
+test('runtime registry: every node has minimum shape', () => {
+  const KNOWN_NO_EVALUATE_NODE_TYPES = new Set([
+    // Keep empty if possible.
+  ]);
+
+  for (const [nodeType, def] of Object.entries(NODE_TYPES)) {
+    assertNonEmptyString(def.category, `${nodeType}.category`);
+
+    assert(Array.isArray(def.inputs) || def.inputs === undefined, `${nodeType}.inputs should be an array or undefined`);
+    assert(Array.isArray(def.outputs) || def.outputs === undefined, `${nodeType}.outputs should be an array or undefined`);
+    assert(Array.isArray(def.params) || def.params === undefined, `${nodeType}.params should be an array or undefined`);
+
+    if (!KNOWN_NO_EVALUATE_NODE_TYPES.has(nodeType)) {
+      assert.equal(typeof def.evaluate, 'function', `${nodeType}.evaluate should be a function`);
+    }
+  }
+});
+
+test('runtime registry: input/param/output entries have stable shape', () => {
+  for (const [nodeType, def] of Object.entries(NODE_TYPES)) {
+    const inputs = def.inputs ?? [];
+    const params = def.params ?? [];
+    const outputs = def.outputs ?? [];
+
+    for (const input of inputs) {
+      assertPortShape(input, `${nodeType}.input`);
+    }
+
+    for (const param of params) {
+      assertPortShape(param, `${nodeType}.param`);
+    }
+
+    for (const output of outputs) {
+      assertPortShape(output, `${nodeType}.output`);
+    }
+
+    assertUniqueNames(inputs, `${nodeType}.inputs`);
+    assertUniqueNames(params, `${nodeType}.params`);
+    assertUniqueNames(outputs, `${nodeType}.outputs`);
+  }
+});
+
+test('runtime registry: namespaced node types use library.function shape', () => {
+  for (const nodeType of Object.keys(NODE_TYPES)) {
+    if (nodeType.includes('.')) {
+      const parts = nodeType.split('.');
+      assert.equal(parts.length, 2, `${nodeType} should have exactly two parts separated by a dot`);
+      assert(parts[0].length > 0, `${nodeType} library part should not be empty`);
+      assert(parts[1].length > 0, `${nodeType} function part should not be empty`);
+    }
+  }
+});
+
+test('runtime registry: math.add shape is stable', () => {
+  const add = NODE_TYPES['math.add'];
+  assert.deepEqual(add.inputs.map((input) => input.name), ['a', 'b']);
+  assert.deepEqual(add.params.map((param) => param.name), ['a', 'b']);
+  assert.deepEqual(add.outputs.map((output) => output.name), ['out']);
+  assert.equal(typeof add.evaluate, 'function');
+});
+
+test('runtime registry: scene.setPosition shape is stable', () => {
+  const setPosition = NODE_TYPES['scene.setPosition'];
+  assert.deepEqual(setPosition.inputs.map((input) => input.name), ['objectId', 'x', 'y', 'z']);
+  assert.deepEqual(setPosition.params.map((param) => param.name), ['objectId', 'x', 'y', 'z']);
+  assert.deepEqual(setPosition.outputs.map((output) => output.name), []);
+  assert.equal(typeof setPosition.evaluate, 'function');
+});


### PR DESCRIPTION
- Add docs/RUNTIME_NODE_REGISTRY.md documenting NODE_TYPES runtime registry
- Add test/runtime-node-registry.test.mjs for shape and stability tests
- Add test/runtime-metadata-drift.test.mjs for metadata/runtime drift detection
- Update package.json test:unit to run new test suites
- Update docs/STABILIZATION_ROADMAP.md with registry test coverage notes
- Update docs/NODE_DEFINITION_SCHEMA.md to reference runtime registry

Known gaps documented in test allowlists:
- Some math functions not yet namespaced in runtime
- Comparison functions in metadata under math, in runtime under logic
- Some state/output/random functions in metadata but not NODE_TYPES yet
- math.abs argument naming drift (metadata: 'a', runtime: 'value')
- function.literal and function.call are internal compiler support, not public API

This PR makes drift visible without changing runtime behavior. The formal registerNodeType() API is future work.

https://claude.ai/code/session_014dZbTQkx7P1Fa5ZkrnyfVF