### PR TITLE
test: audit runtime metadata drift allowlists

### DIFF
--- a/docs/STABILIZATION_ROADMAP.md
+++ b/docs/STABILIZATION_ROADMAP.md
@@ -23,6 +23,7 @@ Recommended order:
    - Document runtime node registry in `docs/RUNTIME_NODE_REGISTRY.md`
    - Add runtime registry shape tests in `test/runtime-node-registry.test.mjs`
    - Add metadata/runtime drift tests in `test/runtime-metadata-drift.test.mjs`
+   - Runtime/metadata drift allowlists are now self-audited so stale entries fail tests
    - Do not yet make metadata the single runtime/compiler source of truth
 5. Clarify input vs param (✓ covered by `input-param-*` stabilization fixtures)
 6. Clarify runtime registration API

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -688,11 +688,11 @@ export const LIBRARY_METADATA = {
       },
       abs: {
         name: 'abs',
-        signature: 'abs(a: 0)',
+        signature: 'math.abs(value: 0)',
         description: 'Computes the absolute value of a number.',
         args: [
           {
-            name: 'a',
+            name: 'value',
             type: 'number',
             positional: false,
             description: 'Number.'
@@ -701,7 +701,7 @@ export const LIBRARY_METADATA = {
         returns: 'number',
         targets: LIBRARY_COMPATIBILITY.math.targets,
         examples: [
-          'result = abs(a: -5)'
+          'result = math.abs(value: -5)'
         ]
       },
       lerp: {

--- a/test/runtime-metadata-drift.test.mjs
+++ b/test/runtime-metadata-drift.test.mjs
@@ -3,8 +3,39 @@ import assert from 'node:assert/strict';
 import { NODE_TYPES } from '../src/loom.js';
 import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
 
+// Allowlists for known drift (entries that will be self-audited)
+const KNOWN_METADATA_ONLY_NODE_TYPES = new Set([
+  'math.negate',
+  'math.greaterThan',
+  'math.lessThan',
+  'output.log',
+  'random.noise',
+  'random.seeded',
+  'state.delay1',
+  'state.integrate',
+  'state.lowpass',
+  'state.smoothLerp'
+]);
+
+const KNOWN_ARG_NAME_MISMATCHES = new Set([]);
+
+const KNOWN_RUNTIME_ONLY_NODE_TYPES = new Set([
+  'function.literal',
+  'function.call'
+]);
+
 function metadataNodeType(libraryName, functionName) {
   return `${libraryName}.${functionName}`;
+}
+
+function getMetadataFunction(nodeType) {
+  const [libraryName, functionName] = nodeType.split('.');
+  return LIBRARY_METADATA[libraryName]?.functions?.[functionName] ?? null;
+}
+
+function parseArgMismatchKey(key) {
+  const [nodeType, argName] = key.split(':');
+  return { nodeType, argName };
 }
 
 function runtimeSlotNames(def) {
@@ -15,32 +46,6 @@ function runtimeSlotNames(def) {
 }
 
 test('metadata drift: advertised metadata functions have runtime nodes', () => {
-  const KNOWN_METADATA_ONLY_NODE_TYPES = new Set([
-    // TODO: math library is not yet fully namespaced in runtime
-    'math.negate',
-    'math.abs',
-    'math.clamp',
-    'math.lerp',
-    'math.smoothstep',
-    'math.sqrt',
-    'math.ceiling',
-    'math.floor',
-    'math.round',
-    'math.min',
-    'math.max',
-    // TODO: comparison functions are in logic library, not math
-    'math.greaterThan',
-    'math.lessThan',
-    // TODO: output, random, and state functions not yet in NODE_TYPES
-    'output.log',
-    'random.noise',
-    'random.seeded',
-    'state.delay1',
-    'state.integrate',
-    'state.lowpass',
-    'state.smoothLerp'
-  ]);
-
   for (const [libraryName, library] of Object.entries(LIBRARY_METADATA)) {
     for (const functionName of Object.keys(library.functions ?? {})) {
       const nodeType = metadataNodeType(libraryName, functionName);
@@ -55,12 +60,22 @@ test('metadata drift: advertised metadata functions have runtime nodes', () => {
   }
 });
 
-test('metadata drift: metadata args exist in runtime inputs or params', () => {
-  const KNOWN_ARG_NAME_MISMATCHES = new Set([
-    // TODO: math.abs runtime uses 'value' but metadata documents 'a'
-    'math.abs:a'
-  ]);
+test('metadata drift: metadata-only allowlist entries are still active', () => {
+  for (const nodeType of KNOWN_METADATA_ONLY_NODE_TYPES) {
+    assert.ok(
+      getMetadataFunction(nodeType),
+      `Allowlist entry ${nodeType} is stale: metadata no longer advertises it`
+    );
 
+    assert.equal(
+      Boolean(NODE_TYPES[nodeType]),
+      false,
+      `Allowlist entry ${nodeType} is stale: runtime now defines it`
+    );
+  }
+});
+
+test('metadata drift: metadata args exist in runtime inputs or params', () => {
   for (const [libraryName, library] of Object.entries(LIBRARY_METADATA)) {
     for (const [functionName, fn] of Object.entries(library.functions ?? {})) {
       const nodeType = metadataNodeType(libraryName, functionName);
@@ -88,6 +103,28 @@ test('metadata drift: metadata args exist in runtime inputs or params', () => {
   }
 });
 
+test('metadata drift: arg mismatch allowlist entries are still active', () => {
+  for (const key of KNOWN_ARG_NAME_MISMATCHES) {
+    const { nodeType, argName } = parseArgMismatchKey(key);
+    const meta = getMetadataFunction(nodeType);
+    const runtime = NODE_TYPES[nodeType];
+
+    assert.ok(meta, `Allowlist entry ${key} is stale: metadata function is missing`);
+    assert.ok(runtime, `Allowlist entry ${key} is stale: runtime node is missing`);
+
+    assert.ok(
+      (meta.args ?? []).some((arg) => arg.name === argName),
+      `Allowlist entry ${key} is stale: metadata arg is missing`
+    );
+
+    assert.equal(
+      runtimeSlotNames(runtime).has(argName),
+      false,
+      `Allowlist entry ${key} is stale: runtime now has arg ${argName}`
+    );
+  }
+});
+
 test('metadata drift: non-void metadata functions expose runtime outputs', () => {
   for (const [libraryName, library] of Object.entries(LIBRARY_METADATA)) {
     for (const [functionName, fn] of Object.entries(library.functions ?? {})) {
@@ -112,12 +149,6 @@ test('metadata drift: non-void metadata functions expose runtime outputs', () =>
 });
 
 test('metadata drift: namespaced runtime public nodes have metadata', () => {
-  const KNOWN_RUNTIME_ONLY_NODE_TYPES = new Set([
-    // TODO: function library nodes are internal compiler/evaluator support, not yet public
-    'function.literal',
-    'function.call'
-  ]);
-
   for (const nodeType of Object.keys(NODE_TYPES)) {
     // Skip unqualified names (legacy phase 0/1 nodes)
     if (!nodeType.includes('.')) {
@@ -144,6 +175,21 @@ test('metadata drift: namespaced runtime public nodes have metadata', () => {
   }
 });
 
+test('metadata drift: runtime-only allowlist entries are still active', () => {
+  for (const nodeType of KNOWN_RUNTIME_ONLY_NODE_TYPES) {
+    assert.ok(
+      NODE_TYPES[nodeType],
+      `Allowlist entry ${nodeType} is stale: runtime no longer defines it`
+    );
+
+    assert.equal(
+      Boolean(getMetadataFunction(nodeType)),
+      false,
+      `Allowlist entry ${nodeType} is stale: metadata now documents it`
+    );
+  }
+});
+
 test('metadata drift: math.add args match runtime slots', () => {
   const meta = LIBRARY_METADATA.math.functions.add;
   const runtime = NODE_TYPES['math.add'];
@@ -160,4 +206,13 @@ test('metadata drift: scene.setPosition args match runtime slots', () => {
   assert.deepEqual(meta.args.map((arg) => arg.name), ['objectId', 'x', 'y', 'z']);
   assert.deepEqual(runtime.inputs.map((input) => input.name), ['objectId', 'x', 'y', 'z']);
   assert.deepEqual(runtime.params.map((param) => param.name), ['objectId', 'x', 'y', 'z']);
+});
+
+test('metadata drift: math.abs args match runtime slots', () => {
+  const meta = LIBRARY_METADATA.math.functions.abs;
+  const runtime = NODE_TYPES['math.abs'];
+
+  assert.deepEqual(meta.args.map((arg) => arg.name), ['value']);
+  assert.deepEqual(runtime.inputs.map((input) => input.name), ['value']);
+  assert.deepEqual(runtime.params.map((param) => param.name), ['value']);
 });


### PR DESCRIPTION
- Move allowlists to top-level constants in runtime-metadata-drift.test.mjs
- Add self-audit tests for each allowlist (metadata-only, arg mismatches, runtime-only)
- Self-audit tests fail when allowlist entries are no longer actually needed
- Remove stale metadata-only allowlist entries (math.abs, math.clamp, math.lerp, math.smoothstep, math.sqrt, math.floor, math.round, math.min, math.max, math.ceiling)
- Fix math.abs metadata: change argument name from 'a' to 'value' to match runtime
- Remove math.abs:a from arg mismatch allowlist (no longer needed)
- Add targeted test for math.abs args matching runtime slots
- Update STABILIZATION_ROADMAP.md to note allowlist self-auditing

This ensures stale allowlist entries cannot remain silently and keeps metadata in sync with runtime.

https://claude.ai/code/session_01Fd2BniqvSDpZCwtyrYUqUK