### PR TITLE
chore: remove metadata-only public nodes

### DIFF
--- a/docs/NODE_DEFINITION_SCHEMA.md
+++ b/docs/NODE_DEFINITION_SCHEMA.md
@@ -280,12 +280,25 @@ The following rules help preserve compatibility and gradual improvement:
 - Do not use metadata field order as runtime semantics unless explicitly documented.
 - Editor-only metadata should be clearly separated from semantic metadata in future versions.
 
+## Public metadata policy
+
+**Metadata-only public nodes are not allowed.** Every function advertised in `LIBRARY_METADATA` must have a corresponding executable implementation in `NODE_TYPES`.
+
+For experimental or future nodes:
+- Design and discuss in lab notes, design documents, or draft PRs
+- Do not add to public `LIBRARY_METADATA` until:
+  - Execution semantics are clearly defined
+  - A working implementation is ready
+  - Tests exist to prevent regression
+
+A metadata function without a runtime node will fail the metadata drift test in `test/runtime-metadata-drift.test.mjs` unless explicitly justified in that test.
+
 ## Known gaps
 
 The following gaps prevent using metadata as the single source of truth:
 
 - Some generated metadata entries (especially from `makeFunctionMetadata`) have empty `args` arrays because argument information is not yet available.
-- Metadata for `logic`, `list`, `random`, `debug`, and `output` functions is incomplete.
+- Metadata for `logic`, `list`, `random`, and `debug` functions is incomplete.
 - Metadata does not yet fully drive compiler validation. Some argument validation is hard-coded in the parser and compiler.
 - Runtime implementation and metadata can still drift (tracked by `test/runtime-metadata-drift.test.mjs`).
 - Node Editor port generation is not fully stabilized and does not yet use metadata as the authoritative source.

--- a/docs/RUNTIME_NODE_REGISTRY.md
+++ b/docs/RUNTIME_NODE_REGISTRY.md
@@ -113,7 +113,7 @@ Each node definition in `NODE_TYPES` should have this minimum shape:
 
 The following policy guides reconciliation between `NODE_TYPES` and `LIBRARY_METADATA`:
 
-- **Metadata functions should map to executable runtime nodes** unless explicitly marked otherwise (e.g., as planned/future work).
+- **Public metadata should only advertise executable runtime nodes.** Every function in `LIBRARY_METADATA` must have a corresponding implementation in `NODE_TYPES`. Experimental or future nodes should be designed in lab notes or PRs, not added to public metadata until execution semantics are clear and implementation is ready.
 
 - **Runtime node input/param names should not casually drift** from metadata argument names. If a metadata function documents argument `x`, the runtime node should also have an input or param named `x`.
 
@@ -137,7 +137,7 @@ The following are not yet complete but are tracked:
 
 - **Node Editor port generation is not yet fully driven by the registry.** Port completions are generated but don't yet auto-sync with runtime definitions.
 
-These gaps are documented in test allowlists (`KNOWN_METADATA_ONLY_NODE_TYPES`, `KNOWN_RUNTIME_ONLY_NODE_TYPES`) and will be addressed in future PRs as coverage improves.
+These gaps are documented in test allowlists (`KNOWN_RUNTIME_ONLY_NODE_TYPES`) and will be addressed in future PRs as coverage improves.
 
 ---
 

--- a/docs/STABILIZATION_ROADMAP.md
+++ b/docs/STABILIZATION_ROADMAP.md
@@ -23,6 +23,7 @@ Recommended order:
    - Document runtime node registry in `docs/RUNTIME_NODE_REGISTRY.md`
    - Add runtime registry shape tests in `test/runtime-node-registry.test.mjs`
    - Add metadata/runtime drift tests in `test/runtime-metadata-drift.test.mjs`
+   - Remove metadata-only public nodes; experimental nodes should stay in design docs until executable
    - Runtime/metadata drift allowlists are now self-audited so stale entries fail tests
    - Do not yet make metadata the single runtime/compiler source of truth
 5. Clarify input vs param (✓ covered by `input-param-*` stabilization fixtures)

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -668,24 +668,6 @@ export const LIBRARY_METADATA = {
           'result = map(value: 0.5, inMin: 0, inMax: 1, outMin: 0, outMax: 10)'
         ]
       },
-      negate: {
-        name: 'negate',
-        signature: 'negate(a: 0)',
-        description: 'Negates a number.',
-        args: [
-          {
-            name: 'a',
-            type: 'number',
-            positional: false,
-            description: 'Number to negate.'
-          }
-        ],
-        returns: 'number',
-        targets: LIBRARY_COMPATIBILITY.math.targets,
-        examples: [
-          'result = negate(a: 5)'
-        ]
-      },
       abs: {
         name: 'abs',
         signature: 'math.abs(value: 0)',
@@ -764,181 +746,6 @@ export const LIBRARY_METADATA = {
           'result = smoothstep(x: 0.5, edge0: 0, edge1: 1)'
         ]
       },
-      greaterThan: {
-        name: 'greaterThan',
-        signature: 'greaterThan(a: 0, b: 0)',
-        description: 'Compares if a > b.',
-        args: [
-          {
-            name: 'a',
-            type: 'number',
-            positional: false,
-            description: 'First number.'
-          },
-          {
-            name: 'b',
-            type: 'number',
-            positional: false,
-            description: 'Second number.'
-          }
-        ],
-        returns: 'boolean',
-        targets: LIBRARY_COMPATIBILITY.math.targets,
-        examples: [
-          'result = greaterThan(a: 5, b: 3)'
-        ]
-      },
-      lessThan: {
-        name: 'lessThan',
-        signature: 'lessThan(a: 0, b: 0)',
-        description: 'Compares if a < b.',
-        args: [
-          {
-            name: 'a',
-            type: 'number',
-            positional: false,
-            description: 'First number.'
-          },
-          {
-            name: 'b',
-            type: 'number',
-            positional: false,
-            description: 'Second number.'
-          }
-        ],
-        returns: 'boolean',
-        targets: LIBRARY_COMPATIBILITY.math.targets,
-        examples: [
-          'result = lessThan(a: 3, b: 5)'
-        ]
-      }
-    }
-  },
-  state: {
-    name: 'state',
-    description: LIBRARY_COMPATIBILITY.state.description,
-    targets: LIBRARY_COMPATIBILITY.state.targets,
-    functions: {
-      lowpass: {
-        name: 'lowpass',
-        signature: 'lowpass(value: 0, tau: 0.2, initial: 0)',
-        description: 'Low-pass filter with exponential smoothing.',
-        args: [
-          {
-            name: 'value',
-            type: 'number',
-            positional: true,
-            description: 'Input value.'
-          },
-          {
-            name: 'tau',
-            type: 'number',
-            positional: false,
-            description: 'Time constant (larger = more smoothing).'
-          },
-          {
-            name: 'initial',
-            type: 'number',
-            positional: false,
-            description: 'Initial state value.'
-          }
-        ],
-        returns: 'number',
-        targets: LIBRARY_COMPATIBILITY.state.targets,
-        examples: [
-          'smoothed = lowpass(input, tau: 0.5)'
-        ]
-      },
-      delay1: {
-        name: 'delay1',
-        signature: 'delay1(value: 0, initial: 0)',
-        description: 'Delays a value by one sample.',
-        args: [
-          {
-            name: 'value',
-            type: 'number',
-            positional: true,
-            description: 'Input value.'
-          },
-          {
-            name: 'initial',
-            type: 'number',
-            positional: false,
-            description: 'Initial state value.'
-          }
-        ],
-        returns: 'number',
-        targets: LIBRARY_COMPATIBILITY.state.targets,
-        examples: [
-          'delayed = delay1(input)'
-        ]
-      },
-      integrate: {
-        name: 'integrate',
-        signature: 'integrate(value: 0, initial: 0, min: null, max: null)',
-        description: 'Integrates a value over time.',
-        args: [
-          {
-            name: 'value',
-            type: 'number',
-            positional: true,
-            description: 'Input value to integrate.'
-          },
-          {
-            name: 'initial',
-            type: 'number',
-            positional: false,
-            description: 'Initial state value.'
-          },
-          {
-            name: 'min',
-            type: 'number|null',
-            positional: false,
-            description: 'Minimum bound (optional).'
-          },
-          {
-            name: 'max',
-            type: 'number|null',
-            positional: false,
-            description: 'Maximum bound (optional).'
-          }
-        ],
-        returns: 'number',
-        targets: LIBRARY_COMPATIBILITY.state.targets,
-        examples: [
-          'integrated = integrate(velocity, initial: 0)'
-        ]
-      },
-      smoothLerp: {
-        name: 'smoothLerp',
-        signature: 'smoothLerp(value: 0, rate: 5, initial: 0)',
-        description: 'Exponentially smooths a value with a rate parameter.',
-        args: [
-          {
-            name: 'value',
-            type: 'number',
-            positional: true,
-            description: 'Input value.'
-          },
-          {
-            name: 'rate',
-            type: 'number',
-            positional: false,
-            description: 'Smoothing rate (higher = faster response).'
-          },
-          {
-            name: 'initial',
-            type: 'number',
-            positional: false,
-            description: 'Initial state value.'
-          }
-        ],
-        returns: 'number',
-        targets: LIBRARY_COMPATIBILITY.state.targets,
-        examples: [
-          'smoothed = smoothLerp(input, rate: 5)'
-        ]
-      }
     }
   },
   fs: {
@@ -1079,9 +886,7 @@ LIBRARY_METADATA.random = {
     ['value', ['random.value()', 'Returns Math.random() in [0, 1).', 'number', 'implemented']],
     ['range', ['random.range(min: 0, max: 1)', 'Returns a random float in [min, max).', 'number', 'implemented']],
     ['int', ['random.int(min: 1, max: 6)', 'Returns a random integer in inclusive [min, max].', 'number', 'implemented']],
-    ['choice', ['random.choice(list)', 'Returns a random item or null for an empty list.', 'any', 'implemented']],
-    ['seeded', ['random.seeded(seed: 1)', 'Planned seeded random generator.', 'any', 'planned']],
-    ['noise', ['random.noise(...)', 'Planned noise generator.', 'number', 'planned']]
+    ['choice', ['random.choice(list)', 'Returns a random item or null for an empty list.', 'any', 'implemented']]
   ].map(([name, [signature, description, returns, status]]) => [name, makeFunctionMetadata('random', name, signature, description, returns, status)]))
 };
 
@@ -1096,14 +901,6 @@ LIBRARY_METADATA.debug = {
   ].map(([name, [signature, description, returns]]) => [name, makeFunctionMetadata('debug', name, signature, description, returns)]))
 };
 
-LIBRARY_METADATA.output = {
-  name: 'output',
-  description: LIBRARY_COMPATIBILITY.output.description,
-  targets: LIBRARY_COMPATIBILITY.output.targets,
-  functions: Object.fromEntries([
-    ['log', ['log(value, label: "")', 'Logs a value to the Output panel and returns the value.', 'any']]
-  ].map(([name, [signature, description, returns]]) => [name, makeFunctionMetadata('output', name, signature, description, returns)]))
-};
 
 LIBRARY_METADATA.fs.functions = Object.fromEntries([
   ['readText', ['fs.readText(path: "file.txt")', 'CLI-only: reads UTF-8 text from the local filesystem.', 'string']],

--- a/test/help-cli.test.mjs
+++ b/test/help-cli.test.mjs
@@ -145,26 +145,16 @@ test('docs planned library shows status', () => {
 test('docs shows math functions', () => {
   const result = runCli(['docs', 'math']);
   assert.equal(result.status, 0, result.stderr);
-  const mathFuncs = ['sine', 'cosine', 'add', 'multiply', 'subtract', 'divide', 'mod', 'clamp', 'map', 'negate', 'abs', 'lerp', 'smoothstep', 'greaterThan', 'lessThan'];
+  const mathFuncs = ['sine', 'cosine', 'add', 'multiply', 'subtract', 'divide', 'mod', 'clamp', 'map', 'abs', 'lerp', 'smoothstep'];
   for (const func of mathFuncs) {
     assert.ok(result.stdout.includes(func), `Missing math function: ${func}`);
   }
 });
 
-test('docs shows state functions', () => {
+test('docs shows state library', () => {
   const result = runCli(['docs', 'state']);
   assert.equal(result.status, 0, result.stderr);
-  assert.ok(result.stdout.includes('lowpass'));
-  assert.ok(result.stdout.includes('delay1'));
-  assert.ok(result.stdout.includes('integrate'));
-  assert.ok(result.stdout.includes('smoothLerp'));
-});
-
-test('docs state.smoothLerp shows function details', () => {
-  const result = runCli(['docs', 'state.smoothLerp']);
-  assert.equal(result.status, 0, result.stderr);
-  assert.ok(result.stdout.includes('smoothLerp'));
-  assert.ok(result.stdout.includes('rate'));
+  assert.ok(result.stdout.includes('state'));
 });
 
 test('docs --help shows usage', () => {

--- a/test/help.test.mjs
+++ b/test/help.test.mjs
@@ -233,26 +233,17 @@ test('all documented libraries have descriptions', () => {
 });
 
 test('math functions all documented', () => {
-  const mathFuncs = ['sine', 'cosine', 'add', 'multiply', 'subtract', 'divide', 'mod', 'clamp', 'map', 'negate', 'abs', 'lerp', 'smoothstep', 'greaterThan', 'lessThan'];
+  const mathFuncs = ['sine', 'cosine', 'add', 'multiply', 'subtract', 'divide', 'mod', 'clamp', 'map', 'abs', 'lerp', 'smoothstep'];
   const mathLib = getLibraryHelp('math');
   for (const func of mathFuncs) {
     assert.ok(mathLib.functions[func], `Missing math function: ${func}`);
   }
 });
 
-test('state functions all documented', () => {
-  const stateFuncs = ['lowpass', 'delay1', 'integrate', 'smoothLerp'];
+test('state library exists', () => {
   const stateLib = getLibraryHelp('state');
-  for (const func of stateFuncs) {
-    assert.ok(stateLib.functions[func], `Missing state function: ${func}`);
-  }
-});
-
-test('state.smoothLerp is documented', () => {
-  const func = getFunctionHelp('state.smoothLerp');
-  assert.equal(func.name, 'smoothLerp');
-  assert.ok(func.description);
-  assert.ok(func.signature);
+  assert.ok(stateLib);
+  assert.ok(stateLib.description);
 });
 
 test('formatLibrariesText includes all libraries', () => {

--- a/test/runtime-metadata-drift.test.mjs
+++ b/test/runtime-metadata-drift.test.mjs
@@ -4,18 +4,7 @@ import { NODE_TYPES } from '../src/loom.js';
 import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
 
 // Allowlists for known drift (entries that will be self-audited)
-const KNOWN_METADATA_ONLY_NODE_TYPES = new Set([
-  'math.negate',
-  'math.greaterThan',
-  'math.lessThan',
-  'output.log',
-  'random.noise',
-  'random.seeded',
-  'state.delay1',
-  'state.integrate',
-  'state.lowpass',
-  'state.smoothLerp'
-]);
+const KNOWN_METADATA_ONLY_NODE_TYPES = new Set([]);
 
 const KNOWN_ARG_NAME_MISMATCHES = new Set([]);
 


### PR DESCRIPTION
- Remove math.negate, math.greaterThan, math.lessThan from metadata (comparison nodes belong under logic.*)
- Remove output.log from metadata (effect semantics not yet defined)
- Remove random.noise, random.seeded from metadata (deterministic random semantics undefined)
- Remove state.delay1, state.integrate, state.lowpass, state.smoothLerp from metadata (stateful node semantics not stabilized)
- Empty KNOWN_METADATA_ONLY_NODE_TYPES allowlist in drift tests
- Update test cases that referenced removed metadata functions
- Update docs/RUNTIME_NODE_REGISTRY.md to clarify drift policy
- Update docs/NODE_DEFINITION_SCHEMA.md with public metadata policy
- Update docs/STABILIZATION_ROADMAP.md to note metadata-only node removal

Policy: public metadata should only advertise executable public nodes.
Experimental nodes should be designed in labs/design docs until implementation is ready.

https://claude.ai/code/session_019LEnk98Ao5amJfQRhzuSSk