### PR TITLE
feat: add runtime node registry API

### DIFF
--- a/docs/RUNTIME_NODE_REGISTRATION.md
+++ b/docs/RUNTIME_NODE_REGISTRATION.md
@@ -1,0 +1,174 @@
+# Runtime Node Registration API
+
+## Purpose
+
+`registerNodeType()` is the formal API for adding executable node types to a Loomlet runtime registry.
+
+It is the foundation for future package loading.
+
+## Minimal example
+
+```js
+import { createNodeRegistry } from '../src/runtime/node-registry.js';
+
+const registry = createNodeRegistry();
+
+registry.registerNodeType('example.double', {
+  category: 'transform',
+  inputs: [{ name: 'value', type: 'number' }],
+  params: [{ name: 'value', type: 'number', default: 0 }],
+  outputs: [{ name: 'out', type: 'number' }],
+  evaluate(inputs) {
+    return { out: inputs.value * 2 };
+  }
+});
+```
+
+## Future package shape
+
+Show non-binding example:
+
+```js
+export function registerLoomletPackage(registry) {
+  registry.registerNodeType('noise.perlin', {
+    category: 'source',
+    inputs: [
+      { name: 'x', type: 'number' },
+      { name: 'y', type: 'number' }
+    ],
+    params: [
+      { name: 'seed', type: 'number', default: 0 }
+    ],
+    outputs: [
+      { name: 'out', type: 'number' }
+    ],
+    evaluate(inputs, params, ctx) {
+      return { out: 0 };
+    }
+  });
+}
+```
+
+## Note
+
+This is not package loading yet. It only defines how executable nodes are registered once a package is trusted and loaded.
+
+## API
+
+### `createNodeRegistry(initialNodeTypes = {})`
+
+Create a new runtime node registry.
+
+- **initialNodeTypes**: optional object of `{ nodeTypeName: definition, ... }` to pre-populate the registry
+- **returns**: registry object
+
+### `registry.registerNodeType(nodeType, definition)`
+
+Register an executable node type.
+
+- **nodeType**: string name like `'math.add'` or `'constant'`
+- **definition**: node type definition object with `category`, `inputs`, `params`, `outputs`, `evaluate`
+- **throws**: `TypeError` if node type name or definition is invalid, or if node type already registered
+- **returns**: normalized node definition
+
+### `registry.getNodeType(nodeType)`
+
+Get a registered node type definition.
+
+- **nodeType**: string name
+- **returns**: node definition object, or `undefined` if not registered
+
+### `registry.hasNodeType(nodeType)`
+
+Check if a node type is registered.
+
+- **nodeType**: string name
+- **returns**: boolean
+
+### `registry.listNodeTypes()`
+
+List all registered node type names.
+
+- **returns**: sorted array of node type names
+
+### `registry.toObject()`
+
+Export all registered node types as a plain object.
+
+- **returns**: object of `{ nodeTypeName: definition, ... }`
+
+### `registry.size`
+
+Read-only property giving the number of registered node types.
+
+## Validation rules
+
+### Node type name
+
+Valid names:
+
+- `'math.add'` — library-qualified form preferred for public nodes
+- `'logic.select'`
+- `'constant'` — unqualified legacy names still allowed
+- `'clock'`
+
+Invalid names:
+
+- `''` — empty
+- `'   '` — whitespace-only
+- `'math add'` — contains whitespace
+- `'.add'` — starts with dot
+- `'math.'` — ends with dot
+
+### Node type definition
+
+Required fields:
+
+- **category** (string, non-empty): node category for visual organization
+- **evaluate** (function): the runtime computation
+
+Optional but standardized:
+
+- **inputs** (array): list of input port definitions
+- **params** (array): list of parameter port definitions
+- **outputs** (array): list of output port definitions
+
+If `inputs`, `params`, or `outputs` are omitted, they are automatically normalized to empty arrays during registration.
+
+Port definitions must have:
+
+- **name** (string, non-empty): port identifier
+- **type** (string, non-empty): Loomlet type name
+
+Port definitions may have:
+
+- **kind** (string, non-empty): `'behavior'` for continuous signals, omitted for discrete values
+- **default** (any): default value if not connected or specified
+
+Validation ensures:
+
+- no duplicate names within inputs
+- no duplicate names within params
+- no duplicate names within outputs
+
+## Target compatibility
+
+Target filtering remains handled outside the registry.
+
+Documentation for target filtering is in `docs/RUNTIME_TARGETS.md`.
+
+## Security note
+
+A package that registers executable nodes is trusted code.
+
+Sandboxing and remote package loading are future work.
+
+---
+
+## See Also
+
+- `src/loom.js` — `DEFAULT_NODE_REGISTRY` runtime registry instance
+- `src/runtime/node-registry.js` — registry implementation
+- `test/node-registry.test.mjs` — registry API tests
+- `docs/RUNTIME_NODE_REGISTRY.md` — registry design and current state
+- `docs/NODE_DEFINITION_SCHEMA.md` — detailed node definition schema

--- a/docs/RUNTIME_NODE_REGISTRY.md
+++ b/docs/RUNTIME_NODE_REGISTRY.md
@@ -121,7 +121,7 @@ The following policy guides reconciliation between `NODE_TYPES` and `LIBRARY_MET
 
 - **New public library nodes should be library-qualified.** Prefer `library.function` form for new additions.
 
-- **A future PR may introduce a formal `registerNodeType()` API,** but this PR does not implement it. For now, node types are defined in static `NODE_TYPES` object.
+- **A formal `registerNodeType()` API is now available** through `createNodeRegistry()` in `src/runtime/node-registry.js`. Built-in node types are registered through the default registry at startup, then exported as `NODE_TYPES` for backward compatibility.
 
 ## 6. Known gaps
 
@@ -143,7 +143,10 @@ These gaps are documented in test allowlists (`KNOWN_RUNTIME_ONLY_NODE_TYPES`) a
 
 ## See Also
 
-- `src/loom.js` — `NODE_TYPES` runtime registry definition
+- `src/loom.js` — `DEFAULT_NODE_REGISTRY` runtime registry instance and `NODE_TYPES` export
+- `src/runtime/node-registry.js` — Registry implementation
+- `docs/RUNTIME_NODE_REGISTRATION.md` — Registry API and usage guide
 - `src/toolchain/library-metadata.js` — `LIBRARY_METADATA` descriptive metadata
+- `test/node-registry.test.mjs` — Registry API tests
 - `test/runtime-node-registry.test.mjs` — Shape and stability tests for `NODE_TYPES`
 - `test/runtime-metadata-drift.test.mjs` — Drift detection between registry and metadata

--- a/docs/STABILIZATION_ROADMAP.md
+++ b/docs/STABILIZATION_ROADMAP.md
@@ -27,7 +27,10 @@ Recommended order:
    - Runtime/metadata drift allowlists are now self-audited so stale entries fail tests
    - Do not yet make metadata the single runtime/compiler source of truth
 5. Clarify input vs param (✓ covered by `input-param-*` stabilization fixtures)
-6. Clarify runtime registration API
+6. Clarify runtime registration API (✓ minimal `createNodeRegistry/registerNodeType` API added)
+   - Minimal `createNodeRegistry()` and `registerNodeType()` API available
+   - Built-in node types are constructed through the default registry
+   - Package loading remains future work
 7. Clarify metadata as shared source for editor/docs/completion
 8. Improve compatibility between JS runtime and Unity runtime where practical
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stabilization-fixtures.test.mjs && node test/stabilization-invalid-fixtures.test.mjs && node test/library-metadata-schema.test.mjs && node test/runtime-node-registry.test.mjs && node test/runtime-metadata-drift.test.mjs && node test/stdlib-baseline.test.mjs",
+    "test:unit": "node test/loom-cli.test.mjs && node test/tour-runnable.test.mjs && node test/vscode-examples.test.mjs && node test/scenesync-demo-cli.test.mjs && node test/loom-repl-session.test.mjs && node test/loom-repl-cli.test.mjs && node test/scenesync-client.test.mjs && node test/scenesync-session-store.test.mjs && node test/scenesync-effects.test.mjs && node test/scenesync-graphs.test.mjs && node test/scenesync-graph-adapter.test.mjs && node test/stabilization-fixtures.test.mjs && node test/stabilization-invalid-fixtures.test.mjs && node test/library-metadata-schema.test.mjs && node test/node-registry.test.mjs && node test/runtime-node-registry.test.mjs && node test/runtime-metadata-drift.test.mjs && node test/stdlib-baseline.test.mjs",
     "loomlet": "node bin/loomlet.mjs",
     "loom": "node bin/loom.mjs",
     "test:cli": "node test/loom-cli.test.mjs",

--- a/src/loom.js
+++ b/src/loom.js
@@ -1,5 +1,7 @@
 // Loom: ブラウザで動くステートレスなデータフロー実行エンジン
 
+import { createNodeRegistry } from './runtime/node-registry.js';
+
 export class LoomError extends Error {
   constructor(code, message, details = {}) {
     super(message);
@@ -553,7 +555,7 @@ function getNodePath() {
 
 
 // ノード型レジストリ
-export const NODE_TYPES = {
+const BUILTIN_NODE_TYPES = {
   // Phase 0 ノード
   clock: {
     category: 'source',
@@ -2229,3 +2231,11 @@ export class Loom {
     return Array.from(cycleNodes);
   }
 }
+
+export function createDefaultNodeRegistry() {
+  return createNodeRegistry(BUILTIN_NODE_TYPES);
+}
+
+export const DEFAULT_NODE_REGISTRY = createDefaultNodeRegistry();
+
+export const NODE_TYPES = DEFAULT_NODE_REGISTRY.toObject();

--- a/src/runtime/node-registry.js
+++ b/src/runtime/node-registry.js
@@ -1,0 +1,160 @@
+export function createNodeRegistry(initialNodeTypes = {}) {
+  const nodeTypes = new Map();
+
+  if (initialNodeTypes && typeof initialNodeTypes === 'object') {
+    for (const [nodeType, definition] of Object.entries(initialNodeTypes)) {
+      const normalized = normalizeNodeTypeDefinition(definition);
+      validateNodeTypeName(nodeType);
+      validateNodeTypeDefinition(nodeType, normalized);
+      nodeTypes.set(nodeType, normalized);
+    }
+  }
+
+  return {
+    registerNodeType(nodeType, definition) {
+      validateNodeTypeName(nodeType);
+      const normalized = normalizeNodeTypeDefinition(definition);
+      validateNodeTypeDefinition(nodeType, normalized);
+
+      if (nodeTypes.has(nodeType)) {
+        throw new Error(`Duplicate node type: ${nodeType}`);
+      }
+
+      nodeTypes.set(nodeType, normalized);
+      return normalized;
+    },
+
+    getNodeType(nodeType) {
+      return nodeTypes.get(nodeType);
+    },
+
+    hasNodeType(nodeType) {
+      return nodeTypes.has(nodeType);
+    },
+
+    listNodeTypes() {
+      return Array.from(nodeTypes.keys()).sort();
+    },
+
+    toObject() {
+      const result = {};
+      for (const [nodeType, definition] of nodeTypes) {
+        result[nodeType] = definition;
+      }
+      return result;
+    },
+
+    get size() {
+      return nodeTypes.size;
+    }
+  };
+}
+
+function validateNodeTypeName(nodeType) {
+  if (typeof nodeType !== 'string') {
+    throw new TypeError(`Node type name must be a string, got ${typeof nodeType}`);
+  }
+
+  if (nodeType.length === 0) {
+    throw new TypeError('Node type name must not be empty');
+  }
+
+  if (/^\s+$/.test(nodeType)) {
+    throw new TypeError('Node type name must not be whitespace-only');
+  }
+
+  if (/\s/.test(nodeType)) {
+    throw new TypeError(`Node type name must not contain whitespace: ${nodeType}`);
+  }
+
+  if (nodeType.startsWith('.')) {
+    throw new TypeError(`Node type name must not start with a dot: ${nodeType}`);
+  }
+
+  if (nodeType.endsWith('.')) {
+    throw new TypeError(`Node type name must not end with a dot: ${nodeType}`);
+  }
+}
+
+export function validateNodeTypeDefinition(nodeType, definition) {
+  if (!definition || typeof definition !== 'object') {
+    throw new TypeError(`Invalid node type ${nodeType}: definition must be an object`);
+  }
+
+  if (typeof definition.category !== 'string' || definition.category.length === 0) {
+    throw new TypeError(`Invalid node type ${nodeType}: category must be a non-empty string`);
+  }
+
+  if (typeof definition.evaluate !== 'function') {
+    throw new TypeError(`Invalid node type ${nodeType}: evaluate must be a function`);
+  }
+
+  const inputs = definition.inputs ?? [];
+  const params = definition.params ?? [];
+  const outputs = definition.outputs ?? [];
+
+  if (!Array.isArray(inputs)) {
+    throw new TypeError(`Invalid node type ${nodeType}: inputs must be an array`);
+  }
+
+  if (!Array.isArray(params)) {
+    throw new TypeError(`Invalid node type ${nodeType}: params must be an array`);
+  }
+
+  if (!Array.isArray(outputs)) {
+    throw new TypeError(`Invalid node type ${nodeType}: outputs must be an array`);
+  }
+
+  validatePortArray(nodeType, 'input', inputs);
+  validatePortArray(nodeType, 'param', params);
+  validatePortArray(nodeType, 'output', outputs);
+}
+
+function validatePortArray(nodeType, portCategory, ports) {
+  const names = new Set();
+
+  for (const port of ports) {
+    if (!port || typeof port !== 'object') {
+      throw new TypeError(
+        `Invalid node type ${nodeType}: ${portCategory} must be an object`
+      );
+    }
+
+    if (typeof port.name !== 'string' || port.name.length === 0) {
+      throw new TypeError(
+        `Invalid node type ${nodeType}: ${portCategory} name must be a non-empty string`
+      );
+    }
+
+    if (typeof port.type !== 'string' || port.type.length === 0) {
+      throw new TypeError(
+        `Invalid node type ${nodeType}: ${portCategory} type must be a non-empty string`
+      );
+    }
+
+    if ('kind' in port) {
+      if (typeof port.kind !== 'string' || port.kind.length === 0) {
+        throw new TypeError(
+          `Invalid node type ${nodeType}: ${portCategory} kind must be a non-empty string`
+        );
+      }
+    }
+
+    if (names.has(port.name)) {
+      throw new TypeError(
+        `Invalid node type ${nodeType}: duplicate ${portCategory} name "${port.name}"`
+      );
+    }
+
+    names.add(port.name);
+  }
+}
+
+function normalizeNodeTypeDefinition(definition) {
+  return {
+    ...definition,
+    inputs: definition.inputs ?? [],
+    params: definition.params ?? [],
+    outputs: definition.outputs ?? []
+  };
+}

--- a/test/node-registry.test.mjs
+++ b/test/node-registry.test.mjs
@@ -1,0 +1,309 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createNodeRegistry,
+  validateNodeTypeDefinition
+} from '../src/runtime/node-registry.js';
+
+test('node registry registers and reads node type', () => {
+  const registry = createNodeRegistry();
+
+  const definition = {
+    category: 'transform',
+    inputs: [{ name: 'a', type: 'number' }],
+    params: [{ name: 'a', type: 'number', default: 0 }],
+    outputs: [{ name: 'out', type: 'number' }],
+    evaluate(inputs) {
+      return { out: inputs.a };
+    }
+  };
+
+  const registered = registry.registerNodeType('test.echo', definition);
+
+  assert.equal(registry.hasNodeType('test.echo'), true);
+  assert.deepEqual(registry.getNodeType('test.echo'), registered);
+  assert.deepEqual(registry.listNodeTypes(), ['test.echo']);
+});
+
+test('node registry initializes from object', () => {
+  const registry = createNodeRegistry({
+    'test.one': {
+      category: 'source',
+      inputs: [],
+      params: [],
+      outputs: [{ name: 'out', type: 'number' }],
+      evaluate() {
+        return { out: 1 };
+      }
+    }
+  });
+
+  assert.equal(registry.hasNodeType('test.one'), true);
+});
+
+test('node registry rejects duplicate node types', () => {
+  const registry = createNodeRegistry();
+  const definition = {
+    category: 'source',
+    inputs: [],
+    params: [],
+    outputs: [],
+    evaluate() {
+      return {};
+    }
+  };
+
+  registry.registerNodeType('test.dup', definition);
+
+  assert.throws(
+    () => registry.registerNodeType('test.dup', definition),
+    /Duplicate node type/
+  );
+});
+
+test('node registry rejects invalid node type names', () => {
+  const registry = createNodeRegistry();
+  const validDef = {
+    category: 'source',
+    inputs: [],
+    params: [],
+    outputs: [],
+    evaluate() {
+      return {};
+    }
+  };
+
+  const invalidNames = ['', '   ', 'math add', '.add', 'math.'];
+
+  for (const name of invalidNames) {
+    assert.throws(
+      () => registry.registerNodeType(name, validDef),
+      TypeError,
+      `Should reject invalid name: "${name}"`
+    );
+  }
+});
+
+test('node registry accepts valid node type names', () => {
+  const registry = createNodeRegistry();
+  const validDef = {
+    category: 'source',
+    inputs: [],
+    params: [],
+    outputs: [],
+    evaluate() {
+      return {};
+    }
+  };
+
+  const validNames = ['math.add', 'logic.select', 'constant', 'clock', 'function.call'];
+
+  for (const name of validNames) {
+    const reg = createNodeRegistry();
+    reg.registerNodeType(name, validDef);
+    assert.equal(reg.hasNodeType(name), true, `Should accept valid name: "${name}"`);
+  }
+});
+
+test('node registry validates definition shape', () => {
+  const registry = createNodeRegistry();
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', null),
+    TypeError
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {}),
+    TypeError
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: '',
+      evaluate() {}
+    }),
+    TypeError
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source'
+    }),
+    TypeError
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      inputs: 'not-array',
+      evaluate() {}
+    }),
+    TypeError
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      params: 'not-array',
+      evaluate() {}
+    }),
+    TypeError
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      outputs: 'not-array',
+      evaluate() {}
+    }),
+    TypeError
+  );
+});
+
+test('node registry validates port shapes', () => {
+  const registry = createNodeRegistry();
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      inputs: [{}],
+      evaluate() {}
+    }),
+    /input name/
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      inputs: [{ name: 'a' }],
+      evaluate() {}
+    }),
+    /input type/
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      outputs: [{ name: 'out', type: 'number', kind: '' }],
+      evaluate() {}
+    }),
+    /output kind/
+  );
+});
+
+test('node registry rejects duplicate port names', () => {
+  const registry = createNodeRegistry();
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      inputs: [
+        { name: 'a', type: 'number' },
+        { name: 'a', type: 'number' }
+      ],
+      evaluate() {}
+    }),
+    /duplicate input name/
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      params: [
+        { name: 'x', type: 'number' },
+        { name: 'x', type: 'number' }
+      ],
+      evaluate() {}
+    }),
+    /duplicate param name/
+  );
+
+  assert.throws(
+    () => registry.registerNodeType('test.invalid', {
+      category: 'source',
+      outputs: [
+        { name: 'out', type: 'number' },
+        { name: 'out', type: 'number' }
+      ],
+      evaluate() {}
+    }),
+    /duplicate output name/
+  );
+});
+
+test('node registry normalizes missing input param output arrays', () => {
+  const registry = createNodeRegistry();
+
+  registry.registerNodeType('test.minimal', {
+    category: 'source',
+    evaluate() {
+      return {};
+    }
+  });
+
+  const def = registry.getNodeType('test.minimal');
+
+  assert.deepEqual(def.inputs, []);
+  assert.deepEqual(def.params, []);
+  assert.deepEqual(def.outputs, []);
+});
+
+test('node registry toObject returns object copy', () => {
+  const registry = createNodeRegistry();
+  const def = {
+    category: 'source',
+    inputs: [],
+    params: [],
+    outputs: [],
+    evaluate() {
+      return {};
+    }
+  };
+
+  registry.registerNodeType('test.node', def);
+
+  const object = registry.toObject();
+
+  assert.deepEqual(object['test.node'], def);
+
+  object['test.other'] = def;
+  assert.equal(registry.hasNodeType('test.other'), false);
+});
+
+test('node registry size property', () => {
+  const registry = createNodeRegistry();
+  assert.equal(registry.size, 0);
+
+  const def = {
+    category: 'source',
+    inputs: [],
+    params: [],
+    outputs: [],
+    evaluate() {
+      return {};
+    }
+  };
+
+  registry.registerNodeType('test.a', def);
+  assert.equal(registry.size, 1);
+
+  registry.registerNodeType('test.b', def);
+  assert.equal(registry.size, 2);
+});
+
+test('node registry preserves definition evaluate function', () => {
+  const registry = createNodeRegistry();
+
+  const mockEvaluate = (inputs) => ({ out: inputs.a * 2 });
+
+  registry.registerNodeType('test.double', {
+    category: 'transform',
+    inputs: [{ name: 'a', type: 'number' }],
+    outputs: [{ name: 'out', type: 'number' }],
+    evaluate: mockEvaluate
+  });
+
+  const def = registry.getNodeType('test.double');
+  assert.equal(def.evaluate, mockEvaluate);
+});

--- a/test/runtime-node-registry.test.mjs
+++ b/test/runtime-node-registry.test.mjs
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { NODE_TYPES } from '../src/loom.js';
+import {
+  NODE_TYPES,
+  DEFAULT_NODE_REGISTRY,
+  createDefaultNodeRegistry
+} from '../src/loom.js';
 
 function assertNonEmptyString(value, label) {
   assert.equal(typeof value, 'string', `${label} should be a string`);
@@ -114,4 +118,41 @@ test('runtime registry: scene.setPosition shape is stable', () => {
   assert.deepEqual(setPosition.params.map((param) => param.name), ['objectId', 'x', 'y', 'z']);
   assert.deepEqual(setPosition.outputs.map((output) => output.name), []);
   assert.equal(typeof setPosition.evaluate, 'function');
+});
+
+test('runtime registry: default registry matches NODE_TYPES export', () => {
+  assert.deepEqual(
+    DEFAULT_NODE_REGISTRY.listNodeTypes(),
+    Object.keys(NODE_TYPES).sort()
+  );
+});
+
+test('runtime registry: DEFAULT_NODE_REGISTRY exposes all node types from NODE_TYPES', () => {
+  const registryNodeTypes = DEFAULT_NODE_REGISTRY.toObject();
+  assert.deepEqual(registryNodeTypes, NODE_TYPES);
+});
+
+test('runtime registry: createDefaultNodeRegistry returns fresh registry', () => {
+  const a = createDefaultNodeRegistry();
+  const b = createDefaultNodeRegistry();
+
+  assert.notEqual(a, b);
+  assert.deepEqual(a.listNodeTypes(), b.listNodeTypes());
+});
+
+test('runtime registry: createDefaultNodeRegistry has correct node types', () => {
+  const registry = createDefaultNodeRegistry();
+  assert.ok(registry.hasNodeType('math.add'));
+  assert.ok(registry.hasNodeType('logic.select'));
+  assert.ok(registry.hasNodeType('constant'));
+});
+
+test('runtime registry: registry preserves node definitions', () => {
+  const mathAdd = DEFAULT_NODE_REGISTRY.getNodeType('math.add');
+  assert.ok(mathAdd);
+  assert.equal(mathAdd.category, 'transform');
+  assert.equal(typeof mathAdd.evaluate, 'function');
+  assert.ok(Array.isArray(mathAdd.inputs));
+  assert.ok(Array.isArray(mathAdd.params));
+  assert.ok(Array.isArray(mathAdd.outputs));
 });


### PR DESCRIPTION
Introduce a formal API for creating node registries and registering
executable node types. This is the foundation for future package loading.

Changes:
- Add src/runtime/node-registry.js with createNodeRegistry() and
  registerNodeType() functions
- Create test/node-registry.test.mjs with comprehensive registry tests
- Update src/loom.js to use the registry for built-in node types
  - Rename NODE_TYPES to BUILTIN_NODE_TYPES
  - Export createDefaultNodeRegistry() function
  - Export DEFAULT_NODE_REGISTRY instance
  - Export NODE_TYPES from the default registry (backward compatible)
- Update test/runtime-node-registry.test.mjs with registry validation tests
- Update package.json to include node-registry.test.mjs in test:unit
- Create docs/RUNTIME_NODE_REGISTRATION.md documenting the API and usage
- Update docs/RUNTIME_NODE_REGISTRY.md with cross-references
- Update docs/STABILIZATION_ROADMAP.md to note runtime registration API completion

The registry validates node type names and definitions, rejects duplicates,
and provides methods for registration, lookup, and enumeration. Node type
definitions are normalized to ensure inputs, params, and outputs are always
arrays.

Package loading and dynamic imports remain future work.

https://claude.ai/code/session_01VQc16VKEA52ga49u1iZeyv