### PR TITLE
Use generated metadata for VS Code library reference

### DIFF
--- a/docs/STABILIZATION_ROADMAP.md
+++ b/docs/STABILIZATION_ROADMAP.md
@@ -41,6 +41,8 @@ Recommended order:
    - Package metadata provides target compatibility for package imports
    - Remote/npm package loading remains future work
 7. Clarify metadata as shared source for editor/docs/completion
+   - VS Code completion, hover, and library reference now share generated library metadata as their default source
+   - manual overrides remain only for examples, aliases, render syntax, and preview-host-specific notes
 8. Improve compatibility between JS runtime and Unity runtime where practical
 
 ## Track B: Labs

--- a/extensions/vscode-loomlet/src/completion-engine.js
+++ b/extensions/vscode-loomlet/src/completion-engine.js
@@ -1,16 +1,11 @@
-const metadata = require('../generated/library-metadata.json');
+const { buildLibraryModel } = require('./library-metadata-model.js');
 
 function getIncludePlanned(configGetter) {
   return Boolean(configGetter?.('loomlet.completion.includePlanned'));
 }
 
 function buildCompletionModel(includePlanned = false) {
-  const libraries = (metadata.libraries || [])
-    .filter((lib) => includePlanned || lib.status === 'implemented');
-  return libraries.map((lib) => ({
-    ...lib,
-    functions: (lib.functions || []).filter((fn) => includePlanned || fn.status === 'implemented')
-  }));
+  return buildLibraryModel(includePlanned);
 }
 
 function inferPlaceholder(arg) {

--- a/extensions/vscode-loomlet/src/library-metadata-model.js
+++ b/extensions/vscode-loomlet/src/library-metadata-model.js
@@ -1,0 +1,46 @@
+const metadata = require('../generated/library-metadata.json');
+
+function buildLibraryModel(includePlanned = false) {
+  const libraries = (metadata.libraries || [])
+    .filter((lib) => includePlanned || lib.status === 'implemented');
+  return libraries.map((lib) => ({
+    ...lib,
+    functions: (lib.functions || []).filter((fn) => includePlanned || fn.status === 'implemented')
+  }));
+}
+
+function buildFunctionReferenceEntries(includePlanned = false) {
+  const libs = buildLibraryModel(includePlanned);
+  const entries = [];
+
+  for (const lib of libs) {
+    for (const fn of lib.functions) {
+      entries.push({
+        names: [fn.fullName],
+        label: fn.fullName,
+        signature: fn.signature,
+        description: fn.description,
+        example: undefined
+      });
+    }
+  }
+
+  return entries;
+}
+
+function getFunctionReferenceMap(includePlanned = false) {
+  const entries = buildFunctionReferenceEntries(includePlanned);
+  const map = new Map();
+  for (const entry of entries) {
+    for (const name of entry.names) {
+      map.set(name, entry);
+    }
+  }
+  return map;
+}
+
+module.exports = {
+  buildLibraryModel,
+  buildFunctionReferenceEntries,
+  getFunctionReferenceMap
+};

--- a/extensions/vscode-loomlet/src/library-reference.js
+++ b/extensions/vscode-loomlet/src/library-reference.js
@@ -1,69 +1,79 @@
+const { buildFunctionReferenceEntries } = require('./library-metadata-model.js');
+
 const PREVIEW_HOST_NOTE = 'Currently supported by the VS Code Runtime Preview host. Other hosts may ignore or reject this until the capability is promoted into the shared runtime contract.';
 
-const LIBRARY_REFERENCE = [
+const MANUAL_OVERRIDES = [
   {
     names: ['clock'],
     label: 'clock',
-    signature: 'clock() -> number',
-    description: 'A time source. In the VS Code Runtime Preview, it advances with the preview animation time.',
-    example: 't = clock()'
+    override: {
+      description: 'A time source. In the VS Code Runtime Preview, it advances with the preview animation time.',
+      example: 't = clock()'
+    }
   },
   {
     names: ['sine', 'math.sine'],
     label: 'sine',
-    signature: 'sine(value, freq: number = 1, amplitude: number = 1) -> number',
-    description: 'Returns a sine wave for the input value. Use freq to control the speed and amplitude to control the range.',
-    example: 't = clock()\nwave = sine(t, freq: 0.8)'
+    override: {
+      example: 't = clock()\nwave = sine(t, freq: 0.8)'
+    }
   },
   {
     names: ['cosine', 'math.cosine'],
     label: 'cosine',
-    signature: 'cosine(value, freq: number = 1, amplitude: number = 1) -> number',
-    description: 'Returns a cosine wave for the input value. It is useful for circular and orbital motion when paired with sine.',
-    example: 't = clock()\nx = sine(t, freq: 0.4)\ny = cosine(t, freq: 0.4)'
+    override: {
+      example: 't = clock()\nx = sine(t, freq: 0.4)\ny = cosine(t, freq: 0.4)'
+    }
   },
   {
     names: ['map', 'math.map'],
     label: 'map',
-    signature: 'map(value, inMin, inMax, outMin, outMax) -> number',
-    description: 'Remaps a value from one numeric range to another. Commonly used to convert -1..1 waves into screen coordinates or sizes.',
-    example: 'width = map(wave, inMin: -1, inMax: 1, outMin: 40, outMax: 320)'
+    override: {
+      example: 'width = map(wave, inMin: -1, inMax: 1, outMin: 40, outMax: 320)'
+    }
   },
   {
     names: ['console.log'],
     label: 'console.log',
-    signature: 'console.log(value)',
-    description: 'Writes a value to the host output. In VS Code, values appear in View > Output > Loomlet.',
-    example: 'console.log(width)'
+    override: {
+      example: 'console.log(width)'
+    }
   },
   {
     names: ['input.mouseX', 'mouseX'],
     label: 'input.mouseX',
-    signature: 'input.mouseX() -> number',
-    description: `Returns the current mouse X coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
-    example: 'import input\nx = input.mouseX()\nrender point(x: x, y: 120, radius: 7)'
+    override: {
+      description: `Returns the current mouse X coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+      example: 'import input\nx = input.mouseX()\nrender point(x: x, y: 120, radius: 7)'
+    }
   },
   {
     names: ['input.mouseY', 'mouseY'],
     label: 'input.mouseY',
-    signature: 'input.mouseY() -> number',
-    description: `Returns the current mouse Y coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
-    example: 'import input\ny = input.mouseY()\nrender point(x: 120, y: y, radius: 7)'
+    override: {
+      description: `Returns the current mouse Y coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+      example: 'import input\ny = input.mouseY()\nrender point(x: 120, y: y, radius: 7)'
+    }
   },
   {
     names: ['input.mouseDown', 'mouseDown'],
     label: 'input.mouseDown',
-    signature: 'input.mouseDown() -> boolean',
-    description: `Returns true while the primary mouse button is pressed in the VS Code Runtime Preview. Use it with render point enabled to make simple drawing tools. ${PREVIEW_HOST_NOTE}`,
-    example: 'import input\nx = input.mouseX()\ny = input.mouseY()\ndown = input.mouseDown()\nrender point(x: x, y: y, enabled: down, trail: 0)'
+    override: {
+      description: `Returns true while the primary mouse button is pressed in the VS Code Runtime Preview. Use it with render point enabled to make simple drawing tools. ${PREVIEW_HOST_NOTE}`,
+      example: 'import input\nx = input.mouseX()\ny = input.mouseY()\ndown = input.mouseDown()\nrender point(x: x, y: y, enabled: down, trail: 0)'
+    }
   },
   {
     names: ['input.key', 'key'],
     label: 'input.key',
-    signature: 'input.key(code: string) -> boolean',
-    description: `Returns true while a key is pressed in the VS Code Runtime Preview. Use KeyboardEvent.code values such as "Space", "ArrowLeft", "ArrowRight", "ArrowUp", and "ArrowDown". ${PREVIEW_HOST_NOTE}`,
-    example: 'import input\nspace = input.key("Space")\nconsole.log(space)'
-  },
+    override: {
+      description: `Returns true while a key is pressed in the VS Code Runtime Preview. Use KeyboardEvent.code values such as "Space", "ArrowLeft", "ArrowRight", "ArrowUp", and "ArrowDown". ${PREVIEW_HOST_NOTE}`,
+      example: 'import input\nspace = input.key("Space")\nconsole.log(space)'
+    }
+  }
+];
+
+const EXTRA_ENTRIES = [
   {
     names: ['render bar', 'bar'],
     label: 'render bar',
@@ -86,6 +96,55 @@ const LIBRARY_REFERENCE = [
     example: 'import input\nspace = input.key("Space")\nleft = input.key("ArrowLeft")\nright = input.key("ArrowRight")\nup = input.key("ArrowUp")\ndown = input.key("ArrowDown")\nrender keys(space: space, left: left, right: right, up: up, down: down)'
   }
 ];
+
+function buildLibraryReference() {
+  const generatedEntries = buildFunctionReferenceEntries(false);
+
+  const overrideMap = new Map();
+  for (const override of MANUAL_OVERRIDES) {
+    for (const name of override.names) {
+      overrideMap.set(name, override);
+    }
+  }
+
+  const entries = [];
+  const seenNames = new Set();
+
+  for (const entry of generatedEntries) {
+    const primaryName = entry.names[0];
+    const overrideData = overrideMap.get(primaryName);
+
+    let finalEntry;
+    if (overrideData) {
+      finalEntry = {
+        names: overrideData.names,
+        label: overrideData.label,
+        signature: entry.signature,
+        description: overrideData.override.description !== undefined ? overrideData.override.description : entry.description,
+        example: overrideData.override.example
+      };
+    } else {
+      finalEntry = entry;
+    }
+
+    entries.push(finalEntry);
+
+    for (const name of finalEntry.names) {
+      seenNames.add(name);
+    }
+  }
+
+  for (const extraEntry of EXTRA_ENTRIES) {
+    entries.push(extraEntry);
+    for (const name of extraEntry.names) {
+      seenNames.add(name);
+    }
+  }
+
+  return entries;
+}
+
+const LIBRARY_REFERENCE = buildLibraryReference();
 
 const ALIAS_TO_REFERENCE = new Map();
 for (const entry of LIBRARY_REFERENCE) {

--- a/extensions/vscode-loomlet/src/library-reference.js
+++ b/extensions/vscode-loomlet/src/library-reference.js
@@ -2,15 +2,7 @@ const { buildFunctionReferenceEntries } = require('./library-metadata-model.js')
 
 const PREVIEW_HOST_NOTE = 'Currently supported by the VS Code Runtime Preview host. Other hosts may ignore or reject this until the capability is promoted into the shared runtime contract.';
 
-const MANUAL_OVERRIDES = [
-  {
-    names: ['clock'],
-    label: 'clock',
-    override: {
-      description: 'A time source. In the VS Code Runtime Preview, it advances with the preview animation time.',
-      example: 't = clock()'
-    }
-  },
+const METADATA_OVERRIDES = [
   {
     names: ['sine', 'math.sine'],
     label: 'sine',
@@ -38,42 +30,45 @@ const MANUAL_OVERRIDES = [
     override: {
       example: 'console.log(width)'
     }
-  },
-  {
-    names: ['input.mouseX', 'mouseX'],
-    label: 'input.mouseX',
-    override: {
-      description: `Returns the current mouse X coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
-      example: 'import input\nx = input.mouseX()\nrender point(x: x, y: 120, radius: 7)'
-    }
-  },
-  {
-    names: ['input.mouseY', 'mouseY'],
-    label: 'input.mouseY',
-    override: {
-      description: `Returns the current mouse Y coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
-      example: 'import input\ny = input.mouseY()\nrender point(x: 120, y: y, radius: 7)'
-    }
-  },
-  {
-    names: ['input.mouseDown', 'mouseDown'],
-    label: 'input.mouseDown',
-    override: {
-      description: `Returns true while the primary mouse button is pressed in the VS Code Runtime Preview. Use it with render point enabled to make simple drawing tools. ${PREVIEW_HOST_NOTE}`,
-      example: 'import input\nx = input.mouseX()\ny = input.mouseY()\ndown = input.mouseDown()\nrender point(x: x, y: y, enabled: down, trail: 0)'
-    }
-  },
-  {
-    names: ['input.key', 'key'],
-    label: 'input.key',
-    override: {
-      description: `Returns true while a key is pressed in the VS Code Runtime Preview. Use KeyboardEvent.code values such as "Space", "ArrowLeft", "ArrowRight", "ArrowUp", and "ArrowDown". ${PREVIEW_HOST_NOTE}`,
-      example: 'import input\nspace = input.key("Space")\nconsole.log(space)'
-    }
   }
 ];
 
 const EXTRA_ENTRIES = [
+  {
+    names: ['clock'],
+    label: 'clock',
+    signature: 'clock() -> number',
+    description: 'A time source. In the VS Code Runtime Preview, it advances with the preview animation time.',
+    example: 't = clock()'
+  },
+  {
+    names: ['input.mouseX', 'mouseX'],
+    label: 'input.mouseX',
+    signature: 'input.mouseX() -> number',
+    description: `Returns the current mouse X coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nx = input.mouseX()\nrender point(x: x, y: 120, radius: 7)'
+  },
+  {
+    names: ['input.mouseY', 'mouseY'],
+    label: 'input.mouseY',
+    signature: 'input.mouseY() -> number',
+    description: `Returns the current mouse Y coordinate in the VS Code Runtime Preview canvas. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\ny = input.mouseY()\nrender point(x: 120, y: y, radius: 7)'
+  },
+  {
+    names: ['input.mouseDown', 'mouseDown'],
+    label: 'input.mouseDown',
+    signature: 'input.mouseDown() -> boolean',
+    description: `Returns true while the primary mouse button is pressed in the VS Code Runtime Preview. Use it with render point enabled to make simple drawing tools. ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nx = input.mouseX()\ny = input.mouseY()\ndown = input.mouseDown()\nrender point(x: x, y: y, enabled: down, trail: 0)'
+  },
+  {
+    names: ['input.key', 'key'],
+    label: 'input.key',
+    signature: 'input.key(code: string) -> boolean',
+    description: `Returns true while a key is pressed in the VS Code Runtime Preview. Use KeyboardEvent.code values such as "Space", "ArrowLeft", "ArrowRight", "ArrowUp", and "ArrowDown". ${PREVIEW_HOST_NOTE}`,
+    example: 'import input\nspace = input.key("Space")\nconsole.log(space)'
+  },
   {
     names: ['render bar', 'bar'],
     label: 'render bar',
@@ -101,7 +96,7 @@ function buildLibraryReference() {
   const generatedEntries = buildFunctionReferenceEntries(false);
 
   const overrideMap = new Map();
-  for (const override of MANUAL_OVERRIDES) {
+  for (const override of METADATA_OVERRIDES) {
     for (const name of override.names) {
       overrideMap.set(name, override);
     }
@@ -109,6 +104,16 @@ function buildLibraryReference() {
 
   const entries = [];
   const seenNames = new Set();
+
+  function addEntry(entry) {
+    for (const name of entry.names) {
+      if (seenNames.has(name)) {
+        throw new Error(`Duplicate name in library reference: ${name}`);
+      }
+      seenNames.add(name);
+    }
+    entries.push(entry);
+  }
 
   for (const entry of generatedEntries) {
     const primaryName = entry.names[0];
@@ -127,18 +132,11 @@ function buildLibraryReference() {
       finalEntry = entry;
     }
 
-    entries.push(finalEntry);
-
-    for (const name of finalEntry.names) {
-      seenNames.add(name);
-    }
+    addEntry(finalEntry);
   }
 
   for (const extraEntry of EXTRA_ENTRIES) {
-    entries.push(extraEntry);
-    for (const name of extraEntry.names) {
-      seenNames.add(name);
-    }
+    addEntry(extraEntry);
   }
 
   return entries;

--- a/extensions/vscode-loomlet/test/library-reference.test.mjs
+++ b/extensions/vscode-loomlet/test/library-reference.test.mjs
@@ -1,24 +1,99 @@
+import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const { LIBRARY_REFERENCE, getLibraryReference } = require('../src/library-reference.js');
+const { buildFunctionReferenceEntries } = require('../src/library-metadata-model.js');
 
-assert.ok(Array.isArray(LIBRARY_REFERENCE), 'LIBRARY_REFERENCE should be an array');
-assert.ok(LIBRARY_REFERENCE.length > 0, 'Expected library reference entries');
+test('LIBRARY_REFERENCE is a non-empty array', () => {
+  assert.ok(Array.isArray(LIBRARY_REFERENCE), 'LIBRARY_REFERENCE should be an array');
+  assert.ok(LIBRARY_REFERENCE.length > 0, 'Expected library reference entries');
+});
 
-for (const entry of LIBRARY_REFERENCE) {
-  assert.ok(entry.label, 'Reference entry should have a label');
-  assert.ok(entry.signature, `${entry.label} should have a signature`);
-  assert.ok(entry.description, `${entry.label} should have a description`);
-  assert.ok(Array.isArray(entry.names), `${entry.label} should have names`);
-  assert.ok(entry.names.length > 0, `${entry.label} should have at least one name`);
-
-  for (const name of entry.names) {
-    assert.equal(getLibraryReference(name), entry, `${name} should resolve to its reference entry`);
+test('each reference entry has required fields', () => {
+  for (const entry of LIBRARY_REFERENCE) {
+    assert.ok(entry.label, 'Reference entry should have a label');
+    assert.ok(entry.signature, `${entry.label} should have a signature`);
+    assert.ok(entry.description, `${entry.label} should have a description`);
+    assert.ok(Array.isArray(entry.names), `${entry.label} should have names`);
+    assert.ok(entry.names.length > 0, `${entry.label} should have at least one name`);
   }
-}
+});
 
-assert.equal(getLibraryReference('__missing__'), null, 'missing reference should return null');
+test('each name resolves to its reference entry', () => {
+  for (const entry of LIBRARY_REFERENCE) {
+    for (const name of entry.names) {
+      assert.equal(getLibraryReference(name), entry, `${name} should resolve to its reference entry`);
+    }
+  }
+});
 
-console.log('All library reference tests passed!');
+test('LIBRARY_REFERENCE has no duplicate names', () => {
+  const allNames = new Set();
+  for (const entry of LIBRARY_REFERENCE) {
+    for (const name of entry.names) {
+      assert.ok(!allNames.has(name), `Duplicate name: ${name}`);
+      allNames.add(name);
+    }
+  }
+});
+
+test('missing references return null', () => {
+  assert.equal(getLibraryReference('__missing__'), null, 'missing reference should return null');
+});
+
+test('getLibraryReference returns generated metadata for math.add', () => {
+  const ref = getLibraryReference('math.add');
+  assert.ok(ref, 'math.add should have a reference');
+  assert.ok(ref.signature.includes('add'), 'signature should include add');
+  assert.ok(ref.description, 'description should be present');
+});
+
+test('getLibraryReference returns generated metadata for scene.setPosition', () => {
+  const ref = getLibraryReference('scene.setPosition');
+  assert.ok(ref, 'scene.setPosition should have a reference');
+  assert.ok(ref.signature.includes('setPosition'), 'signature should include setPosition');
+  assert.ok(ref.description, 'description should be present');
+});
+
+test('getLibraryReference returns override entry for console.log', () => {
+  const ref = getLibraryReference('console.log');
+  assert.ok(ref, 'console.log should have a reference');
+  assert.equal(ref.label, 'console.log', 'label should be console.log');
+  assert.ok(ref.example, 'console.log should have an example from override');
+});
+
+test('getLibraryReference works for render point', () => {
+  const ref = getLibraryReference('render point');
+  assert.ok(ref, 'render point should have a reference');
+  assert.equal(ref.label, 'render point', 'label should be render point');
+  assert.ok(ref.example, 'render point should have an example');
+});
+
+test('getLibraryReference works for render point alias', () => {
+  const ref = getLibraryReference('point');
+  assert.ok(ref, 'point alias should have a reference');
+  assert.equal(ref.label, 'render point', 'label should be render point');
+});
+
+test('getLibraryReference works for math.sine with alias', () => {
+  const refFull = getLibraryReference('math.sine');
+  const refAlias = getLibraryReference('sine');
+  assert.ok(refFull, 'math.sine should have a reference');
+  assert.ok(refAlias, 'sine alias should have a reference');
+  assert.equal(refFull, refAlias, 'both names should resolve to the same entry');
+});
+
+test('planned functions are excluded by default', () => {
+  const generatedDefault = buildFunctionReferenceEntries(false);
+  const generatedPlanned = buildFunctionReferenceEntries(true);
+
+  // Check that includePlanned produces at least as many entries
+  assert.ok(generatedPlanned.length >= generatedDefault.length, 'includePlanned should include at least as many items');
+
+  // Check for a known implemented library exists in both
+  const hasTextDefault = generatedDefault.some(e => e.names.some(n => n.includes('text.')));
+  const hasTextPlanned = generatedPlanned.some(e => e.names.some(n => n.includes('text.')));
+  assert.ok(hasTextDefault && hasTextPlanned, 'implemented libraries should appear in both');
+});

--- a/extensions/vscode-loomlet/test/library-reference.test.mjs
+++ b/extensions/vscode-loomlet/test/library-reference.test.mjs
@@ -85,14 +85,70 @@ test('getLibraryReference works for math.sine with alias', () => {
   assert.equal(refFull, refAlias, 'both names should resolve to the same entry');
 });
 
+test('manual-only entry: clock is available', () => {
+  const ref = getLibraryReference('clock');
+  assert.ok(ref, 'clock should have a reference');
+  assert.equal(ref.label, 'clock', 'clock label should be clock');
+  assert.equal(ref.signature, 'clock() -> number', 'clock should have correct signature');
+  assert.ok(ref.example, 'clock should have an example');
+});
+
+test('manual-only entry: input.mouseX is available', () => {
+  const ref = getLibraryReference('input.mouseX');
+  assert.ok(ref, 'input.mouseX should have a reference');
+  assert.equal(ref.label, 'input.mouseX', 'label should be input.mouseX');
+  assert.ok(ref.example, 'should have an example');
+});
+
+test('manual-only entry: mouseX alias works', () => {
+  const refFull = getLibraryReference('input.mouseX');
+  const refAlias = getLibraryReference('mouseX');
+  assert.ok(refFull && refAlias, 'both should resolve');
+  assert.equal(refFull, refAlias, 'both names should resolve to the same entry');
+});
+
+test('manual-only entry: input.mouseY is available', () => {
+  const ref = getLibraryReference('input.mouseY');
+  assert.ok(ref, 'input.mouseY should have a reference');
+});
+
+test('manual-only entry: mouseY alias works', () => {
+  const refFull = getLibraryReference('input.mouseY');
+  const refAlias = getLibraryReference('mouseY');
+  assert.ok(refFull && refAlias, 'both should resolve');
+  assert.equal(refFull, refAlias, 'both names should resolve to the same entry');
+});
+
+test('manual-only entry: input.mouseDown is available', () => {
+  const ref = getLibraryReference('input.mouseDown');
+  assert.ok(ref, 'input.mouseDown should have a reference');
+});
+
+test('manual-only entry: mouseDown alias works', () => {
+  const refFull = getLibraryReference('input.mouseDown');
+  const refAlias = getLibraryReference('mouseDown');
+  assert.ok(refFull && refAlias, 'both should resolve');
+  assert.equal(refFull, refAlias, 'both names should resolve to the same entry');
+});
+
+test('manual-only entry: input.key is available', () => {
+  const ref = getLibraryReference('input.key');
+  assert.ok(ref, 'input.key should have a reference');
+});
+
+test('manual-only entry: key alias works', () => {
+  const refFull = getLibraryReference('input.key');
+  const refAlias = getLibraryReference('key');
+  assert.ok(refFull && refAlias, 'both should resolve');
+  assert.equal(refFull, refAlias, 'both names should resolve to the same entry');
+});
+
 test('planned functions are excluded by default', () => {
   const generatedDefault = buildFunctionReferenceEntries(false);
   const generatedPlanned = buildFunctionReferenceEntries(true);
 
-  // Check that includePlanned produces at least as many entries
   assert.ok(generatedPlanned.length >= generatedDefault.length, 'includePlanned should include at least as many items');
 
-  // Check for a known implemented library exists in both
   const hasTextDefault = generatedDefault.some(e => e.names.some(n => n.includes('text.')));
   const hasTextPlanned = generatedPlanned.some(e => e.names.some(n => n.includes('text.')));
   assert.ok(hasTextDefault && hasTextPlanned, 'implemented libraries should appear in both');


### PR DESCRIPTION
- Create library-metadata-model.js helper module that loads generated
  metadata and builds reference entries compatible with hover/reference code
- Refactor completion-engine.js to use shared buildLibraryModel() helper
- Refactor library-reference.js to use generated entries with manual overrides
  for examples, aliases, render syntax, and preview-host-specific notes
- Add comprehensive tests for library-reference functionality
- Update STABILIZATION_ROADMAP.md to note that VS Code completion, hover,
  and library reference now share generated library metadata as default source

Completion and reference now use the same generated metadata model, with
manual overrides only for non-standard entries and preview-specific features.

https://claude.ai/code/session_01XQbw1V8drJG7bsSj5r6tgi