### PR TITLE
docs: add release readiness notes for 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Search for `Loomlet` in the VS Code Marketplace.
 - [設計ノート（日本語）](docs/concepts.ja.md)
 - [Scene Sync integration](docs/scene-sync.md)
 - [Release and maintainer notes](docs/RELEASE.md)
+- [Standard library reference](docs/STANDARD_LIBRARY_REFERENCE.md)
+- [Runtime node registration](docs/RUNTIME_NODE_REGISTRATION.md)
+- [Runtime parity fixtures](docs/RUNTIME_PARITY_FIXTURES.md)
+- [Unity runtime compatibility](docs/UNITY_RUNTIME_COMPATIBILITY.md)
+
+Generated metadata and reference docs can be refreshed with `npm run generate:metadata`.
 
 ## License
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,5 +1,54 @@
 # Release artifacts and maintainer notes
 
+## Pre-release checklist
+
+Before cutting a release:
+
+1. Refresh generated metadata and docs.
+
+   ```bash
+   npm run generate:metadata
+   ```
+
+2. Run unit tests.
+
+   ```bash
+   npm test
+   ```
+
+3. Run package dry-run.
+
+   ```bash
+   npm run pack:dry-run
+   ```
+
+4. Optionally build the VS Code extension package.
+
+   ```bash
+   npm run pack:vscode
+   ```
+
+5. Review release notes draft.
+
+6. Bump versions only in the release PR.
+
+## Generated files
+
+The following files are generated from shared metadata and should be committed when changed:
+
+- `extensions/vscode-loomlet/generated/library-metadata.json`
+- `docs/STANDARD_LIBRARY_REFERENCE.md`
+
+Run:
+
+```bash
+npm run generate:metadata
+```
+
+Freshness tests fail if these files are stale.
+
+## Release artifacts and build workflows
+
 GitHub release/build workflows:
 
 - `.github/workflows/release-artifacts.yml`

--- a/docs/RELEASE_NOTES_DRAFT.md
+++ b/docs/RELEASE_NOTES_DRAFT.md
@@ -1,0 +1,26 @@
+# Release Notes Draft
+
+## Next release: 0.1.2
+
+Tentative theme:
+
+Package, metadata, documentation, and runtime compatibility groundwork.
+
+## Highlights
+
+- Runtime node registration API groundwork
+- Trusted local package registration flow
+- Package metadata registry
+- Package import validation with custom node/metadata registries
+- VS Code completion, hover, and library reference now use shared generated metadata
+- Standard library reference docs are generated from shared metadata
+- Generated VS Code metadata and docs are freshness-tested
+- Unity runtime compatibility baseline documented
+- Portable runtime parity fixtures added for future runtime reuse
+
+## Notes
+
+This release does not mean the Unity/C# runtime is implemented.
+It establishes compatibility baseline and reusable fixtures for future implementation.
+
+Remote/npm package loading remains future work.


### PR DESCRIPTION
- Update README with links to generated metadata and runtime compatibility docs
- Expand RELEASE.md with pre-release checklist and generated files guidance
- Add RELEASE_NOTES_DRAFT.md documenting 0.1.2 themes and highlights

No version bump, no runtime changes, docs-only.

https://claude.ai/code/session_012YV6MVEtCtZHZMTYAmGXa5