### PR TITLE
Make REPL help registry-aware

### DIFF
--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -1963,7 +1963,7 @@ async function handleRepl(args) {
         return;
       }
       if (trimmed === ':libs') {
-        print(formatLibrariesText());
+        print(session.listLibraries());
         rl.prompt();
         return;
       }
@@ -2005,9 +2005,9 @@ async function handleRepl(args) {
         const query = trimmed.slice(6).trim();
         try {
           if (query.includes('.')) {
-            print(formatFunctionHelpText(query));
+            print(session.getFunctionHelp(query));
           } else {
-            print(formatLibraryHelpText(query));
+            print(session.getLibraryHelp(query));
           }
         } catch (error) {
           if (error.code === 'UNKNOWN_LIBRARY') {

--- a/docs/labs/PACKAGE_SYSTEM.md
+++ b/docs/labs/PACKAGE_SYSTEM.md
@@ -199,6 +199,46 @@ loom.evaluateOnce();
 
 The `nodeRegistry` option can be passed to both the DSL compiler and runtime to enable package nodes.
 
+## REPL Help with Package Metadata
+
+When a host creates both a node registry and a metadata registry and passes them to `LoomReplSession`, REPL evaluation, import validation, and help all use the same package-aware view:
+
+```js
+import { LoomReplSession } from '../../src/toolchain/repl-session.js';
+import { createNodeRegistry } from '../../src/runtime/node-registry.js';
+import { createLibraryMetadataRegistry } from '../../src/toolchain/metadata-registry.js';
+import { registerBuiltinNodes } from '../../src/nodes/index.js';
+import { registerTrustedPackage } from '../../src/runtime/package-registration.js';
+import * as demoPackage from '../../examples/packages/demo/index.js';
+
+const nodeRegistry = createNodeRegistry();
+const metadataRegistry = createLibraryMetadataRegistry();
+
+registerBuiltinNodes(nodeRegistry);
+registerTrustedPackage(nodeRegistry, demoPackage, { metadataRegistry });
+
+const session = new LoomReplSession({
+  target: 'cli',
+  nodeRegistry,
+  metadataRegistry
+});
+
+// Import and evaluate demo nodes
+session.evaluateSnippet('import demo');
+session.evaluateSnippet('x = demo.double(value: 5)');
+
+// Help functions use the same metadata
+console.log(session.listLibraries()); // Shows 'demo'
+console.log(session.getLibraryHelp('demo')); // Shows demo library docs
+console.log(session.getFunctionHelp('demo.double')); // Shows demo.double docs
+```
+
+The default CLI still shows builtin metadata until a package-loading UX is added. REPL help methods pass the `metadataRegistry` option to formatting functions, enabling custom package metadata to appear in:
+
+- `:libs` command
+- `:help <library>` command
+- `:help <lib.func>` command
+
 ## Example
 
 See `examples/packages/demo/` for a working example with two nodes:

--- a/docs/labs/PACKAGE_SYSTEM.md
+++ b/docs/labs/PACKAGE_SYSTEM.md
@@ -199,9 +199,13 @@ loom.evaluateOnce();
 
 The `nodeRegistry` option can be passed to both the DSL compiler and runtime to enable package nodes.
 
-## REPL Help with Package Metadata
+## REPL Session with Package Registries
 
-When a host creates both a node registry and a metadata registry and passes them to `LoomReplSession`, REPL evaluation, import validation, and help all use the same package-aware view:
+When a host creates both a node registry and a metadata registry and passes them to `LoomReplSession`, REPL evaluation, import validation, and help all use the same package-aware view. This enables:
+
+- **Evaluation**: Custom package nodes execute through `evaluateSnippet()`
+- **Import validation**: Imports are validated against the metadata registry
+- **Help**: Package metadata appears in `:libs`, `:help <library>`, and `:help <lib.func>`
 
 ```js
 import { LoomReplSession } from '../../src/toolchain/repl-session.js';

--- a/src/toolchain/help.js
+++ b/src/toolchain/help.js
@@ -8,19 +8,36 @@ export class HelpError extends Error {
   }
 }
 
-export function listLibraries() {
-  return getAllLibraries();
+function getMetadataObject(options = {}) {
+  if (options.metadataRegistry) {
+    return options.metadataRegistry.toObject();
+  }
+  if (options.metadata) {
+    return options.metadata;
+  }
+  return LIBRARY_METADATA;
 }
 
-export function getLibraryHelp(name) {
-  const lib = LIBRARY_METADATA[name];
+function getLibraryList(metadataObj) {
+  const libNames = Object.keys(metadataObj);
+  return libNames.sort();
+}
+
+export function listLibraries(options = {}) {
+  const metadataObj = getMetadataObject(options);
+  return getLibraryList(metadataObj);
+}
+
+export function getLibraryHelp(name, options = {}) {
+  const metadataObj = getMetadataObject(options);
+  const lib = metadataObj[name];
   if (!lib) {
     throw new HelpError('UNKNOWN_LIBRARY', `No Loomlet library named "${name}"`);
   }
   return lib;
 }
 
-export function getFunctionHelp(qualifiedName) {
+export function getFunctionHelp(qualifiedName, options = {}) {
   const parts = qualifiedName.split('.');
 
   if (parts.length !== 2 || !parts[0] || !parts[1]) {
@@ -29,7 +46,8 @@ export function getFunctionHelp(qualifiedName) {
 
   const [libName, funcName] = parts;
 
-  const lib = LIBRARY_METADATA[libName];
+  const metadataObj = getMetadataObject(options);
+  const lib = metadataObj[libName];
   if (!lib) {
     throw new HelpError('UNKNOWN_LIBRARY', `No Loomlet library named "${libName}"`);
   }
@@ -42,12 +60,13 @@ export function getFunctionHelp(qualifiedName) {
   return func;
 }
 
-export function formatLibrariesText() {
-  const libs = listLibraries();
+export function formatLibrariesText(options = {}) {
+  const metadataObj = getMetadataObject(options);
+  const libs = getLibraryList(metadataObj);
   const lines = ['Loomlet libraries:', ''];
 
   for (const libName of libs) {
-    const lib = LIBRARY_METADATA[libName];
+    const lib = metadataObj[libName];
     const status = lib.status ? ` (${lib.status})` : '';
     const funcCount = Object.keys(lib.functions).length;
     const funcInfo = funcCount > 0 ? ` - ${funcCount} function${funcCount !== 1 ? 's' : ''}` : '';
@@ -62,8 +81,8 @@ export function formatLibrariesText() {
   return lines.join('\n');
 }
 
-export function formatLibraryHelpText(name) {
-  const lib = getLibraryHelp(name);
+export function formatLibraryHelpText(name, options = {}) {
+  const lib = getLibraryHelp(name, options);
   const lines = [lib.name, '', lib.description, ''];
 
   if (lib.status) {
@@ -84,8 +103,8 @@ export function formatLibraryHelpText(name) {
   return lines.join('\n');
 }
 
-export function formatFunctionHelpText(qualifiedName) {
-  const func = getFunctionHelp(qualifiedName);
+export function formatFunctionHelpText(qualifiedName, options = {}) {
+  const func = getFunctionHelp(qualifiedName, options);
   const lines = [func.signature, '', func.description, ''];
 
   if (func.args && func.args.length > 0) {
@@ -123,13 +142,15 @@ export function formatFunctionHelpText(qualifiedName) {
   return lines.join('\n');
 }
 
-export function formatHelpJson(query) {
+export function formatHelpJson(query, options = {}) {
+  const metadataObj = getMetadataObject(options);
+
   if (!query) {
-    const libs = listLibraries();
+    const libs = getLibraryList(metadataObj);
     return {
       type: 'libraries',
       libraries: libs.map(name => {
-        const lib = LIBRARY_METADATA[name];
+        const lib = metadataObj[name];
         return {
           name: lib.name,
           description: lib.description,
@@ -144,7 +165,7 @@ export function formatHelpJson(query) {
   const parts = query.split('.');
 
   if (parts.length === 1) {
-    const lib = getLibraryHelp(parts[0]);
+    const lib = getLibraryHelp(parts[0], { metadata: metadataObj });
     return {
       type: 'library',
       library: {
@@ -165,7 +186,7 @@ export function formatHelpJson(query) {
   }
 
   if (parts.length === 2) {
-    const func = getFunctionHelp(query);
+    const func = getFunctionHelp(query, { metadata: metadataObj });
     return {
       type: 'function',
       function: {

--- a/src/toolchain/repl-session.js
+++ b/src/toolchain/repl-session.js
@@ -1,6 +1,11 @@
 import { inspectLoomSource } from './inspect.js';
 import { runLoomSource } from './run.js';
 import { RUNTIME_TARGETS } from './runtime-targets.js';
+import {
+  formatLibrariesText,
+  formatLibraryHelpText,
+  formatFunctionHelpText
+} from './help.js';
 
 function createEmptySummary() {
   return {
@@ -60,6 +65,8 @@ export class LoomReplSession {
     this.target = options.target || 'cli';
     this.time = Number.isFinite(options.time) ? options.time : 0;
     this.dt = Number.isFinite(options.dt) ? options.dt : 0;
+    this.nodeRegistry = options.nodeRegistry || null;
+    this.metadataRegistry = options.metadataRegistry || null;
     this.sourceLines = [];
     this.source = '';
     this.graph = null;
@@ -89,7 +96,9 @@ export class LoomReplSession {
     const result = runLoomSource(nextSource, {
       target: this.target,
       time: this.time,
-      dt: this.dt
+      dt: this.dt,
+      nodeRegistry: this.nodeRegistry,
+      metadataRegistry: this.metadataRegistry
     });
 
     if (!result.ok) {
@@ -156,7 +165,11 @@ export class LoomReplSession {
         errors: []
       };
     }
-    return inspectLoomSource(this.source, { target: this.target });
+    return inspectLoomSource(this.source, {
+      target: this.target,
+      nodeRegistry: this.nodeRegistry,
+      metadataRegistry: this.metadataRegistry
+    });
   }
 
   getGraph() {
@@ -175,7 +188,9 @@ export class LoomReplSession {
     return runLoomSource(String(source ?? ''), {
       target: this.target,
       time: this.time,
-      dt: this.dt
+      dt: this.dt,
+      nodeRegistry: this.nodeRegistry,
+      metadataRegistry: this.metadataRegistry
     });
   }
 
@@ -189,5 +204,17 @@ export class LoomReplSession {
     }
     variables.sort((a, b) => a.name.localeCompare(b.name));
     return variables;
+  }
+
+  listLibraries() {
+    return formatLibrariesText({ metadataRegistry: this.metadataRegistry });
+  }
+
+  getLibraryHelp(name) {
+    return formatLibraryHelpText(name, { metadataRegistry: this.metadataRegistry });
+  }
+
+  getFunctionHelp(qualifiedName) {
+    return formatFunctionHelpText(qualifiedName, { metadataRegistry: this.metadataRegistry });
   }
 }

--- a/src/toolchain/run.js
+++ b/src/toolchain/run.js
@@ -9,6 +9,16 @@ function isCliSafeSink(nodeTypeName) {
     || nodeTypeName === 'scene.setPosition' || nodeTypeName === 'scene.setRotation' || nodeTypeName === 'scene.setScale';
 }
 
+function getNodeTypes(options = {}) {
+  if (options.nodeRegistry && typeof options.nodeRegistry.toObject === 'function') {
+    return options.nodeRegistry.toObject();
+  }
+  if (options.nodeTypes && typeof options.nodeTypes === 'object') {
+    return options.nodeTypes;
+  }
+  return NODE_TYPES;
+}
+
 function getRefsToRead(graph, get) {
   if (Array.isArray(get)) {
     return get;
@@ -19,8 +29,8 @@ function getRefsToRead(graph, get) {
   return null;
 }
 
-function getDefaultOutputPort(node) {
-  const nodeType = NODE_TYPES[node.type];
+function getDefaultOutputPort(node, nodeTypes) {
+  const nodeType = nodeTypes[node.type];
   if (!nodeType || !Array.isArray(nodeType.outputs) || nodeType.outputs.length === 0) {
     return null;
   }
@@ -31,9 +41,9 @@ function getDefaultOutputPort(node) {
   return outPort ? outPort.name : nodeType.outputs[0].name;
 }
 
-function validateCliRunnableGraph(graph) {
+function validateCliRunnableGraph(graph, nodeTypes) {
   for (const node of graph.nodes) {
-    const nodeType = NODE_TYPES[node.type];
+    const nodeType = nodeTypes[node.type];
     if (!nodeType) {
       throw new LoomError('UNKNOWN_NODE_TYPE', `Unknown node type: ${node.type}`, { nodeId: node.id, type: node.type });
     }
@@ -47,12 +57,12 @@ function validateCliRunnableGraph(graph) {
   }
 }
 
-function collectRequestedValues(engine, graph, get) {
+function collectRequestedValues(engine, graph, get, nodeTypes) {
   const requestedRefs = getRefsToRead(graph, get);
   if (requestedRefs === null) {
     const values = {};
     for (const node of graph.nodes) {
-      const nodeType = NODE_TYPES[node.type];
+      const nodeType = nodeTypes[node.type];
       if (!nodeType || !Array.isArray(nodeType.outputs)) {
         continue;
       }
@@ -72,8 +82,12 @@ function collectRequestedValues(engine, graph, get) {
 
 export function runLoomGraph(graph, options = {}) {
   try {
-    validateCliRunnableGraph(graph);
-    const engine = new Loom(graph);
+    const nodeTypes = getNodeTypes(options);
+    validateCliRunnableGraph(graph, nodeTypes);
+    const engine = new Loom(graph, {
+      nodeRegistry: options.nodeRegistry,
+      nodeTypes: options.nodeTypes
+    });
     engine.evaluateOnce({
       time: Number.isFinite(options.time) ? options.time : 0,
       dt: Number.isFinite(options.dt) ? options.dt : 0
@@ -81,7 +95,7 @@ export function runLoomGraph(graph, options = {}) {
 
     return {
       ok: true,
-      values: collectRequestedValues(engine, graph, options.get),
+      values: collectRequestedValues(engine, graph, options.get, nodeTypes),
       effects: engine.getEffects(),
       graph,
       errors: []

--- a/test/help.test.mjs
+++ b/test/help.test.mjs
@@ -269,3 +269,206 @@ test('planned library has empty functions', () => {
   assert.equal(Object.keys(fsLib.functions).length, 0);
   assert.equal(fsLib.status, 'planned');
 });
+
+test('formatLibrariesText with metadata option includes custom metadata', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      status: 'implemented',
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const text = formatLibrariesText({ metadata });
+  assert.ok(text.includes('demo'));
+  assert.ok(text.includes('Demo package nodes'));
+});
+
+test('formatLibraryHelpText with metadata option includes custom library', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const text = formatLibraryHelpText('demo', { metadata });
+  assert.ok(text.includes('demo'));
+  assert.ok(text.includes('demo.double'));
+  assert.ok(text.includes('Demo package nodes'));
+});
+
+test('formatFunctionHelpText with metadata option includes custom function', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const text = formatFunctionHelpText('demo.double', { metadata });
+  assert.ok(text.includes('demo.double(x)'));
+  assert.ok(text.includes('Doubles a number'));
+  assert.ok(text.includes('x: number'));
+  assert.ok(text.includes('Input value'));
+  assert.ok(text.includes('Returns:'));
+  assert.ok(text.includes('number'));
+  assert.ok(text.includes('Example:'));
+  assert.ok(text.includes('y = demo.double(21)'));
+});
+
+test('formatHelpJson with metadata option includes custom libraries', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const json = formatHelpJson(null, { metadata });
+  assert.equal(json.type, 'libraries');
+  assert.ok(json.libraries.some(lib => lib.name === 'demo'));
+});
+
+test('formatHelpJson with metadata option and library query', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const json = formatHelpJson('demo', { metadata });
+  assert.equal(json.type, 'library');
+  assert.equal(json.library.name, 'demo');
+  assert.ok(json.library.functions.some(f => f.name === 'double'));
+});
+
+test('formatHelpJson with metadata option and function query', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const json = formatHelpJson('demo.double', { metadata });
+  assert.equal(json.type, 'function');
+  assert.equal(json.function.name, 'double');
+  assert.equal(json.function.signature, 'demo.double(x)');
+  assert.ok(json.function.args.some(a => a.name === 'x'));
+});

--- a/test/loom-repl-session.test.mjs
+++ b/test/loom-repl-session.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { LoomReplSession } from '../src/toolchain/repl-session.js';
+import { createLibraryMetadataRegistry } from '../src/toolchain/metadata-registry.js';
 
 test('evaluates assignment snippet', () => {
   const session = new LoomReplSession();
@@ -174,4 +175,134 @@ test('load source persists, run source is isolated', async () => {
   assert.equal(runResult.ok, true);
   const after = session.evaluateSnippet('double(base)');
   assert.equal(after.ok, false);
+});
+
+test('session has help methods', () => {
+  const session = new LoomReplSession();
+  assert.equal(typeof session.listLibraries, 'function');
+  assert.equal(typeof session.getLibraryHelp, 'function');
+  assert.equal(typeof session.getFunctionHelp, 'function');
+});
+
+test('session listLibraries returns library names', () => {
+  const session = new LoomReplSession();
+  const libs = session.listLibraries();
+  assert.ok(libs.includes('Loomlet libraries'));
+  assert.ok(libs.includes('text'));
+  assert.ok(libs.includes('loomlet docs'));
+});
+
+test('session getLibraryHelp returns library text', () => {
+  const session = new LoomReplSession();
+  const help = session.getLibraryHelp('text');
+  assert.ok(help.includes('text'));
+  assert.ok(help.includes('text.upper'));
+});
+
+test('session getFunctionHelp returns function text', () => {
+  const session = new LoomReplSession();
+  const help = session.getFunctionHelp('text.upper');
+  assert.ok(help.includes('text.upper(value)'));
+  assert.ok(help.includes('uppercase'));
+});
+
+test('session with metadataRegistry includes custom library in listLibraries', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const registry = createLibraryMetadataRegistry(metadata);
+  const session = new LoomReplSession({ metadataRegistry: registry });
+  const libs = session.listLibraries();
+  assert.ok(libs.includes('demo'));
+});
+
+test('session with metadataRegistry includes custom library in getLibraryHelp', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const registry = createLibraryMetadataRegistry(metadata);
+  const session = new LoomReplSession({ metadataRegistry: registry });
+  const help = session.getLibraryHelp('demo');
+  assert.ok(help.includes('demo'));
+  assert.ok(help.includes('demo.double'));
+});
+
+test('session with metadataRegistry includes custom function in getFunctionHelp', () => {
+  const metadata = {
+    demo: {
+      name: 'demo',
+      description: 'Demo package nodes.',
+      targets: ['cli'],
+      functions: {
+        double: {
+          name: 'double',
+          signature: 'demo.double(x)',
+          description: 'Doubles a number.',
+          args: [
+            {
+              name: 'x',
+              type: 'number',
+              positional: true,
+              description: 'Input value.'
+            }
+          ],
+          returns: 'number',
+          targets: ['cli'],
+          examples: ['y = demo.double(21)']
+        }
+      }
+    }
+  };
+
+  const registry = createLibraryMetadataRegistry(metadata);
+  const session = new LoomReplSession({ metadataRegistry: registry });
+  const help = session.getFunctionHelp('demo.double');
+  assert.ok(help.includes('demo.double(x)'));
+  assert.ok(help.includes('Doubles a number'));
 });

--- a/test/loom-repl-session.test.mjs
+++ b/test/loom-repl-session.test.mjs
@@ -3,6 +3,9 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { LoomReplSession } from '../src/toolchain/repl-session.js';
 import { createLibraryMetadataRegistry } from '../src/toolchain/metadata-registry.js';
+import { createNodeRegistry } from '../src/runtime/node-registry.js';
+import { registerBuiltinNodes } from '../src/nodes/index.js';
+import { registerTrustedPackage } from '../src/runtime/package-registration.js';
 
 test('evaluates assignment snippet', () => {
   const session = new LoomReplSession();
@@ -305,4 +308,36 @@ test('session with metadataRegistry includes custom function in getFunctionHelp'
   const help = session.getFunctionHelp('demo.double');
   assert.ok(help.includes('demo.double(x)'));
   assert.ok(help.includes('Doubles a number'));
+});
+
+test('REPL session with custom nodeRegistry can execute package nodes', async () => {
+  const demoPackage = await import('../examples/packages/demo/index.js');
+
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+  registerTrustedPackage(nodeRegistry, demoPackage, { metadataRegistry });
+
+  const session = new LoomReplSession({
+    target: 'cli',
+    nodeRegistry,
+    metadataRegistry
+  });
+
+  const importResult = session.evaluateSnippet('import demo');
+  assert.equal(importResult.ok, true, 'import demo should succeed');
+
+  const evalResult = session.evaluateSnippet('x = demo.double(value: 21)');
+  assert.equal(evalResult.ok, true, 'demo.double execution should succeed');
+  assert.equal(evalResult.values['x.out'], 42, 'demo.double(21) should return 42');
+
+  const libs = session.listLibraries();
+  assert.ok(libs.includes('demo'), 'listLibraries should include demo');
+
+  const libHelp = session.getLibraryHelp('demo');
+  assert.ok(libHelp.includes('demo.double'), 'getLibraryHelp should include demo.double');
+
+  const funcHelp = session.getFunctionHelp('demo.double');
+  assert.ok(funcHelp.includes('double'), 'getFunctionHelp should include function description');
 });


### PR DESCRIPTION
Refactor help functions to support optional metadataRegistry and metadata
options, enabling custom package-registered libraries to appear in:
- loomlet docs / docs <library> / docs <library.function>
- REPL :libs / :help <library> / :help <lib.func> commands

Changes:
- help.js: Add getMetadataObject() to support custom metadata sources
  while preserving builtin LIBRARY_METADATA as default
- help.js: Update all formatting functions to accept options parameter
- repl-session.js: Store nodeRegistry and metadataRegistry in constructor
  and pass through to runLoomSource() and inspectLoomSource()
- repl-session.js: Add listLibraries(), getLibraryHelp(), getFunctionHelp()
  methods that use the session's metadataRegistry
- bin/loom.mjs: Update :libs and :help REPL commands to use session methods
- tests: Add comprehensive tests for registry-aware help functions and
  REPL session help methods with custom metadata

Documentation:
- docs/labs/PACKAGE_SYSTEM.md: Add section describing REPL help with
  package metadata and working example

Production CLI still shows builtin metadata until package-loading UX is added.
All tests pass except pre-existing failures unrelated to this change.

https://claude.ai/code/session_01SqyoWquQAPkQEVtxjMmbaD