### PR TITLE
Polish trusted local package loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ npm install -g @afjk/loomlet
 loomlet --help
 ```
 
+To load a trusted local package:
+
+```bash
+loomlet run ./file.loom --package ./examples/packages/demo/index.js --get x.out
+```
+
+See [Package System docs](docs/labs/PACKAGE_SYSTEM.md) for details.
+
 ## Library usage
 
 ```js

--- a/docs/labs/PACKAGE_SYSTEM.md
+++ b/docs/labs/PACKAGE_SYSTEM.md
@@ -245,7 +245,7 @@ The default CLI still shows builtin metadata until a package-loading UX is added
 
 ## CLI Usage with Trusted Local Packages
 
-The `loomlet` CLI can load trusted local packages using the `--package` flag (experimental):
+The `loomlet` CLI can load trusted local packages using the `--package` flag **(experimental)**:
 
 ```bash
 loomlet repl --package ./examples/packages/demo/index.js
@@ -257,23 +257,43 @@ loomlet docs demo --package ./examples/packages/demo/index.js
 loomlet docs demo.double --package ./examples/packages/demo/index.js
 ```
 
-### Package Resolution
+### Important Notes on Packages
 
+**Packages are executable JavaScript.** They must be trusted code. There is no sandboxing or permission system. Load packages only from sources you trust.
+
+### Package Resolution and Paths
+
+- Package paths must point to a JavaScript module file (e.g., `./examples/packages/demo/index.js`)
 - Local file paths are resolved relative to `process.cwd()`
 - Absolute paths are used as-is
-- No npm resolution
-- No remote URL loading
-- No directory package discovery (must specify the `.js` file)
+- **Directory discovery is not supported** — you must specify the `.js` file
+- **npm resolution is not supported**
+- **Remote URL loading is not supported**
 
-### Multiple Packages
+### Multiple Packages and Load Summaries
 
-Multiple packages can be loaded by repeating the `--package` flag:
+Multiple packages can be loaded by repeating the `--package` flag. When a host loads a package, the load summary reports **only the entries added by that package**, not the full registry state. This helps distinguish package contributions from builtin libraries.
+
+For example, after loading the demo package with builtins already present:
+
+```js
+const result = await loadTrustedLocalPackage('./demo/index.js', { 
+  nodeRegistry, 
+  metadataRegistry 
+});
+// result.libraries = ['demo']  (not including 'math', 'text', etc.)
+// result.nodeTypes = ['demo.double', 'demo.offset']
+```
+
+However, loading the same package twice will fail with a "Duplicate node type" error.
+
+### Loading Multiple Packages
+
+Load additional packages by repeating the `--package` flag:
 
 ```bash
 loomlet repl --package ./pkg-a/index.js --package ./pkg-b/index.js
 ```
-
-However, loading the same package twice will fail with a "Duplicate node type" error.
 
 ### REPL with Packages
 
@@ -303,14 +323,10 @@ Doubles a numeric value.
 Clear errors are provided for common issues:
 
 - **Package file not found**: Check the path and ensure the file exists
-- **Package fails to import**: Check for syntax errors in the package module
+- **Package fails to import**: Check for syntax errors in the package module or its dependencies
 - **Invalid package format**: Package must export `registerLoomletPackage` function
 - **Duplicate library metadata**: A library name is already registered
 - **Duplicate node type**: A node type is already registered
-
-### Security
-
-**Packages are executable JavaScript and must be trusted.** There is no sandboxing or permission system. Load packages only from sources you trust.
 
 ## Example
 
@@ -327,11 +343,6 @@ x = demo.double(value: 5)
 y = demo.offset(x, amount: 3)
 ```
 
-## Security Note
-
-**A trusted package is executable JavaScript.**
-
-Packages must be treated as trusted code. Do not load packages from untrusted sources without sandboxing and permission checks. Sandboxing and permission systems are future work.
 
 ## Future Work
 

--- a/src/toolchain/package-loader.js
+++ b/src/toolchain/package-loader.js
@@ -1,8 +1,9 @@
 import { pathToFileURL } from 'node:url';
+import { access } from 'node:fs/promises';
 import path from 'node:path';
 import { registerTrustedPackage } from '../runtime/package-registration.js';
 
-class PackageLoadError extends Error {
+export class PackageLoadError extends Error {
   constructor(message, packagePath, details = {}) {
     super(message);
     this.name = 'PackageLoadError';
@@ -30,6 +31,15 @@ export async function loadTrustedLocalPackage(packagePath, options = {}) {
       resolvedPath = path.resolve(process.cwd(), packagePath);
     }
 
+    // Check that the resolved path exists before attempting import
+    await access(resolvedPath);
+
+    // Track state before loading package
+    const beforeNodeTypes = new Set(Object.keys(nodeRegistry.toObject()));
+    const beforeLibraries = metadataRegistry
+      ? new Set(Object.keys(metadataRegistry.toObject()))
+      : new Set();
+
     const fileUrl = pathToFileURL(resolvedPath).href;
     const packageModule = await import(fileUrl);
 
@@ -38,28 +48,39 @@ export async function loadTrustedLocalPackage(packagePath, options = {}) {
       metadataRegistry
     });
 
-    const nodeTypes = nodeRegistry.toObject();
-    const libraries = [];
-    const nodeTypesList = [];
+    // Capture state after loading package
+    const afterNodeTypes = Object.keys(nodeRegistry.toObject());
+    const afterLibraries = metadataRegistry
+      ? Object.keys(metadataRegistry.toObject())
+      : [];
 
-    for (const nodeTypeName of Object.keys(nodeTypes)) {
-      const [libraryName] = nodeTypeName.split('.');
-      if (libraryName && !libraries.includes(libraryName)) {
-        libraries.push(libraryName);
-      }
-      nodeTypesList.push(nodeTypeName);
-    }
+    // Calculate only the newly added entries
+    const addedNodeTypes = afterNodeTypes.filter((name) => !beforeNodeTypes.has(name));
+    const addedLibraries = afterLibraries.filter((name) => !beforeLibraries.has(name));
 
     return {
       path: packagePath,
       resolvedPath,
-      libraries: libraries.sort(),
-      nodeTypes: nodeTypesList.sort()
+      libraries: addedLibraries.sort(),
+      nodeTypes: addedNodeTypes.sort()
     };
   } catch (error) {
-    if (error.code === 'ERR_MODULE_NOT_FOUND') {
+    // If file doesn't exist, give a clear error
+    if (error.code === 'ENOENT') {
       throw new PackageLoadError(
         `Package file not found: ${packagePath}`,
+        packagePath,
+        { originalError: error }
+      );
+    }
+
+    // If it's a module not found error, distinguish between the package file
+    // and nested imports within the package
+    if (error.code === 'ERR_MODULE_NOT_FOUND') {
+      // The error occurred during import - could be the package file or an internal import
+      // Only report "package file not found" if we didn't already verify file existence above
+      throw new PackageLoadError(
+        `Failed to load package: ${packagePath}\n${error.message}`,
         packagePath,
         { originalError: error }
       );

--- a/test/package-cli-loading.test.mjs
+++ b/test/package-cli-loading.test.mjs
@@ -48,6 +48,53 @@ test('loadTrustedLocalPackage loads demo package', async () => {
   assert.ok(metadataRegistry.hasLibraryMetadata('demo'));
 });
 
+test('loadTrustedLocalPackage summary includes only package-added entries', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+
+  const result = await loadTrustedLocalPackage(DEMO_PACKAGE_PATH, {
+    nodeRegistry,
+    metadataRegistry
+  });
+
+  // Summary should contain only demo, not builtin libraries like math, text, etc.
+  assert.deepEqual(result.libraries, ['demo']);
+  assert.deepEqual(result.nodeTypes, ['demo.double', 'demo.offset']);
+
+  // But the full registry should still have builtins
+  assert.ok(nodeRegistry.hasNodeType('math.add'), 'Builtin math.add should still be in registry');
+  // Package metadata is registered, but not builtin metadata (since we didn't register them)
+  assert.ok(metadataRegistry.hasLibraryMetadata('demo'), 'Package demo should be in metadata');
+});
+
+test('loadTrustedLocalPackage summary filters out builtin libraries', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  // Register builtins first
+  registerBuiltinNodes(nodeRegistry);
+
+  // Verify builtins are there before loading package
+  const beforeLoad = nodeRegistry.toObject();
+  assert.ok(Object.keys(beforeLoad).some((key) => key.startsWith('math.')), 'Builtins should be registered');
+
+  // Load package
+  const result = await loadTrustedLocalPackage(DEMO_PACKAGE_PATH, {
+    nodeRegistry,
+    metadataRegistry
+  });
+
+  // Result should only contain demo entries
+  assert.deepEqual(result.libraries, ['demo']);
+  assert.deepEqual(result.nodeTypes, ['demo.double', 'demo.offset']);
+
+  // No builtin libraries in summary
+  assert.ok(!result.libraries.includes('math'), 'math should not be in summary');
+  assert.ok(!result.libraries.includes('text'), 'text should not be in summary');
+});
+
 test('loadTrustedLocalPackage registers both nodes and metadata', async () => {
   const nodeRegistry = createNodeRegistry();
   const metadataRegistry = createLibraryMetadataRegistry();
@@ -122,12 +169,42 @@ test('loom docs --package shows loaded package metadata', () => {
   assert.ok(result.stdout.includes('demo'), 'Output should include demo library');
 });
 
+test('loom docs --package=<path> form works', () => {
+  const result = runCli(['docs', `--package=${DEMO_PACKAGE_PATH}`]);
+
+  assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('demo'), 'Output should include demo library');
+});
+
+test('loom docs --package <path> form works', () => {
+  const result = runCli(['docs', '--package', DEMO_PACKAGE_PATH]);
+
+  assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('demo'), 'Output should include demo library');
+});
+
+test('loom docs with package shows both builtin and package libraries', () => {
+  const result = runCli(['docs', `--package=${DEMO_PACKAGE_PATH}`]);
+
+  assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('demo'), 'Output should include demo library');
+  assert.ok(result.stdout.includes('math'), 'Output should include builtin math library');
+});
+
 test('loom docs <library> --package shows library help', () => {
   const result = runCli(['docs', 'demo', `--package=${DEMO_PACKAGE_PATH}`]);
 
   assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
   assert.ok(result.stdout.includes('demo'), 'Output should include demo library name');
   assert.ok(result.stdout.includes('double'), 'Output should include double function');
+});
+
+test('loom docs math --package still shows builtin library help', () => {
+  const result = runCli(['docs', 'math', `--package=${DEMO_PACKAGE_PATH}`]);
+
+  assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('math'), 'Output should include math library name');
+  assert.ok(result.stdout.includes('add') || result.stdout.includes('subtract'), 'Output should include math functions');
 });
 
 test('loom docs <lib.func> --package shows function help', () => {


### PR DESCRIPTION
- Export PackageLoadError for easier error handling by hosts
- Track registry state before/after package loading to report only newly added entries
- Check file existence before import to distinguish between missing package files and broken internal imports
- Add tests for package summaries to verify builtin libraries are not included
- Add CLI smoke tests for builtin and package documentation coexistence
- Test both --package <path> and --package=<path> argument forms
- Clarify package system docs about experimental status, JS execution, path forms, and load summaries
- Add compact CLI example to README with link to detailed docs

Fixes:
- loadTrustedLocalPackage() now returns only package-added entries in its summary
- PackageLoadError is now exported for host use
- Missing package file errors are clearer (via file existence check)

Tests:
- loadTrustedLocalPackage summary includes only package-added entries
- loadTrustedLocalPackage summary filters out builtin libraries
- loom docs --package shows both builtin and package libraries
- loom docs <builtin> --package still works
- loom docs <package> --package works
- Both --package=<path> and --package <path> forms are tested
- All 18 package-cli-loading tests pass
- npm test suite passes

https://claude.ai/code/session_018cWTNLQgMxf3EgKwAfAE89