### PR TITLE
Tighten REPL libs command parsing

### DIFF
--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -2083,8 +2083,23 @@ async function handleRepl(args) {
         return;
       }
       if (trimmed === ':libs' || trimmed.startsWith(':libs ')) {
-        const includePlanned = trimmed === ':libs --all';
-        print(session.listLibraries(includePlanned ? { includePlanned: true } : {}));
+        const parts = trimmed.split(/\s+/);
+        const args = parts.slice(1);
+
+        if (args.length === 0) {
+          print(session.listLibraries());
+          rl.prompt();
+          return;
+        }
+
+        if (args.length === 1 && args[0] === '--all') {
+          print(session.listLibraries({ includePlanned: true }));
+          rl.prompt();
+          return;
+        }
+
+        print(`Unknown :libs option: ${args.join(' ')}`);
+        print('Use :libs or :libs --all');
         rl.prompt();
         return;
       }

--- a/test/loom-repl-cli.test.mjs
+++ b/test/loom-repl-cli.test.mjs
@@ -134,3 +134,60 @@ test('repl :libs --all shows planned libraries', () => {
   assert.match(result.stdout, /- dom/);
   assert.match(result.stdout, /planned/);
 });
+
+test('repl :libs with invalid option reports error and continues', () => {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'repl'],
+    {
+      cwd: projectRoot,
+      input: [
+        ':libs nope',
+        ':quit'
+      ].join('\n'),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Unknown :libs option: nope/);
+  assert.match(result.stdout, /Use :libs or :libs --all/);
+});
+
+test('repl :libs with extra arguments reports error', () => {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'repl'],
+    {
+      cwd: projectRoot,
+      input: [
+        ':libs --all extra',
+        ':quit'
+      ].join('\n'),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Unknown :libs option: --all extra/);
+  assert.match(result.stdout, /Use :libs or :libs --all/);
+});
+
+test('repl :libs with unknown flag reports error', () => {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'repl'],
+    {
+      cwd: projectRoot,
+      input: [
+        ':libs --planned',
+        ':quit'
+      ].join('\n'),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Unknown :libs option: --planned/);
+  assert.match(result.stdout, /Use :libs or :libs --all/);
+});


### PR DESCRIPTION
Replace loose check for ':libs' command with proper argument validation.
Previously, unknown options like ':libs nope' were silently accepted as
':libs'. Now, unknown arguments produce a clear error message.

Valid forms:
  :libs
  :libs --all

Invalid forms now report:
  Unknown :libs option: <args>
  Use :libs or :libs --all

The REPL continues to accept further commands after an error.

Add tests for invalid options and extra arguments.

https://claude.ai/code/session_01J16EFTsXrnTcXn2ivTevzo