### PR TITLE
Automate GitHub Release publishing with npm and VS Code Marketplace

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,4 +1,4 @@
-name: Publish VS Code Extension
+name: Manual Publish VS Code Extension
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   build-release-artifacts:
     runs-on: ubuntu-latest
@@ -27,11 +31,37 @@ jobs:
             npm install
           fi
 
+      - name: Validate root package version (release events)
+        if: github.event_name == 'release'
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_NAME="${GITHUB_REF_NAME}"
+
+          if [ "$TAG_NAME" != "v$PACKAGE_VERSION" ]; then
+            echo "Release tag ($TAG_NAME) does not match package.json version (v$PACKAGE_VERSION)"
+            exit 1
+          fi
+
+      - name: Validate VS Code extension version (release events)
+        if: github.event_name == 'release'
+        run: |
+          ROOT_VERSION=$(node -p "require('./package.json').version")
+          EXT_VERSION=$(node -p "require('./extensions/vscode-loomlet/package.json').version")
+
+          if [ "$ROOT_VERSION" != "$EXT_VERSION" ]; then
+            echo "VS Code extension version ($EXT_VERSION) does not match root package version ($ROOT_VERSION)"
+            exit 1
+          fi
+
+      - name: Generate metadata
+        run: npm run generate:metadata
+
+      - name: Verify generated files are committed (release events)
+        if: github.event_name == 'release'
+        run: git diff --exit-code
+
       - name: Run unit tests
         run: npm test
-
-      - name: Generate VS Code metadata
-        run: npm run generate:vscode-metadata
 
       - name: Build CLI npm tarball
         run: npm pack
@@ -46,13 +76,14 @@ jobs:
           fi
 
       - name: Install packed core package into extension
-        working-directory: extensions/vscode-loomlet
         run: |
-          # Find the generated tarball and install it (--no-save to avoid modifying package-lock.json)
-          cd ../../
           TARBALL=$(ls -t afjk-loomlet-*.tgz | head -1)
           cd extensions/vscode-loomlet
           npm install --no-save "../../${TARBALL}"
+
+      - name: Run VS Code extension tests
+        working-directory: extensions/vscode-loomlet
+        run: npm test
 
       - name: Build VS Code extension VSIX
         working-directory: extensions/vscode-loomlet
@@ -73,3 +104,82 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: gh release upload "$TAG_NAME" *.tgz extensions/vscode-loomlet/*.vsix --clobber
+
+  publish-npm:
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js with npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install root dependencies
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+
+  publish-vscode-marketplace:
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install root dependencies
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Generate metadata
+        run: npm run generate:metadata
+
+      - name: Build CLI npm tarball
+        run: npm pack
+
+      - name: Install VS Code extension dependencies
+        working-directory: extensions/vscode-loomlet
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Install packed core package into extension
+        run: |
+          TARBALL=$(ls -t afjk-loomlet-*.tgz | head -1)
+          cd extensions/vscode-loomlet
+          npm install --no-save "../../${TARBALL}"
+
+      - name: Build VS Code extension VSIX
+        working-directory: extensions/vscode-loomlet
+        run: npx @vscode/vsce package
+
+      - name: Publish to Visual Studio Marketplace
+        working-directory: extensions/vscode-loomlet
+        run: |
+          VSIX=$(ls -t *.vsix | head -1)
+          npx @vscode/vsce publish --packagePath "$VSIX" -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -89,6 +89,13 @@ jobs:
         working-directory: extensions/vscode-loomlet
         run: npx @vscode/vsce package
 
+      - name: Upload VSIX workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension-vsix
+          path: extensions/vscode-loomlet/*.vsix
+          if-no-files-found: error
+
       - name: Upload workflow artifacts (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
@@ -131,50 +138,22 @@ jobs:
         run: npm publish --provenance --access public
 
   publish-vscode-marketplace:
-    needs: build-release-artifacts
+    needs:
+      - build-release-artifacts
+      - publish-npm
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install root dependencies
-        run: |
-          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
-            npm ci
-          else
-            npm install
-          fi
-
-      - name: Generate metadata
-        run: npm run generate:metadata
-
-      - name: Build CLI npm tarball
-        run: npm pack
-
-      - name: Install VS Code extension dependencies
-        working-directory: extensions/vscode-loomlet
-        run: |
-          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
-            npm ci
-          else
-            npm install
-          fi
-
-      - name: Install packed core package into extension
-        run: |
-          TARBALL=$(ls -t afjk-loomlet-*.tgz | head -1)
-          cd extensions/vscode-loomlet
-          npm install --no-save "../../${TARBALL}"
-
-      - name: Build VS Code extension VSIX
-        working-directory: extensions/vscode-loomlet
-        run: npx @vscode/vsce package
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vscode-extension-vsix
+          path: extensions/vscode-loomlet
 
       - name: Publish to Visual Studio Marketplace
         working-directory: extensions/vscode-loomlet

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -22,15 +22,13 @@ Before cutting a release:
    npm run pack:dry-run
    ```
 
-4. Optionally build the VS Code extension package.
+4. Ensure root `package.json` version is bumped.
 
-   ```bash
-   npm run pack:vscode
-   ```
+5. Ensure `extensions/vscode-loomlet/package.json` version matches root version.
 
-5. Review release notes draft.
+6. Review release notes.
 
-6. Bump versions only in the release PR.
+7. Create a GitHub Release with a tag like `v0.1.2`.
 
 ## Generated files
 
@@ -47,21 +45,58 @@ npm run generate:metadata
 
 Freshness tests fail if these files are stale.
 
-## Release artifacts and build workflows
+## GitHub Pages deployment
 
-GitHub release/build workflows:
+GitHub Pages is deployed automatically on pushes to `main` via:
 
-- `.github/workflows/release-artifacts.yml`
-  - builds Loomlet npm package tarball (`*.tgz`)
-  - builds Loomlet VS Code extension VSIX (`*.vsix`)
-  - runs on release publish and manual dispatch
-  - does not publish to npm
-  - does not publish to Visual Studio Marketplace
+```
+.github/workflows/deploy-pages.yml
+```
 
-- `.github/workflows/publish-vscode-extension.yml`
-  - manually publishes only `extensions/vscode-loomlet` to Visual Studio Marketplace
-  - uses repository secret `VSCE_PAT`
+This workflow builds the Node Editor and publishes the simple editor, node editor, examples, and source code.
 
-Related docs:
+## GitHub Release automation
 
-- [VS Code extension publish instructions](../extensions/vscode-loomlet/README.md#publishing-the-vs-code-extension)
+Publishing a GitHub Release automatically triggers the full release distribution flow via `.github/workflows/release-artifacts.yml`:
+
+1. **Validates** root package version against the release tag
+2. **Validates** VS Code extension version against root package version
+3. **Generates** metadata and docs via `npm run generate:metadata`
+4. **Fails** if generated files are stale (not committed)
+5. **Runs** unit tests
+6. **Builds** npm tarball
+7. **Runs** VS Code extension tests
+8. **Builds** VSIX
+9. **Uploads** artifacts (`*.tgz` and `*.vsix`) to GitHub Release
+10. **Publishes** `@afjk/loomlet` to npm via trusted publishing
+11. **Publishes** the VS Code extension to Visual Studio Marketplace
+
+## Required configuration
+
+### npm publishing
+
+The `@afjk/loomlet` package is published to npm using [npm Trusted Publishing](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-a-server-automation-token).
+
+The GitHub repository must be configured with a trusted publishing setup for `@afjk/loomlet` on npm. This requires:
+
+1. An npm access token configured in the npm account with automation permissions
+2. The GitHub repository linked in the npm account's trusted publishers settings
+
+Alternatively, if using token-based publishing, the `npm_token` repository secret must be configured.
+
+### Visual Studio Marketplace publishing
+
+VS Code extension publishing requires the `VSCE_PAT` repository secret, which is a Personal Access Token with Marketplace publishing permissions.
+
+## Manual workflows
+
+### Manual VS Code extension publish
+
+The `.github/workflows/publish-vscode-extension.yml` workflow is available as a fallback for emergency republishes or extension-only fixes:
+
+```
+.github/workflows/publish-vscode-extension.yml
+  - manually triggered via workflow_dispatch
+  - publishes only extensions/vscode-loomlet to Visual Studio Marketplace
+  - requires VSCE_PAT secret
+```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -75,14 +75,11 @@ Publishing a GitHub Release automatically triggers the full release distribution
 
 ### npm publishing
 
-The `@afjk/loomlet` package is published to npm using [npm Trusted Publishing](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-a-server-automation-token).
+The `@afjk/loomlet` package is published to npm using npm Trusted Publishing.
 
-The GitHub repository must be configured with a trusted publishing setup for `@afjk/loomlet` on npm. This requires:
+Trusted Publishing does not require an `NPM_TOKEN` repository secret. Configure this GitHub repository and release workflow as a trusted publisher in the npm package settings.
 
-1. An npm access token configured in the npm account with automation permissions
-2. The GitHub repository linked in the npm account's trusted publishers settings
-
-Alternatively, if using token-based publishing, the `npm_token` repository secret must be configured.
+If token-based publishing is used instead, configure `NODE_AUTH_TOKEN` explicitly and update the workflow accordingly.
 
 ### Visual Studio Marketplace publishing
 


### PR DESCRIPTION
- Add release version validation (tag vs package.json)
- Add VS Code extension version validation
- Use full metadata generation (npm run generate:metadata)
- Verify generated files are committed (fail on stale files)
- Run tests before building artifacts
- Build npm tarball and VS Code VSIX with self-contained jobs
- Publish @afjk/loomlet to npm with provenance on release events
- Publish VS Code extension to Marketplace on release events
- Keep manual VS Code publish workflow as fallback
- Update RELEASE.md with new automation documentation
- Rename manual workflow to 'Manual Publish VS Code Extension'

https://claude.ai/code/session_01JQ7Wby2yMzAHwdRaPwUifZ