### PR TITLE
Prepare 0.1.2 release: bump version numbers

### DIFF
--- a/extensions/vscode-loomlet/package-lock.json
+++ b/extensions/vscode-loomlet/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@afjk/loomlet": "^0.1.2"
+        "@afjk/loomlet": "^0.1.0"
       },
       "devDependencies": {
         "esbuild": "^0.21.0",

--- a/extensions/vscode-loomlet/package-lock.json
+++ b/extensions/vscode-loomlet/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "loomlet-vscode",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loomlet-vscode",
-      "version": "0.0.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@afjk/loomlet": "^0.1.0"
+        "@afjk/loomlet": "^0.1.2"
       },
       "devDependencies": {
         "esbuild": "^0.21.0",

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -120,7 +120,7 @@
     "build": "npm run build:webview"
   },
   "dependencies": {
-    "@afjk/loomlet": "^0.1.2"
+    "@afjk/loomlet": "^0.1.0"
   },
   "devDependencies": {
     "esbuild": "^0.21.0",

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -2,7 +2,7 @@
   "name": "loomlet-vscode",
   "displayName": "Loomlet",
   "description": "VS Code support for Loomlet language files and Scene Sync workflows",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "publisher": "afjk",
   "license": "MIT",
   "repository": {
@@ -120,7 +120,7 @@
     "build": "npm run build:webview"
   },
   "dependencies": {
-    "@afjk/loomlet": "^0.1.0"
+    "@afjk/loomlet": "^0.1.2"
   },
   "devDependencies": {
     "esbuild": "^0.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afjk/loomlet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afjk/loomlet",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "loom": "bin/loom.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afjk/loomlet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "type": "module",
   "description": "A small reactive DSL and node graph toolkit for interactive scenes.",


### PR DESCRIPTION
- Update root package.json version to 0.1.2
- Update root package-lock.json to reflect version bump
- Update VS Code extension version to 0.1.2
- Update VS Code extension package-lock.json to reflect version bump
- Update VS Code extension dependency on @afjk/loomlet to ^0.1.2
- Generated metadata is already up to date
- All tests pass
- npm pack --dry-run succeeds

Release notes for 0.1.2 are finalized in docs/RELEASE_NOTES_DRAFT.md

Note: pack:vscode fails with expected error about missing @afjk/loomlet@^0.1.2
since the package hasn't been published yet. This will be resolved after the
npm publish step in the release workflow.

https://claude.ai/code/session_01REQ4nFkNiLwh1Nivc7ypgf