### PR TITLE
Fix planned library filtering test to use dynamic metadata

### DIFF
--- a/extensions/vscode-loomlet/test/completion-engine.test.mjs
+++ b/extensions/vscode-loomlet/test/completion-engine.test.mjs
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { getCompletionContext } = require('../src/completion-context.js');
 const { buildCompletions } = require('../src/completion-engine.js');
+const metadata = require('../generated/library-metadata.json');
 
 function labels(source) {
   const ctx = getCompletionContext(source, source.length);
@@ -43,11 +44,14 @@ test('argument completion excludes already-used names', () => {
 });
 
 test('planned items excluded by default and shown when enabled', () => {
-  const defaultItems = buildCompletions(getCompletionContext('random.', 'random.'.length), false).map((i) => i.label);
-  assert.ok(!defaultItems.includes('seeded'));
+  const plannedLib = metadata.libraries.find((lib) => lib.status === 'planned');
+  assert.ok(plannedLib, 'should have at least one planned library');
 
-  const plannedItems = buildCompletions(getCompletionContext('random.', 'random.'.length), true).map((i) => i.label);
-  assert.ok(plannedItems.includes('seeded'));
+  const defaultItems = buildCompletions(getCompletionContext('import ', 'import '.length), false).map((i) => i.label);
+  assert.ok(!defaultItems.includes(plannedLib.name), `${plannedLib.name} should be excluded by default`);
+
+  const plannedItems = buildCompletions(getCompletionContext('import ', 'import '.length), true).map((i) => i.label);
+  assert.ok(plannedItems.includes(plannedLib.name), `${plannedLib.name} should be included when includePlanned=true`);
 });
 
 test('binary operator snippets use two positional args', () => {


### PR DESCRIPTION
## Summary
Updated the planned items exclusion test to dynamically reference library metadata instead of hardcoding specific library names, making the test more maintainable and resilient to metadata changes.

## Key Changes
- Added import of `library-metadata.json` to access library definitions
- Modified test to dynamically find a library with 'planned' status instead of assuming 'seeded' exists
- Changed completion context from `'random.'` to `'import '` to test library-level completions rather than member completions
- Updated assertions to reference the dynamically found planned library and include descriptive error messages

## Implementation Details
- The test now validates that planned libraries are properly excluded by default and included when `includePlanned=true` flag is set
- By using metadata to find a planned library at runtime, the test becomes independent of specific library implementations
- This approach ensures the test will continue to work correctly as the library metadata evolves

https://claude.ai/code/session_018SaodrVdRwPvL59KrgsYvL