### PR TITLE
[codex] Load trusted packages from manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ npm install -g @afjk/loomlet
 loomlet --help
 ```
 
-To load a trusted local package:
+To load a trusted local package file or manifest directory:
 
 ```bash
 loomlet run ./file.loom --package ./examples/packages/demo/index.js --get x.out
+loomlet run ./file.loom --package ./path/to/package-dir --get x.out
 ```
 
 See [Package System docs](docs/labs/PACKAGE_SYSTEM.md) for details.

--- a/bin/loom.mjs
+++ b/bin/loom.mjs
@@ -104,14 +104,14 @@ function parsePackageArgs(args) {
     if (arg === '--package') {
       const packagePath = args[index + 1];
       if (!packagePath || packagePath.startsWith('-')) {
-        throw new Error('--package requires a file path');
+        throw new Error('--package requires a file or directory path');
       }
       packages.push(packagePath);
       index += 1;
     } else if (arg.startsWith('--package=')) {
       const packagePath = arg.slice(10);
       if (!packagePath) {
-        throw new Error('--package= requires a file path');
+        throw new Error('--package= requires a file or directory path');
       }
       packages.push(packagePath);
     } else {
@@ -178,7 +178,7 @@ Options:
   -o, --out <file>    Write GraphJSON to a file
   --pretty false      Print compact JSON
   --target <target>   Validate imports for a runtime target. Default: any
-  --package <path>    Load a trusted local package (repeatable)`;
+  --package <path>    Load a trusted local package file or manifest directory (repeatable)`;
 }
 
 function getFormatHelp() {
@@ -199,7 +199,7 @@ Options:
   --graph             Print GraphJSON
   --json              Print the full inspection result as JSON
   --target <target>   Validate imports for a runtime target. Default: any
-  --package <path>    Load a trusted local package (repeatable)`;
+  --package <path>    Load a trusted local package file or manifest directory (repeatable)`;
 }
 
 function getRunHelp() {
@@ -212,7 +212,7 @@ Options:
   --dt <number>     Evaluation env.deltaTime in seconds.
   --json            Print result values as JSON
   --target <target> Only cli is supported by loomlet run in this version. Default: cli
-  --package <path>  Load a trusted local package (repeatable)`;
+  --package <path>  Load a trusted local package file or manifest directory (repeatable)`;
 }
 
 function getReplHelp() {
@@ -220,7 +220,7 @@ function getReplHelp() {
   loomlet repl [--package <path>]
 
 Options:
-  --package <path>   Load a trusted local package (repeatable)
+  --package <path>   Load a trusted local package file or manifest directory (repeatable)
 
 Commands:
   :help              Show REPL help
@@ -2168,7 +2168,7 @@ async function handleDocs(args) {
       'Options:',
       '  --json                 Output as JSON',
       '  --include-planned      Include planned libraries',
-      '  --package <path>       Load a trusted local package (repeatable)',
+      '  --package <path>       Load a trusted local package file or manifest directory (repeatable)',
       '',
       'Examples:',
       '  loomlet docs',
@@ -2177,6 +2177,7 @@ async function handleDocs(args) {
       '  loomlet docs text.upper --json',
       '  loomlet docs --include-planned',
       '  loomlet docs --package ./examples/packages/demo/index.js',
+      '  loomlet docs --package ./path/to/package-dir',
       '  loomlet docs demo --package ./examples/packages/demo/index.js'
     ];
     print(lines.join('\n'));

--- a/docs/labs/PACKAGE_SYSTEM.md
+++ b/docs/labs/PACKAGE_SYSTEM.md
@@ -1,12 +1,12 @@
 # Package System (v0 Foundation)
 
-Loomlet package extension v0 supports trusted local JavaScript modules loaded explicitly by file path. Packages are executable JavaScript and must be trusted.
+Loomlet package extension v0 supports trusted local JavaScript modules loaded explicitly by file path, plus explicit directory loading through `loomlet.package.json`. Packages are executable JavaScript and must be trusted.
 
 ## v0 Supported Surface
 
 In v0, packages support:
 
-- **Explicit file path loading**: `--package <path>` on CLI or `loadTrustedLocalPackage()` at runtime
+- **Explicit local loading**: `--package <path>` on CLI or `loadTrustedLocalPackage()` at runtime, where `<path>` is a JavaScript module file or a directory containing `loomlet.package.json`
 - **Runtime node registration**: Packages register node implementations into a NodeRegistry via `registerLoomletPackage()`
 - **Optional metadata registration**: Packages can export metadata for discoverability and target compatibility
 - **Package-aware import validation**: Compiler validates imports against metadata targets when available
@@ -15,7 +15,7 @@ In v0, packages support:
 ## v0 Design Principles
 
 - **Trusted source only**: Packages are executable JavaScript with full process capabilities. There is no sandboxing or permission system. Load packages only from sources you trust.
-- **Explicit loading**: Packages must be loaded explicitly by file path. There is no package discovery, catalog, directory scanning, or npm resolution.
+- **Explicit loading**: Packages must be loaded explicitly by file path or directory path. There is no package discovery, catalog, recursive directory scanning, or npm resolution.
 - **Runtime-only or metadata-aware**: A package can work with runtime registration alone, or can add optional metadata for better tooling support.
 
 ## Runtime Package API
@@ -318,18 +318,42 @@ loomlet docs demo --package ./examples/packages/demo/index.js
 loomlet docs demo.double --package ./examples/packages/demo/index.js
 ```
 
+Directory packages are loaded by pointing `--package` at a directory that contains `loomlet.package.json`:
+
+```bash
+loomlet run ./file.loom --package ./path/to/package-dir --get x.out
+loomlet docs --package ./path/to/package-dir
+```
+
 ### Important Notes on Packages
 
 **Packages are executable JavaScript.** They must be trusted code. There is no sandboxing or permission system. Load packages only from sources you trust.
 
 ### Package Resolution and Paths
 
-- Package paths must point to a JavaScript module file (e.g., `./examples/packages/demo/index.js`)
+- Package paths must point to a JavaScript module file (e.g., `./examples/packages/demo/index.js`) or to a directory containing `loomlet.package.json`
 - Local file paths are resolved relative to `process.cwd()`
 - Absolute paths are used as-is
-- **Directory discovery is not supported** — you must specify the `.js` file
+- Directory package loading only checks the exact directory passed to `--package`; recursive discovery is not supported
 - **npm resolution is not supported**
 - **Remote URL loading is not supported**
+
+### Directory Manifest Shape
+
+`loomlet.package.json` v0 requires `name`, `version`, and `loomlet.entry`. `loomlet.metadata` is optional and, when present, points to a JSON or JavaScript metadata file. Metadata files are treated as a Loomlet library metadata map, matching the existing `loomletMetadata` export shape.
+
+```json
+{
+  "name": "my-package",
+  "version": "0.0.0",
+  "loomlet": {
+    "entry": "./index.js",
+    "metadata": "./metadata.json"
+  }
+}
+```
+
+The entry module must export `registerLoomletPackage(registry, context)`. The metadata path is resolved relative to the package directory and must stay inside that directory.
 
 ### Multiple Packages and Load Summaries
 
@@ -405,9 +429,9 @@ y = demo.offset(x, amount: 3)
 ```
 
 
-## Future Manifest Direction (Not Implemented)
+## Future Manifest Direction
 
-In future versions, packages may use a manifest file to declare metadata, dependencies, and compatibility. A suggested manifest shape for stabilization work:
+Future versions may extend the manifest to declare API compatibility, dependencies, and richer compatibility data. A possible extended manifest shape:
 
 ```json
 {
@@ -427,13 +451,13 @@ In future versions, packages may use a manifest file to declare metadata, depend
 }
 ```
 
-This manifest may eventually enable:
+An extended manifest may eventually enable:
 - Declaring compatible Loomlet API versions
 - Specifying supported targets (cli, web, scenesync, unity, etc)
 - Declaring dependencies on other packages
 - Auto-discovering packages from manifest files instead of explicit paths
 
-However, the current v0 approach (explicit file path loading without manifest) provides more control and reduces complexity for trusted packages.
+The current v0 manifest loader does not perform version solving, dependency resolution, npm resolution, publishing, package catalog lookup, remote/CDN loading, sandboxing, or permission checks.
 
 ## Versioning Axes
 
@@ -469,7 +493,7 @@ The following are explicitly deferred from v0 and will be addressed in future wo
 - **npm package loading**: Load packages from npm registry
 - **Remote/URL loading**: Load packages from HTTP(S) URLs or CDNs
 - **Directory discovery**: Auto-discover packages from directories or manifest files
-- **Manifest file resolution**: Load packages via manifest.json instead of explicit paths
+- **Package manifest extensions**: Dependency, API-version, and catalog fields beyond the v0 local loader
 - **Sandboxing**: Run packages in a restricted execution environment
 - **Permission system**: Grant/revoke package capabilities before execution
 - **Package catalog / discovery**: Registry or marketplace of available packages

--- a/src/toolchain/package-loader.js
+++ b/src/toolchain/package-loader.js
@@ -1,7 +1,9 @@
 import { pathToFileURL } from 'node:url';
-import { access } from 'node:fs/promises';
+import { access, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { registerTrustedPackage } from '../runtime/package-registration.js';
+
+const MANIFEST_FILENAME = 'loomlet.package.json';
 
 export class PackageLoadError extends Error {
   constructor(message, packagePath, details = {}) {
@@ -10,6 +12,197 @@ export class PackageLoadError extends Error {
     this.packagePath = packagePath;
     this.details = details;
   }
+}
+
+function resolvePackagePath(packagePath) {
+  return path.isAbsolute(packagePath)
+    ? packagePath
+    : path.resolve(process.cwd(), packagePath);
+}
+
+async function loadJsonFile(filePath, packagePath, label) {
+  let text;
+  try {
+    text = await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new PackageLoadError(
+        `${label} not found: ${packagePath}`,
+        packagePath,
+        { originalError: error }
+      );
+    }
+    throw error;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new PackageLoadError(
+      `${label} is not valid JSON: ${packagePath}\n${error.message}`,
+      packagePath,
+      { originalError: error }
+    );
+  }
+}
+
+function validatePackageManifest(manifest, packagePath) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nManifest must be a JSON object.`,
+      packagePath
+    );
+  }
+
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nRequired field "name" must be a non-empty string.`,
+      packagePath
+    );
+  }
+
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nRequired field "version" must be a non-empty string.`,
+      packagePath
+    );
+  }
+
+  if (!manifest.loomlet || typeof manifest.loomlet !== 'object' || Array.isArray(manifest.loomlet)) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nRequired field "loomlet" must be an object.`,
+      packagePath
+    );
+  }
+
+  if (typeof manifest.loomlet.entry !== 'string' || manifest.loomlet.entry.length === 0) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nRequired field "loomlet.entry" must be a non-empty string.`,
+      packagePath
+    );
+  }
+
+  if (
+    manifest.loomlet.metadata !== undefined &&
+    (typeof manifest.loomlet.metadata !== 'string' || manifest.loomlet.metadata.length === 0)
+  ) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nOptional field "loomlet.metadata" must be a non-empty string when provided.`,
+      packagePath
+    );
+  }
+}
+
+function resolveManifestRelativePath(packageRoot, manifestPath, fieldName, packagePath) {
+  if (path.isAbsolute(manifestPath)) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nField "${fieldName}" must be a relative path.`,
+      packagePath
+    );
+  }
+
+  const normalized = path.normalize(manifestPath);
+  if (normalized === '..' || normalized.startsWith(`..${path.sep}`)) {
+    throw new PackageLoadError(
+      `Invalid package manifest: ${packagePath}\nField "${fieldName}" must stay inside the package directory.`,
+      packagePath
+    );
+  }
+
+  return path.resolve(packageRoot, normalized);
+}
+
+function normalizeMetadataModule(metadataModule) {
+  if (metadataModule?.loomletMetadata) {
+    return metadataModule.loomletMetadata;
+  }
+  if (metadataModule?.default) {
+    return metadataModule.default;
+  }
+  return metadataModule;
+}
+
+async function loadManifestMetadata(metadataPath, packagePath) {
+  if (metadataPath.endsWith('.json')) {
+    return loadJsonFile(metadataPath, packagePath, 'Package metadata file');
+  }
+
+  const metadataModule = await import(pathToFileURL(metadataPath).href);
+  return normalizeMetadataModule(metadataModule);
+}
+
+async function resolvePackageEntry(packagePath) {
+  const resolvedPath = resolvePackagePath(packagePath);
+  let packageStat;
+
+  try {
+    packageStat = await stat(resolvedPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new PackageLoadError(
+        `Package file not found: ${packagePath}`,
+        packagePath,
+        { originalError: error }
+      );
+    }
+    throw error;
+  }
+
+  if (!packageStat.isDirectory()) {
+    await access(resolvedPath);
+    return {
+      kind: 'file',
+      path: packagePath,
+      resolvedPath,
+      entryPath: resolvedPath,
+      manifestPath: null,
+      metadataPath: null,
+      packageModule: await import(pathToFileURL(resolvedPath).href)
+    };
+  }
+
+  const manifestPath = path.join(resolvedPath, MANIFEST_FILENAME);
+  const manifest = await loadJsonFile(
+    manifestPath,
+    packagePath,
+    `Package manifest ${MANIFEST_FILENAME}`
+  );
+  validatePackageManifest(manifest, packagePath);
+
+  const entryPath = resolveManifestRelativePath(
+    resolvedPath,
+    manifest.loomlet.entry,
+    'loomlet.entry',
+    packagePath
+  );
+  const entryModule = await import(pathToFileURL(entryPath).href);
+
+  let metadataPath = null;
+  let packageModule = entryModule;
+  if (manifest.loomlet.metadata) {
+    metadataPath = resolveManifestRelativePath(
+      resolvedPath,
+      manifest.loomlet.metadata,
+      'loomlet.metadata',
+      packagePath
+    );
+    const loomletMetadata = await loadManifestMetadata(metadataPath, packagePath);
+    packageModule = {
+      registerLoomletPackage: entryModule.registerLoomletPackage,
+      loomletMetadata
+    };
+  }
+
+  return {
+    kind: 'directory',
+    path: packagePath,
+    resolvedPath,
+    entryPath,
+    manifestPath,
+    metadataPath,
+    manifest,
+    packageModule
+  };
 }
 
 export async function loadTrustedLocalPackage(packagePath, options = {}) {
@@ -23,16 +216,8 @@ export async function loadTrustedLocalPackage(packagePath, options = {}) {
 
   const { nodeRegistry, metadataRegistry } = options;
 
-  let resolvedPath;
   try {
-    if (path.isAbsolute(packagePath)) {
-      resolvedPath = packagePath;
-    } else {
-      resolvedPath = path.resolve(process.cwd(), packagePath);
-    }
-
-    // Check that the resolved path exists before attempting import
-    await access(resolvedPath);
+    const packageEntry = await resolvePackageEntry(packagePath);
 
     // Track state before loading package
     const beforeNodeTypes = new Set(Object.keys(nodeRegistry.toObject()));
@@ -40,10 +225,7 @@ export async function loadTrustedLocalPackage(packagePath, options = {}) {
       ? new Set(Object.keys(metadataRegistry.toObject()))
       : new Set();
 
-    const fileUrl = pathToFileURL(resolvedPath).href;
-    const packageModule = await import(fileUrl);
-
-    registerTrustedPackage(nodeRegistry, packageModule, {
+    registerTrustedPackage(nodeRegistry, packageEntry.packageModule, {
       nodeRegistry,
       metadataRegistry
     });
@@ -60,7 +242,10 @@ export async function loadTrustedLocalPackage(packagePath, options = {}) {
 
     return {
       path: packagePath,
-      resolvedPath,
+      resolvedPath: packageEntry.resolvedPath,
+      manifestPath: packageEntry.manifestPath,
+      entryPath: packageEntry.entryPath,
+      metadataPath: packageEntry.metadataPath,
       libraries: addedLibraries.sort(),
       nodeTypes: addedNodeTypes.sort()
     };

--- a/test/fixtures/manifest-package.loom
+++ b/test/fixtures/manifest-package.loom
@@ -1,0 +1,3 @@
+import manifestpkg
+
+x = manifestpkg.value()

--- a/test/fixtures/manifest-package/index.js
+++ b/test/fixtures/manifest-package/index.js
@@ -1,0 +1,11 @@
+export function registerLoomletPackage(registry) {
+  registry.registerNodeType('manifestpkg.value', {
+    category: 'source',
+    outputs: [
+      { name: 'out', type: 'number', kind: 'behavior' }
+    ],
+    evaluate() {
+      return { out: 7 };
+    }
+  });
+}

--- a/test/fixtures/manifest-package/loomlet.package.json
+++ b/test/fixtures/manifest-package/loomlet.package.json
@@ -1,0 +1,8 @@
+{
+  "name": "manifest-package",
+  "version": "0.0.0",
+  "loomlet": {
+    "entry": "./index.js",
+    "metadata": "./metadata.json"
+  }
+}

--- a/test/fixtures/manifest-package/metadata.json
+++ b/test/fixtures/manifest-package/metadata.json
@@ -1,0 +1,18 @@
+{
+  "manifestpkg": {
+    "name": "manifestpkg",
+    "description": "Manifest package fixture metadata.",
+    "targets": ["cli", "web"],
+    "functions": {
+      "value": {
+        "name": "value",
+        "signature": "manifestpkg.value()",
+        "description": "Returns a fixture value.",
+        "args": [],
+        "returns": "number",
+        "targets": ["cli", "web"],
+        "examples": ["result = manifestpkg.value()"]
+      }
+    }
+  }
+}

--- a/test/fixtures/package-invalid-manifest/loomlet.package.json
+++ b/test/fixtures/package-invalid-manifest/loomlet.package.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.0.0",
+  "loomlet": {
+    "entry": "./index.js"
+  }
+}

--- a/test/fixtures/package-missing-entry/loomlet.package.json
+++ b/test/fixtures/package-missing-entry/loomlet.package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-missing-entry",
+  "version": "0.0.0",
+  "loomlet": {
+    "entry": "./missing.js"
+  }
+}

--- a/test/fixtures/package-missing-manifest/README.md
+++ b/test/fixtures/package-missing-manifest/README.md
@@ -1,0 +1,1 @@
+This directory intentionally has no loomlet.package.json fixture.

--- a/test/package-cli-loading.test.mjs
+++ b/test/package-cli-loading.test.mjs
@@ -27,7 +27,9 @@ function runCli(args, options = {}) {
 }
 
 const DEMO_PACKAGE_PATH = './examples/packages/demo/index.js';
+const MANIFEST_PACKAGE_PATH = './test/fixtures/manifest-package';
 const FIXTURE_PACKAGE_DEMO_LOOM = './test/fixtures/package-demo.loom';
+const FIXTURE_MANIFEST_PACKAGE_LOOM = './test/fixtures/manifest-package.loom';
 
 test('loadTrustedLocalPackage loads demo package', async () => {
   const nodeRegistry = createNodeRegistry();
@@ -116,6 +118,108 @@ test('loadTrustedLocalPackage registers both nodes and metadata', async () => {
   assert.ok(demoMeta.functions.offset);
 });
 
+test('loadTrustedLocalPackage preserves explicit file package loading', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+
+  const result = await loadTrustedLocalPackage(DEMO_PACKAGE_PATH, {
+    nodeRegistry,
+    metadataRegistry
+  });
+
+  assert.equal(result.path, DEMO_PACKAGE_PATH);
+  assert.equal(result.manifestPath, null);
+  assert.ok(result.entryPath.endsWith('/examples/packages/demo/index.js'));
+  assert.ok(nodeRegistry.hasNodeType('demo.double'));
+  assert.ok(metadataRegistry.hasLibraryMetadata('demo'));
+});
+
+test('loadTrustedLocalPackage loads directory manifest entry and metadata', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+
+  const result = await loadTrustedLocalPackage(MANIFEST_PACKAGE_PATH, {
+    nodeRegistry,
+    metadataRegistry
+  });
+
+  assert.equal(result.path, MANIFEST_PACKAGE_PATH);
+  assert.ok(result.manifestPath.endsWith('/test/fixtures/manifest-package/loomlet.package.json'));
+  assert.ok(result.entryPath.endsWith('/test/fixtures/manifest-package/index.js'));
+  assert.ok(result.metadataPath.endsWith('/test/fixtures/manifest-package/metadata.json'));
+  assert.deepEqual(result.libraries, ['manifestpkg']);
+  assert.deepEqual(result.nodeTypes, ['manifestpkg.value']);
+  assert.ok(nodeRegistry.hasNodeType('manifestpkg.value'));
+  assert.ok(metadataRegistry.hasLibraryMetadata('manifestpkg'));
+  assert.equal(metadataRegistry.getLibraryMetadata('manifestpkg').functions.value.returns, 'number');
+});
+
+test('loadTrustedLocalPackage throws for directory missing manifest', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+
+  await assert.rejects(
+    async () => {
+      await loadTrustedLocalPackage('./test/fixtures/package-missing-manifest', {
+        nodeRegistry,
+        metadataRegistry
+      });
+    },
+    (error) => {
+      assert.ok(error.message.includes('Package manifest loomlet.package.json not found'));
+      return true;
+    }
+  );
+});
+
+test('loadTrustedLocalPackage throws for directory missing entry', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+
+  await assert.rejects(
+    async () => {
+      await loadTrustedLocalPackage('./test/fixtures/package-missing-entry', {
+        nodeRegistry,
+        metadataRegistry
+      });
+    },
+    (error) => {
+      assert.ok(error.message.includes('Failed to load package'));
+      assert.ok(error.message.includes('missing.js'));
+      return true;
+    }
+  );
+});
+
+test('loadTrustedLocalPackage throws for invalid directory manifest', async () => {
+  const nodeRegistry = createNodeRegistry();
+  const metadataRegistry = createLibraryMetadataRegistry();
+
+  registerBuiltinNodes(nodeRegistry);
+
+  await assert.rejects(
+    async () => {
+      await loadTrustedLocalPackage('./test/fixtures/package-invalid-manifest', {
+        nodeRegistry,
+        metadataRegistry
+      });
+    },
+    (error) => {
+      assert.ok(error.message.includes('Invalid package manifest'));
+      assert.ok(error.message.includes('Required field "name"'));
+      return true;
+    }
+  );
+});
+
 test('loadTrustedLocalPackage throws for missing file', async () => {
   const nodeRegistry = createNodeRegistry();
   const metadataRegistry = createLibraryMetadataRegistry();
@@ -183,6 +287,14 @@ test('loom docs --package <path> form works', () => {
   assert.ok(result.stdout.includes('demo'), 'Output should include demo library');
 });
 
+test('loom docs --package <directory> shows manifest metadata', () => {
+  const result = runCli(['docs', '--package', MANIFEST_PACKAGE_PATH]);
+
+  assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('manifestpkg'), 'Output should include manifest package library');
+  assert.ok(result.stdout.includes('Manifest package fixture metadata'));
+});
+
 test('loom docs with package shows both builtin and package libraries', () => {
   const result = runCli(['docs', `--package=${DEMO_PACKAGE_PATH}`]);
 
@@ -220,6 +332,34 @@ test('loom run <file> --package loads and executes code with package', () => {
 
   assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
   assert.ok(result.stdout.includes('42'), 'demo.double(21) should return 42');
+});
+
+test('loom run <file> --package <directory> loads and executes manifest package', () => {
+  const result = runCli([
+    'run',
+    FIXTURE_MANIFEST_PACKAGE_LOOM,
+    '--package',
+    MANIFEST_PACKAGE_PATH,
+    '--get',
+    'x.out'
+  ]);
+
+  assert.strictEqual(result.status, 0, `CLI should succeed. stderr: ${result.stderr}`);
+  assert.ok(result.stdout.includes('7'), 'manifestpkg.value() should return 7');
+});
+
+test('loom compile rejects manifest package import for unsupported target', () => {
+  const result = runCli([
+    'compile',
+    FIXTURE_MANIFEST_PACKAGE_LOOM,
+    '--package',
+    MANIFEST_PACKAGE_PATH,
+    '--target',
+    'unity'
+  ]);
+
+  assert.notStrictEqual(result.status, 0, 'Compile should reject unsupported target');
+  assert.ok(result.stderr.includes("Import 'manifestpkg' is not available in target 'unity'"));
 });
 
 test('loom run <file> --package with same package flag twice fails', () => {


### PR DESCRIPTION
## Summary

Closes #262.

## What changed

- Preserved existing `--package <file.js>` support.
- Added explicit `--package <directory>` support via `loomlet.package.json`.
- Validates manifest shape, loads `loomlet.entry`, and registers optional metadata.
- Added fixtures, package loading tests, CLI docs/help text, and package system docs updates.

## Tests run

- `node test/package-cli-loading.test.mjs`
- `node test/package-import-validation.test.mjs`
- `node test/package-metadata-registration.test.mjs`

## Focused tests

- File package loading still works.
- Directory manifest loading works.
- Entry and metadata are registered.
- Missing manifest, missing entry, and invalid manifest fail clearly.
- Manifest package metadata participates in target import validation.

## Known limitations

- Local trusted package directories only.
- No npm, remote/CDN loading, sandboxing, permissions, dependency resolution, catalog, version solver, or publishing.
- Manifest metadata is treated as a library metadata map.

## Follow-up work

- Decide whether future manifests should validate `loomlet.apiVersion` and `loomlet.targets` more strictly.
- Add editor/VS Code consumption of manifest metadata later.

## Scope check

- [x] This PR only addresses #262.
- [x] Non-goals from the issue are respected.
- [x] No unrelated implementation is included.
- [x] No afjk.jp runtime dependency is introduced.
- [x] Scene Sync Export self-containment is not broken.
