### PR TITLE
[codex] Add semantic component expression access

### DIFF
--- a/docs/RELEASE_NOTES_NEXT.md
+++ b/docs/RELEASE_NOTES_NEXT.md
@@ -74,8 +74,9 @@ The semantic axis vocabulary is now documented.
 
 - `right`, `up`, and `front` are the public semantic axis names.
 - `r`, `u`, and `f` are short aliases.
-- The current v0 implementation is limited to filter predicate DSL component access, such as `value.right`, `value.up`, and `value.front`.
-- General expression component access and multi-component swizzle remain future work.
+- Filter predicate DSL component access supports `value.right`, `value.up`, `value.front`, and aliases.
+- General DSL expression component access supports `expr.right`, `expr.up`, `expr.front`, and aliases by lowering to explicit `getComponent` nodes.
+- Multi-component swizzle remains future work.
 
 ### Package extension foundation
 
@@ -136,7 +137,6 @@ The portable runtime boundary is now documented for Scene Sync Export and future
 The following are intentionally not part of the stable next-release promise:
 
 - full source-preserving DSL <-> Node Editor round-trip
-- general expression component access
 - multi-component swizzle
 - function definition as subgraph
 - npm / remote package loading

--- a/docs/design/semantic-component-access-v0.md
+++ b/docs/design/semantic-component-access-v0.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-This note documents the current v0 foundation for semantic component access in support of afjk/loomlet#208.
-It focuses on the currently implemented predicate DSL behavior and intended lowering model, while deferring broader value-model/editor work.
+This note documents the current v0 foundation for semantic component access in support of afjk/loomlet#208 and afjk/loomlet#256.
+It focuses on predicate DSL behavior, general DSL expression access, and the explicit lowering model, while deferring broader value-model/editor work.
 
 ## Public vocabulary (v0)
 
@@ -43,7 +43,7 @@ It does not introduce automatic world/local conversion in core.
 
 ## Current v0 implementation status
 
-Current implementation is limited to filter predicate DSL field access on `value`:
+Filter predicate DSL field access on `value` supports:
 
 - `value.right`
 - `value.up`
@@ -55,7 +55,17 @@ Current implementation is limited to filter predicate DSL field access on `value
 This behavior is implemented in `RestrictedDSLEvaluator` and covered by tests in `test/stdlib-baseline.test.mjs`.
 For predicate compatibility, `value.x` / `value.y` are still accepted internally today, but they are not the preferred semantic public vocabulary for this v0 direction.
 
-General DSL expression component access is not fully implemented yet and remains future work.
+General DSL expressions also support single-component access:
+
+- `expr.right`
+- `expr.up`
+- `expr.front`
+- `expr.r`
+- `expr.u`
+- `expr.f`
+
+These expressions lower to explicit `getComponent` graph nodes with a normalized `component` parameter.
+Multi-component swizzles such as `expr.ru` are not implemented in this v0 scope.
 
 ## Virtual node / lowering model
 
@@ -66,7 +76,7 @@ Intended lowering model:
 
 - `v.right` → `getComponent(v, "right")`
 - `v.r` → `getComponent(v, "right")`
-- `v.ru` → `swizzle(v, ["right", "up"])`
+- `v.ru` → future `swizzle(v, ["right", "up"])`
 
 Node Editor may eventually expose virtual component ports, but compiled/exported graphs must preserve explicit semantics.
 
@@ -86,7 +96,6 @@ Multi-component swizzle is future work unless/until implemented in runtime/compi
 
 ## Explicitly deferred
 
-- General DSL expression component access
 - Multi-component swizzle return shape
 - Node Editor virtual port UI
 - Automatic world/local conversion

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -32,6 +32,13 @@ const TT = {
 const posFrom = (line, column, offset) => ({ line, column, offset });
 const spanFrom = (s, e) => ({ start: s, end: e });
 const mkIdent = (tok) => ({ type: 'Identifier', name: tok.value, span: tok.span });
+const SEMANTIC_COMPONENT_ALIASES = {
+  r: 'right',
+  u: 'up',
+  f: 'front'
+};
+const SEMANTIC_COMPONENTS = new Set(['right', 'up', 'front', ...Object.keys(SEMANTIC_COMPONENT_ALIASES)]);
+const normalizeSemanticComponent = (component) => SEMANTIC_COMPONENT_ALIASES[component] || component;
 
 function tokenize(src) {
   const tokens = [];
@@ -139,15 +146,39 @@ export function parseDSLToAST(source) {
       return parsePipe();
     }
     function parsePipe() { let left = parseAtom(); while (true) { if (peek().type === TT.PIPE || (peek().type === TT.NEWLINE && peek(1).type === TT.PIPE)) { if (peek().type === TT.NEWLINE) take(); const pt = take(); const right = parseCall(); left = { type: 'PipeExpression', left, right, span: spanFrom(left.span.start, right.span.end) }; } else break; } return left; }
+    function isCallStart() {
+      if (peek().type !== TT.IDENT) return false;
+      let lookahead = 1;
+      while (peek(lookahead).type === TT.DOT && peek(lookahead + 1).type === TT.IDENT) lookahead += 2;
+      return peek(lookahead).type === TT.LPAREN;
+    }
+    function parseMemberPostfix(object) {
+      let expr = object;
+      while (peek().type === TT.DOT) {
+        take();
+        const property = expect(TT.IDENT);
+        expr = {
+          type: 'MemberExpression',
+          object: expr,
+          property: mkIdent(property),
+          span: spanFrom(expr.span.start, property.span.end)
+        };
+      }
+      return expr;
+    }
     function parseAtom() {
       const t = peek();
       if (t.type === TT.NUMBER) { take(); return { type: 'NumberLiteral', value: t.value.value, raw: t.value.raw, span: t.span }; }
       if (t.type === TT.STRING) { take(); return { type: 'StringLiteral', value: t.value.value, raw: t.value.raw, span: t.span }; }
       if (t.type === TT.BOOL) { take(); return { type: 'BooleanLiteral', value: t.value, span: t.span }; }
       if (t.type === TT.NULL) { take(); return { type: 'NullLiteral', span: t.span }; }
-      if (t.type === TT.LBRACKET) return parseArray();
-      if (t.type === TT.LBRACE) return parseObject();
-      if (t.type === TT.IDENT) { if (peek(1).type === TT.LPAREN || peek(1).type === TT.DOT) return parseCall(); take(); return mkIdent(t); }
+      if (t.type === TT.LBRACKET) return parseMemberPostfix(parseArray());
+      if (t.type === TT.LBRACE) return parseMemberPostfix(parseObject());
+      if (t.type === TT.IDENT) {
+        if (isCallStart()) return parseMemberPostfix(parseCall());
+        take();
+        return parseMemberPostfix(mkIdent(t));
+      }
       throw new LoomDSLError(`Unexpected token: ${t.type}`, t.span.start.line, t.span.start.column, 'UNEXPECTED_TOKEN');
     }
     function parseArray() { const st = expect(TT.LBRACKET); const elements = []; while (peek().type !== TT.RBRACKET && peek().type !== TT.EOF) { elements.push(parseExpr()); if (peek().type === TT.COMMA) take(); else break; } const ed = expect(TT.RBRACKET); return { type: 'ArrayLiteral', elements, span: spanFrom(st.span.start, ed.span.end) }; }
@@ -213,7 +244,7 @@ export function parseDSLToAST(source) {
       let stmt;
       if (stTok.type === TT.IDENT && stTok.value === 'render') { take(); const call = parseCall(); stmt = { type: 'RenderStatement', call, span: spanFrom(stTok.span.start, call.span.end) }; }
       else if (stTok.type === TT.IDENT && peek(1).type === TT.ASSIGN) { const target = mkIdent(take()); take(); const value = parseExpr(); stmt = { type: 'AssignmentStatement', target, value, span: spanFrom(target.span.start, value.span.end) }; }
-      else if (stTok.type === TT.IDENT && (peek(1).type === TT.LPAREN || peek(1).type === TT.DOT)) { const expression = parseCall(); stmt = { type: 'ExpressionStatement', expression, span: expression.span }; }
+      else if (stTok.type === TT.IDENT && (peek(1).type === TT.LPAREN || peek(1).type === TT.DOT)) { const expression = parseExpr(); stmt = { type: 'ExpressionStatement', expression, span: expression.span }; }
       else throw new LoomDSLError('Expected assignment or render statement', stTok.span.start.line, stTok.span.start.column, 'UNEXPECTED_TOKEN');
       seenNonImportStatement = true;
       if (pendingComments.length) { stmt.leadingComments = pendingComments; pendingComments = []; }
@@ -264,6 +295,7 @@ function astToLegacy(program) {
     if (e.type === 'CallExpression') return { type: 'call', name: e.callee.name, args: e.args.map(a => a.type === 'NamedArg' ? { named: true, name: a.name.name, value: convExpr(a.value) } : { named: false, value: convExpr(a.value) }), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'FunctionLiteral') return { type: 'fn', params: e.params.map((p) => p.name), body: convExpr(e.body), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'PipeExpression') return { type: 'pipe', left: convExpr(e.left), call: convExpr(e.right) };
+    if (e.type === 'MemberExpression') return { type: 'member', object: convExpr(e.object), property: e.property.name, line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'Identifier') return { type: 'ident', name: e.name, line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'NumberLiteral') return { type: 'number', value: e.value, line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'StringLiteral') return { type: 'string', value: e.value, line: e.span.start.line, col: e.span.start.column };
@@ -325,6 +357,15 @@ function buildGraph(stmts, options = {}) { /* mostly original */
     nodes.push({ id, type: 'constant', params: { value: expr.value } });
     return id;
   }
+  function buildMember(expr, resultId) {
+    if (!SEMANTIC_COMPONENTS.has(expr.property)) {
+      throw new LoomDSLError(`Unsupported semantic component access: ${expr.property}`, expr.line, expr.col, 'UNKNOWN_ARGUMENT');
+    }
+    const id = resultId || anonId();
+    nodes.push({ id, type: 'getComponent', params: { component: normalizeSemanticComponent(expr.property) } });
+    wireToNode(expr.object, id, 'value');
+    return id;
+  }
   function buildUserCall(call, resultId) {
     const id = resultId || anonId();
     nodes.push({ id, type: 'function.call' });
@@ -337,17 +378,17 @@ function buildGraph(stmts, options = {}) { /* mostly original */
   }
   function wireToNode(expr, id, port) {
     if (expr.type === 'ident') edges.push({ from: resolveIdent(expr.name, expr.line, expr.col), to: `${id}.${port}` });
-    else if (expr.type === 'call' || expr.type === 'pipe' || expr.type === 'fn') { const inId = buildExpr(expr, null, null); const inNode = nodes.find(n => n.id === inId); edges.push({ from: `${inId}.${defaultOutputPort(inNode.type, nodeTypes)}`, to: `${id}.${port}` }); }
+    else if (expr.type === 'call' || expr.type === 'pipe' || expr.type === 'fn' || expr.type === 'member') { const inId = buildExpr(expr, null, null); const inNode = nodes.find(n => n.id === inId); edges.push({ from: `${inId}.${defaultOutputPort(inNode.type, nodeTypes)}`, to: `${id}.${port}` }); }
     else { const nodeObj = nodes.find(n => n.id === id); nodeObj.params ||= {}; nodeObj.params[port] = expr.value; }
   }
   function buildNode(call, resultId, pipeFrom) { const fnName = call.name; if (!nodeTypes[fnName]) { if (scope[fnName]) return buildUserCall(call, resultId); throw new LoomDSLError(`Unknown node type: ${fnName}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); } const typeDef = nodeTypes[fnName]; const id = resultId || anonId(); const nodeObj = { id, type: fnName }; nodes.push(nodeObj); const inputNames = typeDef.inputs.map(i => i.name); const paramNames = (typeDef.params || []).map(p => p.name); const pos = call.args.filter(a => !a.named); const named = call.args.filter(a => a.named); const hasUnknownNamed = named.some(a => !inputNames.includes(a.name) && !paramNames.includes(a.name)); if (typeDef.commutative && pos.length && named.length && !hasUnknownNamed) throw new LoomDSLError(`Node '${fnName}' is commutative: arguments must be all positional or all named`, call.line, call.col, 'MISSING_ARGUMENT_NAME'); if (!canUseTwoPositionalArgs(fnName, typeDef) && pos.length > (pipeFrom ? 0 : 1)) throw new LoomDSLError(`Argument at position 2 for '${fnName}' requires a name`, call.line, call.col, 'MISSING_ARGUMENT_NAME'); let idx = 0;
     const wire = (expr, port) => wireToNode(expr, id, port);
     if (pipeFrom) edges.push({ from: pipeFrom, to: `${id}.${inputNames[idx++]}` });
     for (const a of pos) wire(a.value, inputNames[idx++]);
-    for (const a of named) { if (inputNames.includes(a.name)) wire(a.value, a.name); else if (paramNames.includes(a.name)) { if (a.value.type === 'ident' || a.value.type === 'call' || a.value.type === 'fn') throw new LoomDSLError(`Parameter '${a.name}' for '${fnName}' must be a literal`, call.line, call.col, 'UNEXPECTED_TOKEN'); nodeObj.params ||= {}; nodeObj.params[a.name] = a.value.value; } else throw new LoomDSLError(`Unknown argument '${a.name}' for '${fnName}'`, call.line, call.col, 'UNKNOWN_ARGUMENT'); }
+    for (const a of named) { if (inputNames.includes(a.name)) wire(a.value, a.name); else if (paramNames.includes(a.name)) { if (a.value.type === 'ident' || a.value.type === 'call' || a.value.type === 'fn' || a.value.type === 'member') throw new LoomDSLError(`Parameter '${a.name}' for '${fnName}' must be a literal`, call.line, call.col, 'UNEXPECTED_TOKEN'); nodeObj.params ||= {}; nodeObj.params[a.name] = a.value.value; } else throw new LoomDSLError(`Unknown argument '${a.name}' for '${fnName}'`, call.line, call.col, 'UNKNOWN_ARGUMENT'); }
     return id; };
-  const buildExpr = (expr, resultId, pipeFrom) => expr.type === 'call' ? buildNode(expr, resultId, pipeFrom) : expr.type === 'fn' ? buildFunctionLiteral(expr, resultId) : ['number', 'string', 'bool', 'null', 'array', 'object'].includes(expr.type) ? buildLiteral(expr, resultId) : expr.type === 'pipe' ? (() => { const lId = buildExpr(expr.left, null, null); const ln = nodes.find(n => n.id === lId); return buildNode(expr.call, resultId, `${lId}.${defaultOutputPort(ln.type)}`); })() : expr.type === 'ident' ? scope[expr.name] || (()=>{throw new LoomDSLError(`Undefined identifier: ${expr.name}`, expr.line, expr.col, 'UNDEFINED_IDENTIFIER');})() : (()=>{throw new LoomDSLError('Cannot use literal as expression', expr.line, expr.col, 'UNEXPECTED_TOKEN');})();
-  const buildRender = (call) => { const named = {}; for (const a of call.args) { if (!a.named) throw new LoomDSLError('render arguments must be named', call.line, call.col, 'MISSING_ARGUMENT_NAME'); named[a.name] = a.value; } const rv = (e) => e.type === 'ident' ? resolveIdent(e.name, e.line, e.col) : e.value; if (call.name === 'point') return { type: 'point', x: named.x ? rv(named.x) : undefined, y: named.y ? rv(named.y) : undefined, color: named.color ? named.color.value : '#00ff00', trail: named.trail ? named.trail.value : 0.1 }; if (call.name === 'bar') return { type: 'bar', width: named.width ? rv(named.width) : undefined, color: named.color ? named.color.value : '#00ccff', height: named.height ? named.height.value : 40, y: named.y ? rv(named.y) : undefined }; throw new LoomDSLError(`Unknown render function: ${call.name}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); };
+  const buildExpr = (expr, resultId, pipeFrom) => expr.type === 'call' ? buildNode(expr, resultId, pipeFrom) : expr.type === 'fn' ? buildFunctionLiteral(expr, resultId) : ['number', 'string', 'bool', 'null', 'array', 'object'].includes(expr.type) ? buildLiteral(expr, resultId) : expr.type === 'member' ? buildMember(expr, resultId) : expr.type === 'pipe' ? (() => { const lId = buildExpr(expr.left, null, null); const ln = nodes.find(n => n.id === lId); return buildNode(expr.call, resultId, `${lId}.${defaultOutputPort(ln.type)}`); })() : expr.type === 'ident' ? scope[expr.name] || (()=>{throw new LoomDSLError(`Undefined identifier: ${expr.name}`, expr.line, expr.col, 'UNDEFINED_IDENTIFIER');})() : (()=>{throw new LoomDSLError('Cannot use literal as expression', expr.line, expr.col, 'UNEXPECTED_TOKEN');})();
+  const buildRender = (call) => { const named = {}; for (const a of call.args) { if (!a.named) throw new LoomDSLError('render arguments must be named', call.line, call.col, 'MISSING_ARGUMENT_NAME'); named[a.name] = a.value; } const rv = (e) => { if (e.type === 'ident') return resolveIdent(e.name, e.line, e.col); if (e.type === 'member' || e.type === 'call' || e.type === 'pipe') { const id = buildExpr(e, null, null); const node = nodes.find(n => n.id === id); return `${id}.${defaultOutputPort(node.type, nodeTypes)}`; } return e.value; }; if (call.name === 'point') return { type: 'point', x: named.x ? rv(named.x) : undefined, y: named.y ? rv(named.y) : undefined, color: named.color ? named.color.value : '#00ff00', trail: named.trail ? named.trail.value : 0.1 }; if (call.name === 'bar') return { type: 'bar', width: named.width ? rv(named.width) : undefined, color: named.color ? named.color.value : '#00ccff', height: named.height ? named.height.value : 40, y: named.y ? rv(named.y) : undefined }; throw new LoomDSLError(`Unknown render function: ${call.name}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); };
   for (const s of stmts) {
     if (s.type === 'render') renderConfig = buildRender(s.call);
     else if (s.type === 'effect') buildExpr(s.expr, `_effect${++effectCounter}`, null);
@@ -378,6 +419,7 @@ export function formatDSL(ast, options = {}) {
       for (const c of chain) lines.push(`${indent(level + 1)}|> ${fmtExpr(c, level + 1)}`);
       return lines.join('\n');
     }
+    if (e.type === 'MemberExpression') return `${fmtExpr(e.object, level)}.${e.property.name}`;
     if (e.type === 'CallExpression') return fmtCall(e, level);
     if (e.type === 'Identifier') return e.name;
     if (e.type === 'NumberLiteral' || e.type === 'StringLiteral') return e.raw;

--- a/src/nodes/core.js
+++ b/src/nodes/core.js
@@ -1,5 +1,7 @@
 import { LoomError, RestrictedDSLEvaluator, coerceFiniteNumber, getNodeFs, getNodePath, inspectValue, resolveStateInputValue, sanitizeStateValue, stringifyJsonValue, stringifyTextValue, toArray } from './helpers.js';
 
+const SEMANTIC_COMPONENTS = new Set(['right', 'up', 'front']);
+
 export function registerCoreNodes(registry) {
   registry.registerNodeType('input', {
     category: 'source',
@@ -192,6 +194,23 @@ export function registerCoreNodes(registry) {
   registry.registerNodeType('debug.assert', { category: 'transform', inputs: [{ name: 'condition', type: 'any', default: false, kind: 'behavior' }, { name: 'message', type: 'string', default: 'Assertion failed', kind: 'behavior' }], outputs: [{ name: 'out', type: 'boolean', kind: 'behavior' }], params: [{ name: 'condition', type: 'any', default: false }, { name: 'message', type: 'string', default: 'Assertion failed' }], evaluate: (inputs) => { if (!inputs.condition) throw new LoomError('ASSERTION_FAILED', stringifyTextValue(inputs.message) || 'Assertion failed'); return { out: true }; } });
   registry.registerNodeType('debug.inspect', { category: 'transform', inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }], outputs: [{ name: 'out', type: 'string', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: null }], evaluate: (inputs) => ({ out: inspectValue(inputs.value) }) });
   registry.registerNodeType('debug.trace', { category: 'transform', inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }, { name: 'label', type: 'string', default: 'trace', kind: 'behavior' }], outputs: [{ name: 'out', type: 'any', kind: 'behavior' }], params: [{ name: 'value', type: 'any', default: null }, { name: 'label', type: 'string', default: 'trace' }], evaluate: (inputs, params, ctx) => { ctx.engine?._recordEffect({ type: 'debug.trace', label: inputs.label, value: inputs.value, nodeId: ctx.currentNodeId }); return { out: inputs.value }; } });
+  registry.registerNodeType('getComponent', {
+    category: 'transform',
+    inputs: [{ name: 'value', type: 'any', default: null, kind: 'behavior' }],
+    outputs: [{ name: 'out', type: 'any', kind: 'behavior' }],
+    params: [{ name: 'component', type: 'string', default: 'right' }],
+    evaluate: (inputs, params) => {
+      const value = inputs.value;
+      const component = String(params.component ?? '');
+      if (!SEMANTIC_COMPONENTS.has(component)) {
+        return { out: undefined };
+      }
+      if (value != null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, component)) {
+        return { out: value[component] };
+      }
+      return { out: undefined };
+    }
+  });
   registry.registerNodeType('delay1', {
     category: 'state',
     inputs: [

--- a/test/loom-dsl.test.html
+++ b/test/loom-dsl.test.html
@@ -306,6 +306,37 @@ wave = sine(t, freq: 0.3, amplitude: 2)`;
       assert(out.graph.nodes.some(n => n.id === "_effect1" && n.type === "console.log"), "effect node generated");
       assert(out.graph.edges.some(e => e.to === "_effect1.value"), "effect edge generated");
     });
+    test("18f. compileToGraph lowers semantic component access to getComponent", () => {
+      const src = `v = constant(value: {right: 3, up: 4, front: 5})\nr = v.right\nu = v.u`;
+      const { ast, errors } = parseDSLToAST(src);
+      assertEqual(errors.length, 0);
+      assertEqual(ast.body[1].value.type, "MemberExpression");
+      const out = compileToGraph(ast);
+      assertEqual(out.errors.length, 0);
+      assert(hasNode(out.graph.nodes, "r", "getComponent"), "right access node generated");
+      assert(hasNode(out.graph.nodes, "u", "getComponent"), "alias access node generated");
+      assertEqual(out.graph.nodes.find(n => n.id === "r").params, { component: "right" });
+      assertEqual(out.graph.nodes.find(n => n.id === "u").params, { component: "up" });
+      assert(hasEdge(out.graph.edges, "v.out", "r.value"));
+      assert(hasEdge(out.graph.edges, "v.out", "u.value"));
+    });
+    test("18g. compileToGraph rejects unsupported component swizzle", () => {
+      const { ast } = parseDSLToAST("v = constant(value: {right: 1})\nru = v.ru");
+      const out = compileToGraph(ast);
+      assert(out.errors.length > 0, "compile error returned");
+      assertEqual(out.errors[0].code, "UNKNOWN_ARGUMENT");
+    });
+    test("18h. compileToGraph supports semantic component access in render args", () => {
+      const { ast } = parseDSLToAST("v = constant(value: {right: 1, up: 2})\nrender point(x: v.right, y: v.up)");
+      const out = compileToGraph(ast);
+      assertEqual(out.errors.length, 0);
+      const xNode = out.graph.nodes.find(n => n.type === "getComponent" && n.params.component === "right");
+      const yNode = out.graph.nodes.find(n => n.type === "getComponent" && n.params.component === "up");
+      assert(xNode, "x component node");
+      assert(yNode, "y component node");
+      assertEqual(out.graph.render.x, `${xNode.id}.out`);
+      assertEqual(out.graph.render.y, `${yNode.id}.out`);
+    });
 
     test("19. parseDSLToAST parse error is non-throwing", () => {
       const out = parseDSLToAST("a = ");

--- a/test/stdlib-baseline.test.mjs
+++ b/test/stdlib-baseline.test.mjs
@@ -122,6 +122,41 @@ test('debug baseline nodes', () => {
   assert.throws(() => evalNode('debug.assert', { condition: false, message: 'bad' }), (error) => error instanceof LoomError && error.code === 'ASSERTION_FAILED' && /bad/.test(error.message));
 });
 
+test('getComponent reads explicit semantic vector components', () => {
+  const graph = {
+    nodes: [
+      { id: 'vector', type: 'constant', params: { value: { right: 2, up: 3, front: 4 } } },
+      { id: 'right', type: 'getComponent', params: { component: 'right' } },
+      { id: 'up', type: 'getComponent', params: { component: 'up' } },
+      { id: 'front', type: 'getComponent', params: { component: 'front' } }
+    ],
+    edges: [
+      { from: 'vector.out', to: 'right.value' },
+      { from: 'vector.out', to: 'up.value' },
+      { from: 'vector.out', to: 'front.value' }
+    ]
+  };
+  const engine = new Loom(graph);
+  engine.evaluateOnce();
+
+  assert.equal(engine.getValue('right.out'), 2);
+  assert.equal(engine.getValue('up.out'), 3);
+  assert.equal(engine.getValue('front.out'), 4);
+  assert.equal(evalNode('getComponent', { value: { x: 9 }, component: 'x' }), undefined);
+});
+
+test('DSL semantic component access evaluates through explicit getComponent nodes', () => {
+  const result = runLoomSource('v = constant(value: {right: 2, up: 3, front: 4})\nr = v.r\nf = v.front', {
+    get: ['r.out', 'f.out']
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.values['r.out'], 2);
+  assert.equal(result.values['f.out'], 4);
+  assert.ok(result.graph.nodes.some((node) => node.id === 'r' && node.type === 'getComponent'));
+  assert.ok(result.graph.nodes.some((node) => node.id === 'f' && node.type === 'getComponent'));
+});
+
 test('clock reads host-provided env.time deterministically', () => {
   const graph = {
     nodes: [


### PR DESCRIPTION
## Summary

Closes #256.

## What changed

- Added general DSL expression access for `expr.right`, `expr.up`, `expr.front`, and aliases `expr.r`, `expr.u`, `expr.f`.
- Lowers semantic component access to explicit `getComponent` graph nodes with normalized component params.
- Added runtime `getComponent` behavior for semantic components only.
- Updated semantic component docs/release notes and focused tests.

## Tests run

- `node --check src/loom-dsl.js`
- `node --test --test-name-pattern "getComponent|DSL semantic component access" test/stdlib-baseline.test.mjs`
- `node test/runtime-metadata-drift.test.mjs`
- Direct parser/compiler smoke via `node --input-type=module -e ...`

## Focused tests

- `position.right`, `position.up`, `position.front` lowering.
- `position.r`, `position.u`, `position.f` alias normalization.
- Multi-component swizzle rejection for this v0 scope.
- Runtime `getComponent` evaluation.

## Known limitations

- Single-component access only.
- No `.ru`, `.rf`, `.uf`, or `.ruf` swizzles.
- No `x/y/z` preferred public API.
- No host coordinate conversion or world/local conversion.
- Browser harness tests were not run because Playwright was not used during cleanup.

## Follow-up work

- Implement #261 multi-component semantic swizzle separately after this PR stabilizes.

## Scope check

- [x] This PR only addresses #256.
- [x] Non-goals from the issue are respected.
- [x] No unrelated implementation is included.
- [x] No afjk.jp runtime dependency is introduced.
- [x] Scene Sync Export self-containment is not broken.
