### PR TITLE
Stabilize Unity renderer color binding test

### DIFF
--- a/unity/com.afjk.loomlet-runtime/Runtime/Unity/LoomletBehaviourRunner.cs
+++ b/unity/com.afjk.loomlet-runtime/Runtime/Unity/LoomletBehaviourRunner.cs
@@ -79,6 +79,7 @@ namespace Loomlet.Unity
                     ResolveTransform(fallbackObject).localScale = LoomletUnityConversions.Vector3(value, ResolveTransform(fallbackObject).localScale);
                     break;
                 case LoomletUnityProperty.RendererColor:
+                    if (value == null) return;
                     var renderer = ResolveRenderer(fallbackObject);
                     if (renderer != null) LoomletUnityMaterialColor.Apply(renderer, LoomletUnityConversions.Color(value, Color.white));
                     break;

--- a/unity/com.afjk.loomlet-runtime/Tests/EditMode/LoomletUnityAdapterTests.cs
+++ b/unity/com.afjk.loomlet-runtime/Tests/EditMode/LoomletUnityAdapterTests.cs
@@ -55,7 +55,42 @@ namespace Loomlet.Runtime.Tests
                 var block = new MaterialPropertyBlock();
                 go.GetComponent<Renderer>().GetPropertyBlock(block);
 
-                Assert.AreEqual(new Color(0.25f, 0.5f, 0.75f, 1f), block.GetColor("_Color"));
+                AssertColor(new Color(0.25f, 0.5f, 0.75f, 1f), block.GetColor("_Color"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void RendererColorBindingDoesNothingForMissingOutput()
+        {
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            try
+            {
+                var renderer = go.GetComponent<Renderer>();
+                var initial = new Color(0.1f, 0.2f, 0.3f, 1f);
+                LoomletUnityMaterialColor.Apply(renderer, initial);
+
+                var binding = new LoomletUnityBinding
+                {
+                    output = "missing.out",
+                    property = LoomletUnityProperty.RendererColor
+                };
+
+                binding.Apply(CreateHostInputResult(new Dictionary<string, object>
+                {
+                    ["r"] = 1.0,
+                    ["g"] = 1.0,
+                    ["b"] = 1.0,
+                    ["a"] = 1.0
+                }), go);
+
+                var block = new MaterialPropertyBlock();
+                renderer.GetPropertyBlock(block);
+
+                AssertColor(initial, block.GetColor("_Color"));
             }
             finally
             {
@@ -68,6 +103,15 @@ namespace Loomlet.Runtime.Tests
             var graph = LoomletGraph.FromJson("{\"nodes\":[{\"id\":\"color\",\"type\":\"host.input\",\"params\":{\"name\":\"color\"}}],\"edges\":[]}");
             var context = new LoomletEvaluationContext().SetHostInput("color", value);
             return new LoomletEvaluator(graph).Evaluate(context);
+        }
+
+        private static void AssertColor(Color expected, Color actual)
+        {
+            const float tolerance = 0.0001f;
+            Assert.That(actual.r, Is.EqualTo(expected.r).Within(tolerance), "r");
+            Assert.That(actual.g, Is.EqualTo(expected.g).Within(tolerance), "g");
+            Assert.That(actual.b, Is.EqualTo(expected.b).Within(tolerance), "b");
+            Assert.That(actual.a, Is.EqualTo(expected.a).Within(tolerance), "a");
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Unity EditMode color binding assertion that can fail even when the displayed RGBA values are identical.

- Compare renderer property block color components with a small tolerance instead of exact `Color` object equality.
- Make `RendererColor` binding no-op when the configured output is missing/null, avoiding accidental fallback-to-white behavior.
- Add a test covering missing renderer color output preserving the existing property block color.

## Verification

- `git diff --check`

Could not run Unity EditMode tests locally from this workspace because `uloop get-project-info` reports no Unity project at the repository root.