### PR TITLE
[codex] Publish Unity runtime to UPM

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -191,3 +191,36 @@ jobs:
           npx @vscode/vsce publish --packagePath "$VSIX" -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  publish-unity-upm:
+    needs:
+      - build-release-artifacts
+      - publish-npm
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Publish Unity Runtime to upm.afjk.jp
+        working-directory: unity/com.afjk.loomlet-runtime
+        env:
+          UPM_TOKEN: ${{ secrets.UPM_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -z "$UPM_TOKEN" ]; then
+            echo "UPM_TOKEN secret is required to publish to upm.afjk.jp"
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          npm pack --dry-run
+
+          echo "//upm.afjk.jp/:_authToken=${UPM_TOKEN}" > ~/.npmrc
+          npm publish --registry https://upm.afjk.jp

--- a/unity/com.afjk.loomlet-runtime/CHANGELOG.md
+++ b/unity/com.afjk.loomlet-runtime/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.3.0
+
+- Prepare `com.afjk.loomlet-runtime` for publishing to the `upm.afjk.jp` scoped registry.
+- Include runtime-only Unity assemblies for consuming compiled Loomlet Graph JSON.

--- a/unity/com.afjk.loomlet-runtime/CHANGELOG.md.meta
+++ b/unity/com.afjk.loomlet-runtime/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4c7324f67d2e4b3eb8478fa5df0bf7c2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/com.afjk.loomlet-runtime/LICENSE.md
+++ b/unity/com.afjk.loomlet-runtime/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 afjk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/unity/com.afjk.loomlet-runtime/LICENSE.md.meta
+++ b/unity/com.afjk.loomlet-runtime/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 96d3e30533194a129342186937b2d5b8
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/com.afjk.loomlet-runtime/README.md
+++ b/unity/com.afjk.loomlet-runtime/README.md
@@ -28,7 +28,7 @@ Add the afjk scoped registry and the package dependency to `Packages/manifest.js
 }
 ```
 
-The package version follows the Loomlet GitHub Release tag without the leading `v`. For example, release tag `v0.3.0` publishes `com.afjk.loomlet-runtime@0.3.0`.
+The package version follows the Loomlet GitHub Release tag without the leading `v`. For example, release tag `v0.3.0` publishes `com.afjk.loomlet-runtime@0.3.0`. Replace `0.3.0` with the version you want to install.
 
 ## Runtime model
 
@@ -36,9 +36,9 @@ Loomlet authoring and compilation happen outside Unity. Use the JavaScript CLI, 
 
 Scene Sync Unity packages can depend on this package for graph evaluation and Unity object adapters. This runtime package does not depend on Scene Sync.
 
-## Fixture parity
+## Fixture parity for repository development
 
-EditMode tests use `Tests/Fixtures/portable-node-cases.json`, copied from `test/fixtures/runtime-parity/portable-node-cases.json`. Run `npm test` from the repository root to detect fixture drift.
+In this repository, EditMode tests use `Tests/Fixtures/portable-node-cases.json`, copied from `test/fixtures/runtime-parity/portable-node-cases.json`. Run `npm test` from the repository root to detect fixture drift. These tests are not included in the published UPM package.
 
 ## Scene Sync
 

--- a/unity/com.afjk.loomlet-runtime/README.md
+++ b/unity/com.afjk.loomlet-runtime/README.md
@@ -9,6 +9,33 @@ The package is split into:
 
 `Loomlet.Runtime` does not reference `UnityEngine`. Host authority remains outside user behavior graphs: Scene Clock values are read-only, and pause/seek/resume/reset/follow-server controls are host-side operations rather than Loomlet effects.
 
+## Installation
+
+Add the afjk scoped registry and the package dependency to `Packages/manifest.json`:
+
+```json
+{
+  "scopedRegistries": [
+    {
+      "name": "afjk UPM Registry",
+      "url": "https://upm.afjk.jp",
+      "scopes": ["com.afjk"]
+    }
+  ],
+  "dependencies": {
+    "com.afjk.loomlet-runtime": "0.3.0"
+  }
+}
+```
+
+The package version follows the Loomlet GitHub Release tag without the leading `v`. For example, release tag `v0.3.0` publishes `com.afjk.loomlet-runtime@0.3.0`.
+
+## Runtime model
+
+Loomlet authoring and compilation happen outside Unity. Use the JavaScript CLI, VS Code extension, Node Editor, or another host tool to produce Loomlet Graph JSON, then load that Graph JSON in Unity. Unity does not parse `.loomlet` DSL source and does not compile DSL files.
+
+Scene Sync Unity packages can depend on this package for graph evaluation and Unity object adapters. This runtime package does not depend on Scene Sync.
+
 ## Fixture parity
 
 EditMode tests use `Tests/Fixtures/portable-node-cases.json`, copied from `test/fixtures/runtime-parity/portable-node-cases.json`. Run `npm test` from the repository root to detect fixture drift.

--- a/unity/com.afjk.loomlet-runtime/package.json
+++ b/unity/com.afjk.loomlet-runtime/package.json
@@ -4,6 +4,17 @@
   "displayName": "Loomlet Runtime",
   "description": "Runtime-only Unity package for evaluating compiled Loomlet Graph JSON.",
   "unity": "2021.3",
+  "files": [
+    "Runtime",
+    "Runtime.meta",
+    "README.md",
+    "README.md.meta",
+    "CHANGELOG.md",
+    "CHANGELOG.md.meta",
+    "LICENSE.md",
+    "LICENSE.md.meta",
+    "package.json.meta"
+  ],
   "keywords": [
     "loomlet",
     "dataflow",
@@ -14,5 +25,8 @@
     "name": "afjk",
     "url": "https://github.com/afjk"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://upm.afjk.jp"
+  }
 }


### PR DESCRIPTION
## Summary

- Add a `publish-unity-upm` release job that publishes `unity/com.afjk.loomlet-runtime` to `https://upm.afjk.jp` after release artifacts and npm publish complete.
- Align the Unity package version from the GitHub Release tag, run `npm pack --dry-run`, and publish using the `UPM_TOKEN` secret.
- Prepare the Unity package metadata and docs for UPM distribution with scoped registry install instructions, changelog, and license files.

Closes #284.

## Validation

- `npm_config_cache=/private/tmp/npm-cache npm pack --dry-run` in `unity/com.afjk.loomlet-runtime`
- Workflow YAML parsed successfully with Ruby `YAML.load_file`
- `npm_config_cache=/private/tmp/npm-cache npx -y -p node@20 -p npm@10 npm test`

Note: local `/usr/local/bin/node` is `v20.11.1` and fails an existing fs node baseline because `process.getBuiltinModule` is unavailable there; the latest Node 20 used by Actions passes.
