### PR TITLE
[codex] Add Unity math portable nodes

### DIFF
--- a/test/fixtures/runtime-parity/portable-node-cases.json
+++ b/test/fixtures/runtime-parity/portable-node-cases.json
@@ -346,6 +346,26 @@
       "expected": 8
     },
     {
+      "id": "math.abs.basic",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.abs",
+            "params": {
+              "value": -5
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 5
+    },
+    {
       "id": "math.sine.at_zero",
       "library": "math",
       "level": "portable",
@@ -385,6 +405,209 @@
               "amplitude": 1,
               "phase": 0,
               "offset": 0
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.tan.at_zero",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.tan",
+            "params": {
+              "value": 0
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.tan.pi_over_4",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.tan",
+            "params": {
+              "value": 0.7853981633974483
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-12
+    },
+    {
+      "id": "math.smoothstep.midpoint",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 0.5,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0.5,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.below_range",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": -0.5,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.above_range",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 1.5,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.at_edge0",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 0,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.at_edge1",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 1,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.equal_edges_below",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 0.5,
+              "edge0": 1,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.equal_edges_at_edge",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 1,
+              "edge0": 1,
+              "edge1": 1
             }
           }
         ],

--- a/unity/com.afjk.loomlet-runtime/Runtime/Core/PortableNodes.cs
+++ b/unity/com.afjk.loomlet-runtime/Runtime/Core/PortableNodes.cs
@@ -17,6 +17,7 @@ namespace Loomlet.Runtime
 
         private static void RegisterMath(LoomletFunctionRegistry r)
         {
+            r.Register("math.abs", new[] { "value" }, (i, c) => Out(Math.Abs(LoomletValues.Number(i["value"]))));
             r.Register("math.add", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Number(i["a"]) + LoomletValues.Number(i["b"])));
             r.Register("math.subtract", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Number(i["a"]) - LoomletValues.Number(i["b"])));
             r.Register("math.multiply", new[] { "a", "b" }, (i, c) => Out(LoomletValues.Number(i["a"], 1) * LoomletValues.Number(i["b"], 1)));
@@ -44,6 +45,17 @@ namespace Loomlet.Runtime
             r.Register("math.pow", new[] { "value", "exponent" }, (i, c) => Out(Math.Pow(LoomletValues.Number(i["value"]), LoomletValues.Number(i["exponent"], 1))));
             r.Register("math.sine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (i, c) => Out(Math.Sin(LoomletValues.Number(i["t"]) * LoomletValues.Number(i["freq"], 1) * 2 * Math.PI + LoomletValues.Number(i["phase"])) * LoomletValues.Number(i["amplitude"], 1) + LoomletValues.Number(i["offset"])));
             r.Register("math.cosine", new[] { "t", "freq", "amplitude", "phase", "offset" }, (i, c) => Out(Math.Cos(LoomletValues.Number(i["t"]) * LoomletValues.Number(i["freq"], 1) * 2 * Math.PI + LoomletValues.Number(i["phase"])) * LoomletValues.Number(i["amplitude"], 1) + LoomletValues.Number(i["offset"])));
+            r.Register("math.tan", new[] { "value" }, (i, c) => Out(Math.Tan(LoomletValues.Number(i["value"]))));
+            r.Register("math.smoothstep", new[] { "x", "edge0", "edge1" }, (i, c) =>
+            {
+                var x = LoomletValues.Number(i["x"]);
+                var edge0 = LoomletValues.Number(i["edge0"]);
+                var edge1 = LoomletValues.Number(i["edge1"], 1);
+                if (edge0 == edge1) return Out(x < edge0 ? 0.0 : 1.0);
+                var t = (x - edge0) / (edge1 - edge0);
+                t = Math.Max(0, Math.Min(1, t));
+                return Out(t * t * (3 - 2 * t));
+            });
         }
 
         private static void RegisterLogic(LoomletFunctionRegistry r)

--- a/unity/com.afjk.loomlet-runtime/Tests/Fixtures/portable-node-cases.json
+++ b/unity/com.afjk.loomlet-runtime/Tests/Fixtures/portable-node-cases.json
@@ -346,6 +346,26 @@
       "expected": 8
     },
     {
+      "id": "math.abs.basic",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.abs",
+            "params": {
+              "value": -5
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 5
+    },
+    {
       "id": "math.sine.at_zero",
       "library": "math",
       "level": "portable",
@@ -385,6 +405,209 @@
               "amplitude": 1,
               "phase": 0,
               "offset": 0
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.tan.at_zero",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.tan",
+            "params": {
+              "value": 0
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.tan.pi_over_4",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.tan",
+            "params": {
+              "value": 0.7853981633974483
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-12
+    },
+    {
+      "id": "math.smoothstep.midpoint",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 0.5,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0.5,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.below_range",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": -0.5,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.above_range",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 1.5,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.at_edge0",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 0,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.at_edge1",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 1,
+              "edge0": 0,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 1,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.equal_edges_below",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 0.5,
+              "edge0": 1,
+              "edge1": 1
+            }
+          }
+        ],
+        "edges": []
+      },
+      "evaluate": {},
+      "get": "n.out",
+      "expected": 0,
+      "tolerance": 1e-9
+    },
+    {
+      "id": "math.smoothstep.equal_edges_at_edge",
+      "library": "math",
+      "level": "portable",
+      "graph": {
+        "nodes": [
+          {
+            "id": "n",
+            "type": "math.smoothstep",
+            "params": {
+              "x": 1,
+              "edge0": 1,
+              "edge1": 1
             }
           }
         ],


### PR DESCRIPTION
## Summary

Adds Unity/C# runtime implementations for portable math nodes that were already exposed in Loomlet metadata for Unity-compatible targets:

- `math.abs`
- `math.tan`
- `math.smoothstep`

The PR also extends the portable runtime parity fixture set with coverage for those nodes and syncs the Unity fixture copy so the drift check continues to enforce parity.

## Impact

Unity runtime consumers can evaluate compiled Graph JSON containing these portable math nodes instead of hitting unsupported-node errors. The shared parity fixtures now pin the expected behavior across the JavaScript and Unity runtime paths.

## Validation

- `node test/runtime-parity-fixtures.test.mjs`
- `node scripts/check-unity-runtime-fixtures.mjs`
- `npm test`