### PR TITLE
Add Scene Sync object audio node

### DIFF
--- a/dist/loomlet-scenesync-runtime.browser.js
+++ b/dist/loomlet-scenesync-runtime.browser.js
@@ -149,6 +149,13 @@ function defaultApplySceneEffect(effect, host) {
     if (typeof material?.color?.setRGB === 'function') {
       material.color.setRGB(effect.color[0], effect.color[1], effect.color[2]);
     }
+  } else if (effect.type === 'scene.setAudio') {
+    object.userData = object.userData || {};
+    object.userData.audio = {
+      url: effect.url,
+      playOnAwake: effect.playOnAwake !== false,
+      loop: effect.loop !== false
+    };
   }
 }
 
@@ -163,6 +170,15 @@ function makeSceneEffect(type, inputs, params, ctx) {
   if (type === 'scene.setScale') return { ...base, scale: [inputs.x, inputs.y, inputs.z].map(Number) };
   if (type === 'scene.setVisible') return { ...base, visible: Boolean(inputs.visible) };
   if (type === 'scene.setColor') return { ...base, color: [inputs.r, inputs.g, inputs.b].map(Number) };
+  if (type === 'scene.setAudio') {
+    return {
+      ...base,
+      url: stringifyText(inputs.url),
+      playOnAwake: inputs.playOnAwake !== false,
+      loop: inputs.loop !== false,
+      time: Number.isFinite(ctx.env.time) ? ctx.env.time : 0
+    };
+  }
   return base;
 }
 
@@ -453,7 +469,7 @@ function buildNodeTypes() {
     }
   });
 
-  const sceneTypes = ['scene.setPosition', 'scene.offsetPosition', 'scene.setRotation', 'scene.setScale', 'scene.setVisible', 'scene.setColor'];
+  const sceneTypes = ['scene.setPosition', 'scene.offsetPosition', 'scene.setRotation', 'scene.setScale', 'scene.setVisible', 'scene.setColor', 'scene.setAudio'];
   for (const type of sceneTypes) {
     register(type, {
       inputs: sceneInputsFor(type),
@@ -470,7 +486,8 @@ function buildNodeTypes() {
     sceneSetRotation: 'scene.setRotation',
     sceneSetScale: 'scene.setScale',
     sceneSetVisible: 'scene.setVisible',
-    sceneSetColor: 'scene.setColor'
+    sceneSetColor: 'scene.setColor',
+    sceneSetAudio: 'scene.setAudio'
   };
   for (const [alias, canonical] of Object.entries(adapterAliases)) {
     nodes[alias] = nodes[canonical];
@@ -485,6 +502,7 @@ function sceneInputsFor(type) {
   if (type === 'scene.setScale') return [objectId, { name: 'x', default: 1 }, { name: 'y', default: 1 }, { name: 'z', default: 1 }];
   if (type === 'scene.setVisible') return [objectId, { name: 'visible', default: true }];
   if (type === 'scene.setColor') return [objectId, { name: 'r', default: 1 }, { name: 'g', default: 1 }, { name: 'b', default: 1 }];
+  if (type === 'scene.setAudio') return [objectId, { name: 'url', default: '' }, { name: 'playOnAwake', default: true }, { name: 'loop', default: true }];
   return [objectId, { name: 'x', default: 0 }, { name: 'y', default: 0 }, { name: 'z', default: 0 }];
 }
 

--- a/dist/loomlet-scenesync-runtime.browser.js
+++ b/dist/loomlet-scenesync-runtime.browser.js
@@ -175,8 +175,7 @@ function makeSceneEffect(type, inputs, params, ctx) {
       ...base,
       url: stringifyText(inputs.url),
       playOnAwake: inputs.playOnAwake !== false,
-      loop: inputs.loop !== false,
-      time: Number.isFinite(ctx.env.time) ? ctx.env.time : 0
+      loop: inputs.loop !== false
     };
   }
   return base;

--- a/docs/STANDARD_LIBRARY_REFERENCE.md
+++ b/docs/STANDARD_LIBRARY_REFERENCE.md
@@ -352,6 +352,24 @@ Arguments:
 | y | number | no | Y offset. |
 | z | number | no | Z offset. |
 
+### scene.setAudio
+
+Signature: `scene.setAudio(objectId: "...", url: "https://...", playOnAwake: true, loop: true)`
+
+Returns: `void`
+Status: `implemented`
+
+Sets an audio component on a Scene Sync object.
+
+Arguments:
+
+| Name | Type | Positional | Description |
+|---|---|---:|---|
+| objectId | string | yes | ID of the object. |
+| url | string | no | HTTP(S) URL for an audio file. |
+| playOnAwake | boolean | no | Whether playback starts when the component is applied. |
+| loop | boolean | no | Whether playback loops. |
+
 ## math
 
 Pure math and numeric transform nodes

--- a/extensions/vscode-loomlet/generated/library-metadata.json
+++ b/extensions/vscode-loomlet/generated/library-metadata.json
@@ -466,6 +466,41 @@
               "description": "Z offset."
             }
           ]
+        },
+        {
+          "name": "setAudio",
+          "fullName": "scene.setAudio",
+          "status": "implemented",
+          "signature": "scene.setAudio(objectId: \"...\", url: \"https://...\", playOnAwake: true, loop: true)",
+          "description": "Sets an audio component on a Scene Sync object.",
+          "returns": "void",
+          "allowsTwoPositionalArgs": false,
+          "inputs": [
+            {
+              "name": "objectId",
+              "type": "string",
+              "positional": true,
+              "description": "ID of the object."
+            },
+            {
+              "name": "url",
+              "type": "string",
+              "positional": false,
+              "description": "HTTP(S) URL for an audio file."
+            },
+            {
+              "name": "playOnAwake",
+              "type": "boolean",
+              "positional": false,
+              "description": "Whether playback starts when the component is applied."
+            },
+            {
+              "name": "loop",
+              "type": "boolean",
+              "positional": false,
+              "description": "Whether playback loops."
+            }
+          ]
         }
       ]
     },

--- a/src/nodes/scene.js
+++ b/src/nodes/scene.js
@@ -105,4 +105,32 @@ export function registerSceneNodes(registry) {
       return {};
     }
   });
+  registry.registerNodeType('scene.setAudio', {
+    category: 'sink',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'url', type: 'string', default: '', kind: 'behavior' },
+      { name: 'playOnAwake', type: 'boolean', default: true, kind: 'behavior' },
+      { name: 'loop', type: 'boolean', default: true, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'url', type: 'string', default: '' },
+      { name: 'playOnAwake', type: 'boolean', default: true },
+      { name: 'loop', type: 'boolean', default: true }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.setAudio',
+        objectId: inputs.objectId,
+        url: inputs.url,
+        playOnAwake: inputs.playOnAwake !== false,
+        loop: inputs.loop !== false,
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  });
 }

--- a/src/scenesync-runtime.browser.js
+++ b/src/scenesync-runtime.browser.js
@@ -172,8 +172,7 @@ function makeSceneEffect(type, inputs, params, ctx) {
       ...base,
       url: stringifyText(inputs.url),
       playOnAwake: inputs.playOnAwake !== false,
-      loop: inputs.loop !== false,
-      time: Number.isFinite(ctx.env.time) ? ctx.env.time : 0
+      loop: inputs.loop !== false
     };
   }
   return base;

--- a/src/scenesync-runtime.browser.js
+++ b/src/scenesync-runtime.browser.js
@@ -146,6 +146,13 @@ function defaultApplySceneEffect(effect, host) {
     if (typeof material?.color?.setRGB === 'function') {
       material.color.setRGB(effect.color[0], effect.color[1], effect.color[2]);
     }
+  } else if (effect.type === 'scene.setAudio') {
+    object.userData = object.userData || {};
+    object.userData.audio = {
+      url: effect.url,
+      playOnAwake: effect.playOnAwake !== false,
+      loop: effect.loop !== false
+    };
   }
 }
 
@@ -160,6 +167,15 @@ function makeSceneEffect(type, inputs, params, ctx) {
   if (type === 'scene.setScale') return { ...base, scale: [inputs.x, inputs.y, inputs.z].map(Number) };
   if (type === 'scene.setVisible') return { ...base, visible: Boolean(inputs.visible) };
   if (type === 'scene.setColor') return { ...base, color: [inputs.r, inputs.g, inputs.b].map(Number) };
+  if (type === 'scene.setAudio') {
+    return {
+      ...base,
+      url: stringifyText(inputs.url),
+      playOnAwake: inputs.playOnAwake !== false,
+      loop: inputs.loop !== false,
+      time: Number.isFinite(ctx.env.time) ? ctx.env.time : 0
+    };
+  }
   return base;
 }
 
@@ -450,7 +466,7 @@ function buildNodeTypes() {
     }
   });
 
-  const sceneTypes = ['scene.setPosition', 'scene.offsetPosition', 'scene.setRotation', 'scene.setScale', 'scene.setVisible', 'scene.setColor'];
+  const sceneTypes = ['scene.setPosition', 'scene.offsetPosition', 'scene.setRotation', 'scene.setScale', 'scene.setVisible', 'scene.setColor', 'scene.setAudio'];
   for (const type of sceneTypes) {
     register(type, {
       inputs: sceneInputsFor(type),
@@ -467,7 +483,8 @@ function buildNodeTypes() {
     sceneSetRotation: 'scene.setRotation',
     sceneSetScale: 'scene.setScale',
     sceneSetVisible: 'scene.setVisible',
-    sceneSetColor: 'scene.setColor'
+    sceneSetColor: 'scene.setColor',
+    sceneSetAudio: 'scene.setAudio'
   };
   for (const [alias, canonical] of Object.entries(adapterAliases)) {
     nodes[alias] = nodes[canonical];
@@ -482,6 +499,7 @@ function sceneInputsFor(type) {
   if (type === 'scene.setScale') return [objectId, { name: 'x', default: 1 }, { name: 'y', default: 1 }, { name: 'z', default: 1 }];
   if (type === 'scene.setVisible') return [objectId, { name: 'visible', default: true }];
   if (type === 'scene.setColor') return [objectId, { name: 'r', default: 1 }, { name: 'g', default: 1 }, { name: 'b', default: 1 }];
+  if (type === 'scene.setAudio') return [objectId, { name: 'url', default: '' }, { name: 'playOnAwake', default: true }, { name: 'loop', default: true }];
   return [objectId, { name: 'x', default: 0 }, { name: 'y', default: 0 }, { name: 'z', default: 0 }];
 }
 

--- a/src/scenesync/effects.js
+++ b/src/scenesync/effects.js
@@ -6,7 +6,8 @@ function isSceneSyncEffect(effect) {
   const validTypes = new Set([
     'scene.setPosition',
     'scene.setRotation',
-    'scene.setScale'
+    'scene.setScale',
+    'scene.setAudio'
   ]);
 
   return validTypes.has(effect.type) && effect.target === 'scenesync';
@@ -48,6 +49,15 @@ function sceneEffectToBroadcastOp(effect) {
   } else if (effect.type === 'scene.setScale') {
     validateVector(effect.scale, 3, 'scale');
     op.scale = effect.scale;
+  } else if (effect.type === 'scene.setAudio') {
+    if (typeof effect.url !== 'string' || effect.url.trim().length === 0) {
+      throw new Error('Invalid scene effect: audio url is required');
+    }
+    op.audio = {
+      url: effect.url,
+      playOnAwake: effect.playOnAwake !== false,
+      loop: effect.loop !== false
+    };
   } else {
     throw new Error(`Invalid scene effect: unknown type ${effect.type}`);
   }

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -11,7 +11,8 @@ const SUPPORTED_NODES = new Set([
   'scene.setRotation',
   'scene.setScale',
   'scene.setColor',
-  'scene.setVisible'
+  'scene.setVisible',
+  'scene.setAudio'
 ]);
 
 const NODE_TYPE_MAPPING = {
@@ -25,7 +26,8 @@ const NODE_TYPE_MAPPING = {
   'scene.setRotation': 'sceneSetRotation',
   'scene.setScale': 'sceneSetScale',
   'scene.setColor': 'sceneSetColor',
-  'scene.setVisible': 'sceneSetVisible'
+  'scene.setVisible': 'sceneSetVisible',
+  'scene.setAudio': 'sceneSetAudio'
 };
 
 const OUTPUT_PORT_MAPPING = {
@@ -49,7 +51,9 @@ const OUTPUT_PORT_MAPPING = {
   'scene.setColor': undefined,
   'sceneSetColor': undefined,
   'scene.setVisible': undefined,
-  'sceneSetVisible': undefined
+  'sceneSetVisible': undefined,
+  'scene.setAudio': undefined,
+  'sceneSetAudio': undefined
 };
 
 function generateStableNodeBase(nodeType) {
@@ -65,6 +69,7 @@ function generateStableNodeBase(nodeType) {
   if (mapped === 'sceneSetScale') return 'scale';
   if (mapped === 'sceneSetColor') return 'color';
   if (mapped === 'sceneSetVisible') return 'visible';
+  if (mapped === 'sceneSetAudio') return 'audio';
   return mapped;
 }
 
@@ -131,6 +136,14 @@ function pickParams(nodeType, params = {}) {
   }
   if (nodeType === 'scene.setVisible') {
     return { ...(params.visible !== undefined ? { visible: params.visible } : {}) };
+  }
+  if (nodeType === 'scene.setAudio') {
+    return {
+      ...(params.objectId ? { target: params.objectId } : {}),
+      ...(params.url !== undefined ? { url: params.url } : {}),
+      ...(params.playOnAwake !== undefined ? { playOnAwake: params.playOnAwake } : {}),
+      ...(params.loop !== undefined ? { loop: params.loop } : {})
+    };
   }
   if (nodeType === 'math.sine' || nodeType === 'math.cosine') {
     return {

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -367,6 +367,42 @@ export const LIBRARY_METADATA = {
         examples: [
           'scene.offsetPosition("sample-cube", x: 1, y: 0.5, z: 0)'
         ]
+      },
+      setAudio: {
+        name: 'setAudio',
+        signature: 'scene.setAudio(objectId: "...", url: "https://...", playOnAwake: true, loop: true)',
+        description: 'Sets an audio component on a Scene Sync object.',
+        args: [
+          {
+            name: 'objectId',
+            type: 'string',
+            positional: true,
+            description: 'ID of the object.'
+          },
+          {
+            name: 'url',
+            type: 'string',
+            positional: false,
+            description: 'HTTP(S) URL for an audio file.'
+          },
+          {
+            name: 'playOnAwake',
+            type: 'boolean',
+            positional: false,
+            description: 'Whether playback starts when the component is applied.'
+          },
+          {
+            name: 'loop',
+            type: 'boolean',
+            positional: false,
+            description: 'Whether playback loops.'
+          }
+        ],
+        returns: 'void',
+        targets: LIBRARY_COMPATIBILITY.scene.targets,
+        examples: [
+          'scene.setAudio("sample-cube", url: "https://example.com/sound.mp3", playOnAwake: true, loop: true)'
+        ]
       }
     }
   },

--- a/test/scenesync-effects.test.mjs
+++ b/test/scenesync-effects.test.mjs
@@ -37,6 +37,18 @@ test('isSceneSyncEffect returns true for scene.setScale', () => {
   assert.equal(isSceneSyncEffect(effect), true);
 });
 
+test('isSceneSyncEffect returns true for scene.setAudio', () => {
+  const effect = {
+    type: 'scene.setAudio',
+    target: 'scenesync',
+    objectId: 'sample-cube',
+    url: 'https://example.com/sound.mp3',
+    playOnAwake: true,
+    loop: true
+  };
+  assert.equal(isSceneSyncEffect(effect), true);
+});
+
 test('isSceneSyncEffect returns false for non-scenesync target', () => {
   const effect = {
     type: 'scene.setPosition',
@@ -98,6 +110,27 @@ test('sceneEffectToBroadcastOp converts scale', () => {
     kind: 'scene-delta',
     objectId: 'sample-cube',
     scale: [2, 2, 2]
+  });
+});
+
+test('sceneEffectToBroadcastOp converts audio', () => {
+  const effect = {
+    type: 'scene.setAudio',
+    objectId: 'sample-cube',
+    url: 'https://example.com/sound.mp3',
+    playOnAwake: true,
+    loop: false
+  };
+
+  const op = sceneEffectToBroadcastOp(effect);
+  assert.deepEqual(op, {
+    kind: 'scene-delta',
+    objectId: 'sample-cube',
+    audio: {
+      url: 'https://example.com/sound.mp3',
+      playOnAwake: true,
+      loop: false
+    }
   });
 });
 

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -177,6 +177,21 @@ scene.setScale("sample-cube", x: 1.2, y: 1.2, z: 1.2)
   assert.deepEqual(result.scope, { object: 'sample-cube' });
 });
 
+test('supports object audio scene sink', () => {
+  const source = `
+import scene
+scene.setAudio("speaker", url: "https://example.com/sound.mp3")
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+  const audioNode = result.graph.nodes.find((n) => n.type === 'sceneSetAudio');
+
+  assert.ok(audioNode);
+  assert.equal(audioNode.params.target, 'speaker');
+  assert.equal(audioNode.params.url, 'https://example.com/sound.mp3');
+  assert.deepEqual(result.scope, { object: 'speaker' });
+});
+
 
 test('multiple sine nodes receive unique IDs and valid edges', () => {
   const source = `

--- a/test/scenesync-runtime-browser-bundle.test.mjs
+++ b/test/scenesync-runtime-browser-bundle.test.mjs
@@ -140,3 +140,39 @@ test('Scene Sync browser runtime supports legacy adapter node aliases with targe
   assert.equal(object.position.y, 2);
   assert.equal(object.position.z, 3);
 });
+
+test('Scene Sync browser runtime emits object audio effects', async () => {
+  const runtimeModule = await import(`${pathToFileURL(bundlePath).href}?case=audio-${Date.now()}`);
+  const effects = [];
+  const runtime = runtimeModule.createSceneSyncRuntime({
+    nodes: [
+      {
+        id: 'audio',
+        type: 'scene.setAudio',
+        params: {
+          objectId: 'speaker',
+          url: 'https://example.com/sound.mp3',
+          playOnAwake: true,
+          loop: true
+        }
+      }
+    ],
+    edges: []
+  }, {
+    applyEffects: false,
+    onEffect: (effect) => effects.push(effect)
+  });
+
+  runtime.evaluateAt({ time: 12.5, events: [] });
+
+  assert.deepEqual(effects[0], {
+    type: 'scene.setAudio',
+    objectId: 'speaker',
+    target: 'scenesync',
+    nodeId: 'audio',
+    url: 'https://example.com/sound.mp3',
+    playOnAwake: true,
+    loop: true,
+    time: 12.5
+  });
+});

--- a/test/scenesync-runtime-browser-bundle.test.mjs
+++ b/test/scenesync-runtime-browser-bundle.test.mjs
@@ -172,7 +172,6 @@ test('Scene Sync browser runtime emits object audio effects', async () => {
     nodeId: 'audio',
     url: 'https://example.com/sound.mp3',
     playOnAwake: true,
-    loop: true,
-    time: 12.5
+    loop: true
   });
 });


### PR DESCRIPTION
## Summary
- Add scene.setAudio / sceneSetAudio as a Scene Sync object audio sink
- Include graph adapter, effect conversion, metadata, and browser runtime support
- Regenerate the Scene Sync browser runtime bundle

## Tests
- node test/scenesync-graph-adapter.test.mjs
- node test/scenesync-effects.test.mjs
- node test/runtime-metadata-drift.test.mjs
- node test/scenesync-runtime-browser-bundle.test.mjs