### PR TITLE
Add node canvas interactions: drag-drop, context menu, zoom controls

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -71,6 +71,13 @@
           </div>
         </div>
         <div id="node-editor" class="node-editor-canvas"></div>
+        <div class="node-canvas-toolbar">
+          <button id="node-zoom-in-btn" class="node-canvas-btn" title="Zoom in">＋</button>
+          <button id="node-zoom-out-btn" class="node-canvas-btn" title="Zoom out">－</button>
+          <button id="node-zoom-fit-btn" class="node-canvas-btn" title="Fit all nodes in view">⛶</button>
+          <button id="node-add-btn" class="node-canvas-btn" title="Add node (or right-click on canvas)">Add Node</button>
+        </div>
+        <div class="node-canvas-hint">Right-click: add node / Drag from Palette / Ctrl+click: multi-select / Del: delete</div>
       </div>
 
       <!-- Bottom area: GraphJSON, Errors, and Inspector -->

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -190,7 +190,11 @@ const elements = {
   clearSceneSyncBehaviorBtn: document.getElementById('clearSceneSyncBehaviorBtn'),
   sceneSyncPayloadPreview: document.getElementById('sceneSyncPayloadPreview'),
   loadSceneSyncJumpPresetBtn: document.getElementById('loadSceneSyncJumpPresetBtn'),
-  loadSceneSyncCirclePresetBtn: document.getElementById('loadSceneSyncCirclePresetBtn')
+  loadSceneSyncCirclePresetBtn: document.getElementById('loadSceneSyncCirclePresetBtn'),
+  nodeZoomInBtn: document.getElementById('node-zoom-in-btn'),
+  nodeZoomOutBtn: document.getElementById('node-zoom-out-btn'),
+  nodeZoomFitBtn: document.getElementById('node-zoom-fit-btn'),
+  nodeAddBtn: document.getElementById('node-add-btn')
 };
 
 function setPanelsVisible(visible) {
@@ -1713,16 +1717,31 @@ function attachInspectorActionListeners() {
 async function deleteSelectedNode() {
   const node = getSelectedEditorNode();
   if (!node) return;
+  await deleteNodes([node.id]);
+}
 
-  const message = `Delete node '${node.id}'? Connected edges will also be removed.`;
+async function deleteNodes(nodeIds) {
+  const state = store.getState();
+  const existing = (nodeIds || []).filter((id) => state.editorModel?.nodesById?.[id]);
+  if (existing.length === 0) return;
+
+  const message = existing.length === 1
+    ? `Delete node '${existing[0]}'? Connected edges will also be removed.`
+    : `Delete ${existing.length} nodes (${existing.join(', ')})? Connected edges will also be removed.`;
   if (!window.confirm(message)) return;
 
-  const result = await handleOperation({
-    type: 'removeNode',
-    id: node.id
-  });
+  let removedSelected = false;
+  for (const id of existing) {
+    const result = await handleOperation({
+      type: 'removeNode',
+      id
+    });
+    if (result && !result.error && id === selectedNodeId) {
+      removedSelected = true;
+    }
+  }
 
-  if (result && !result.error) {
+  if (removedSelected) {
     selectedNodeId = null;
     renderInspector();
   }
@@ -2070,7 +2089,7 @@ function renderNodePaletteItem(entry) {
   const params = entry.params.map((param) => param.name).join(', ') || 'none';
 
   return `
-    <div class="node-palette-item">
+    <div class="node-palette-item" draggable="true" data-drag-node-type="${escapeHtml(entry.typeName)}" title="Drag onto the canvas to place this node">
       <div class="node-palette-main">
         <div class="node-palette-title">${escapeHtml(entry.typeName)}</div>
         <div class="node-palette-category-label">${escapeHtml(entry.category)}</div>
@@ -2110,6 +2129,14 @@ function renderNodePalette() {
       addNodeFromPalette(typeName);
     });
   });
+
+  list.querySelectorAll('[data-drag-node-type]').forEach((item) => {
+    item.addEventListener('dragstart', (event) => {
+      const typeName = item.getAttribute('data-drag-node-type');
+      event.dataTransfer.setData(NODE_DRAG_MIME, typeName);
+      event.dataTransfer.effectAllowed = 'copy';
+    });
+  });
 }
 
 function renderNodePaletteCategories() {
@@ -2126,7 +2153,7 @@ function renderNodePaletteCategories() {
   ].join('');
 }
 
-async function addNodeFromPalette(typeName) {
+async function addNodeFromPalette(typeName, position = null) {
   const def = NODE_TYPES[typeName];
   if (!def) {
     setEditorError(`Unknown node type: ${typeName}`);
@@ -2144,7 +2171,9 @@ async function addNodeFromPalette(typeName) {
     type: typeName,
     category,
     params: createDefaultParamsForNodeType(typeName, NODE_TYPES),
-    position: createPositionForNewNode(category, nodes, findNonOverlappingPosition, NODE_LAYOUT_STEP_Y)
+    position: position
+      ? { x: Math.round(position.x), y: Math.round(position.y) }
+      : createPositionForNewNode(category, nodes, findNonOverlappingPosition, NODE_LAYOUT_STEP_Y)
   };
 
   await handleOperation({
@@ -2153,6 +2182,178 @@ async function addNodeFromPalette(typeName) {
   });
 
   setSelectedNodeId(id);
+}
+
+/* Canvas context menu (right-click to add/manage nodes) */
+
+const NODE_DRAG_MIME = 'application/x-loomlet-node-type';
+let canvasContextMenuEl = null;
+
+function closeCanvasContextMenu() {
+  if (canvasContextMenuEl) {
+    canvasContextMenuEl.remove();
+    canvasContextMenuEl = null;
+  }
+}
+
+function clampMenuToViewport(menu, clientX, clientY) {
+  const rect = menu.getBoundingClientRect();
+  const left = Math.min(clientX, window.innerWidth - rect.width - 8);
+  const top = Math.min(clientY, window.innerHeight - rect.height - 8);
+  menu.style.left = `${Math.max(8, left)}px`;
+  menu.style.top = `${Math.max(8, top)}px`;
+}
+
+function openCanvasContextMenu({ clientX, clientY, graphPosition, nodeId }) {
+  closeCanvasContextMenu();
+
+  const menu = document.createElement('div');
+  menu.className = 'canvas-context-menu';
+  menu.style.left = `${clientX}px`;
+  menu.style.top = `${clientY}px`;
+
+  if (nodeId) {
+    renderNodeActionsMenu(menu, nodeId);
+  } else {
+    renderAddNodeMenu(menu, graphPosition);
+  }
+
+  document.body.appendChild(menu);
+  clampMenuToViewport(menu, clientX, clientY);
+  canvasContextMenuEl = menu;
+
+  if (!nodeId) {
+    menu.querySelector('.canvas-context-menu-search')?.focus();
+  }
+}
+
+function renderNodeActionsMenu(menu, nodeId) {
+  const state = store.getState();
+  const node = state.editorModel?.nodesById?.[nodeId];
+  if (!node) return;
+
+  const header = document.createElement('div');
+  header.className = 'canvas-context-menu-header';
+  header.textContent = node.label || node.id;
+  menu.appendChild(header);
+
+  const inspectItem = document.createElement('button');
+  inspectItem.className = 'canvas-context-menu-item';
+  inspectItem.textContent = 'Inspect';
+  inspectItem.addEventListener('click', () => {
+    closeCanvasContextMenu();
+    setSelectedNodeId(nodeId);
+    selectBottomTab('inspector');
+  });
+  menu.appendChild(inspectItem);
+
+  const deleteItem = document.createElement('button');
+  deleteItem.className = 'canvas-context-menu-item is-danger';
+  deleteItem.textContent = 'Delete node';
+  deleteItem.addEventListener('click', () => {
+    closeCanvasContextMenu();
+    setSelectedNodeId(nodeId);
+    deleteSelectedNode();
+  });
+  menu.appendChild(deleteItem);
+}
+
+function renderAddNodeMenu(menu, graphPosition) {
+  const header = document.createElement('div');
+  header.className = 'canvas-context-menu-header';
+  header.textContent = 'Add node';
+  menu.appendChild(header);
+
+  const search = document.createElement('input');
+  search.type = 'text';
+  search.className = 'canvas-context-menu-search';
+  search.placeholder = 'Search node types...';
+  menu.appendChild(search);
+
+  const list = document.createElement('div');
+  list.className = 'canvas-context-menu-list';
+  menu.appendChild(list);
+
+  const entries = getNodeTypeEntries(NODE_TYPES);
+
+  const renderEntries = () => {
+    const query = search.value.trim().toLowerCase();
+    const filtered = entries.filter((entry) => {
+      if (!query) return true;
+      return (
+        entry.typeName.toLowerCase().includes(query) ||
+        entry.category.toLowerCase().includes(query)
+      );
+    });
+
+    list.innerHTML = '';
+
+    if (filtered.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'canvas-context-menu-empty';
+      empty.textContent = 'No matching node types';
+      list.appendChild(empty);
+      return;
+    }
+
+    let lastCategory = null;
+    for (const entry of filtered) {
+      if (entry.category !== lastCategory) {
+        const label = document.createElement('div');
+        label.className = 'canvas-context-menu-category';
+        label.textContent = entry.category;
+        list.appendChild(label);
+        lastCategory = entry.category;
+      }
+
+      const item = document.createElement('button');
+      item.className = 'canvas-context-menu-item';
+      item.textContent = entry.typeName;
+      item.addEventListener('click', async () => {
+        closeCanvasContextMenu();
+        await addNodeFromPalette(entry.typeName, graphPosition);
+      });
+      list.appendChild(item);
+    }
+  };
+
+  search.addEventListener('input', renderEntries);
+  search.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeCanvasContextMenu();
+    } else if (event.key === 'Enter') {
+      list.querySelector('.canvas-context-menu-item')?.click();
+    }
+  });
+
+  renderEntries();
+}
+
+function getCanvasCenterGraphPosition() {
+  const host = elements.nodeEditorHost;
+  if (!host || !nodeEditor) return null;
+  const rect = host.getBoundingClientRect();
+  return nodeEditor.clientPointToGraph(rect.left + rect.width / 2, rect.top + rect.height / 2);
+}
+
+function setupNodeCanvasDragAndDrop() {
+  const host = elements.nodeEditorHost;
+  if (!host) return;
+
+  host.addEventListener('dragover', (event) => {
+    if (event.dataTransfer?.types?.includes(NODE_DRAG_MIME)) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  });
+
+  host.addEventListener('drop', async (event) => {
+    const typeName = event.dataTransfer?.getData(NODE_DRAG_MIME);
+    if (!typeName) return;
+    event.preventDefault();
+    const position = nodeEditor?.clientPointToGraph(event.clientX, event.clientY);
+    await addNodeFromPalette(typeName, position);
+  });
 }
 
 function isTextEditingTarget(target) {
@@ -2190,13 +2391,23 @@ function handleGlobalKeyDown(event) {
     }
   }
 
+  if (event.key === 'Escape') {
+    closeCanvasContextMenu();
+    return;
+  }
+
   // Handle node deletion with Delete/Backspace
   if (event.key !== 'Delete' && event.key !== 'Backspace') return;
-  if (!selectedNodeId) return;
   if (isTextEditingTarget(event.target)) return;
 
+  const canvasSelectedIds = nodeEditor?.getSelectedNodeIds?.() || [];
+  const targetIds = canvasSelectedIds.length > 0
+    ? canvasSelectedIds
+    : (selectedNodeId ? [selectedNodeId] : []);
+  if (targetIds.length === 0) return;
+
   event.preventDefault();
-  deleteSelectedNode();
+  deleteNodes(targetIds);
 }
 
 function cloneJson(value) {
@@ -2472,6 +2683,26 @@ function clearEditorHistory() {
 }
 
 function setupEventListeners() {
+  elements.nodeZoomInBtn?.addEventListener('click', () => nodeEditor?.zoomBy(1.25));
+  elements.nodeZoomOutBtn?.addEventListener('click', () => nodeEditor?.zoomBy(0.8));
+  elements.nodeZoomFitBtn?.addEventListener('click', () => nodeEditor?.zoomToFit());
+  elements.nodeAddBtn?.addEventListener('click', (event) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    openCanvasContextMenu({
+      clientX: rect.left,
+      clientY: rect.bottom + 4,
+      graphPosition: getCanvasCenterGraphPosition() || { x: 0, y: 0 },
+      nodeId: null
+    });
+    event.stopPropagation();
+  });
+
+  document.addEventListener('pointerdown', (event) => {
+    if (canvasContextMenuEl && !canvasContextMenuEl.contains(event.target)) {
+      closeCanvasContextMenu();
+    }
+  });
+
   elements.applyDslBtn.addEventListener('click', applyDsl);
   elements.generateDslBtn.addEventListener('click', generateDsl);
   elements.runPreviewBtn.addEventListener('click', () => {
@@ -2692,10 +2923,12 @@ async function init() {
       store.setState({ errors: [{ message: `Editor error: ${error.message}`, code: 'EDITOR_ERROR' }] });
       renderErrors();
     },
-    onSelectNode: setSelectedNodeId
+    onSelectNode: setSelectedNodeId,
+    onContextMenu: openCanvasContextMenu
   });
 
   setupEventListeners();
+  setupNodeCanvasDragAndDrop();
   loadBottomPanelLayout();
   loadEditorSplitLayout();
   loadActiveBottomTab();

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1158,8 +1158,27 @@ function setSelectedNodeId(nodeId) {
   } else {
     selectedNodeId = nodeId || null;
   }
+  syncCanvasSelection();
   renderInspector();
   renderNodeList();
+}
+
+// Keep the Rete canvas selection consistent with the inspector selection so
+// that Delete always targets what the UI shows as selected. When the picked
+// node is already part of a canvas multi-selection (Ctrl+click flow), the
+// existing selection is preserved.
+function syncCanvasSelection() {
+  if (!nodeEditor?.setSelection) return;
+
+  if (!selectedNodeId) {
+    nodeEditor.setSelection([]);
+    return;
+  }
+
+  const canvasSelectedIds = nodeEditor.getSelectedNodeIds();
+  if (!canvasSelectedIds.includes(selectedNodeId)) {
+    nodeEditor.setSelection([selectedNodeId]);
+  }
 }
 
 function setEditorError(message) {
@@ -1730,18 +1749,15 @@ async function deleteNodes(nodeIds) {
     : `Delete ${existing.length} nodes (${existing.join(', ')})? Connected edges will also be removed.`;
   if (!window.confirm(message)) return;
 
-  let removedSelected = false;
-  for (const id of existing) {
-    const result = await handleOperation({
-      type: 'removeNode',
-      id
-    });
-    if (result && !result.error && id === selectedNodeId) {
-      removedSelected = true;
-    }
-  }
+  const removesSelected = selectedNodeId && existing.includes(selectedNodeId);
 
-  if (removedSelected) {
+  const result = await handleOperation(
+    existing.length === 1
+      ? { type: 'removeNode', id: existing[0] }
+      : { type: 'removeNodes', ids: existing }
+  );
+
+  if (result && !result.error && removesSelected) {
     selectedNodeId = null;
     renderInspector();
   }

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -192,6 +192,23 @@ export class NodeEditorView {
     return this.editor.getNodes().filter((node) => node.selected).map((node) => node.id);
   }
 
+  async setSelection(nodeIds = []) {
+    const ids = new Set(nodeIds);
+
+    for (const node of this.editor.getNodes()) {
+      if (node.selected && !ids.has(node.id)) {
+        await this.nodeSelector.unselect(node.id);
+      }
+    }
+
+    for (const id of ids) {
+      const node = this.editor.getNode(id);
+      if (node && !node.selected) {
+        await this.nodeSelector.select(id, true);
+      }
+    }
+  }
+
   async zoomToFit() {
     const nodes = this.editor.getNodes();
     if (nodes.length === 0) return false;

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -92,11 +92,12 @@ function findReteConnectionIdByEdgeId(connectionMap, edgeId) {
 // --- NodeEditorView ---
 
 export class NodeEditorView {
-  constructor(container, { onOperation, onError, onSelectNode } = {}) {
+  constructor(container, { onOperation, onError, onSelectNode, onContextMenu } = {}) {
     this.container = container;
     this.onOperation = onOperation || (() => {});
     this.onError = onError || ((e) => console.error('NodeEditorView:', e));
     this.onSelectNode = onSelectNode || (() => {});
+    this.onContextMenu = onContextMenu || (() => {});
     this.isRendering = false;
     this.connectionMap = new Map();
     this._renderLock = null;
@@ -116,7 +117,14 @@ export class NodeEditorView {
     this.area.use(this.connectionPlugin);
     this.area.use(this.renderPlugin);
 
+    this.selector = AreaExtensions.selector();
+    this.nodeSelector = AreaExtensions.selectableNodes(this.area, this.selector, {
+      accumulating: AreaExtensions.accumulateOnCtrl()
+    });
+    AreaExtensions.simpleNodesOrder(this.area);
+
     this._setupPipes();
+    this._setupContextMenu();
   }
 
   _setupPipes() {
@@ -145,6 +153,70 @@ export class NodeEditorView {
 
       return context;
     });
+  }
+
+  _setupContextMenu() {
+    this._contextMenuHandler = (event) => {
+      event.preventDefault();
+      const nodeId = this._findNodeIdFromEventTarget(event.target);
+      this.onContextMenu({
+        clientX: event.clientX,
+        clientY: event.clientY,
+        graphPosition: this.clientPointToGraph(event.clientX, event.clientY),
+        nodeId
+      });
+    };
+    this.container.addEventListener('contextmenu', this._contextMenuHandler);
+  }
+
+  _findNodeIdFromEventTarget(target) {
+    if (!target || !this.area?.nodeViews) return null;
+    for (const [nodeId, view] of this.area.nodeViews) {
+      if (view.element === target || view.element.contains(target)) {
+        return nodeId;
+      }
+    }
+    return null;
+  }
+
+  clientPointToGraph(clientX, clientY) {
+    const rect = this.container.getBoundingClientRect();
+    const { x, y, k } = this.area.area.transform;
+    return {
+      x: (clientX - rect.left - x) / k,
+      y: (clientY - rect.top - y) / k
+    };
+  }
+
+  getSelectedNodeIds() {
+    return this.editor.getNodes().filter((node) => node.selected).map((node) => node.id);
+  }
+
+  async zoomToFit() {
+    const nodes = this.editor.getNodes();
+    if (nodes.length === 0) return false;
+
+    try {
+      await AreaExtensions.zoomAt(this.area, nodes);
+      return true;
+    } catch (e) {
+      console.warn('zoomToFit failed:', e.message);
+      return false;
+    }
+  }
+
+  async zoomBy(factor) {
+    const area = this.area.area;
+    const { x, y, k } = area.transform;
+    const nextK = Math.min(2.5, Math.max(0.1, k * factor));
+    if (nextK === k) return;
+
+    const rect = this.container.getBoundingClientRect();
+    const cx = rect.width / 2;
+    const cy = rect.height / 2;
+
+    await area.zoom(nextK, 0, 0);
+    await area.translate(cx - ((cx - x) * nextK) / k, cy - ((cy - y) * nextK) / k);
   }
 
   _onConnectionCreated(connection) {
@@ -427,6 +499,10 @@ export class NodeEditorView {
   }
 
   destroy() {
+    if (this._contextMenuHandler) {
+      this.container.removeEventListener('contextmenu', this._contextMenuHandler);
+      this._contextMenuHandler = null;
+    }
     this.area.destroy();
     this.container.innerHTML = '';
     this.currentEditorModel = null;

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1129,3 +1129,142 @@ button:disabled:hover,
   padding: 8px;
   color: rgba(255, 255, 255, 0.7);
 }
+
+/* Node canvas toolbar and hint */
+
+.node-pane {
+  position: relative;
+}
+
+.node-canvas-toolbar {
+  position: absolute;
+  top: 44px;
+  right: 12px;
+  display: flex;
+  gap: 4px;
+  z-index: 20;
+}
+
+.node-canvas-btn {
+  background: var(--panel-bg-strong);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.node-canvas-btn:hover {
+  border-color: var(--primary-color);
+  background: rgba(74, 144, 226, 0.2);
+}
+
+.node-canvas-hint {
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  z-index: 20;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+  pointer-events: none;
+}
+
+/* Canvas context menu */
+
+.canvas-context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 220px;
+  max-width: 280px;
+  background: rgba(24, 24, 24, 0.97);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.canvas-context-menu-header {
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 4px 6px 2px;
+}
+
+.canvas-context-menu-search {
+  background: #111;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  outline: none;
+}
+
+.canvas-context-menu-search:focus {
+  border-color: var(--primary-color);
+}
+
+.canvas-context-menu-list {
+  max-height: 280px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.canvas-context-menu-category {
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 6px 2px;
+}
+
+.canvas-context-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  color: var(--text-color);
+  border: none;
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.canvas-context-menu-item:hover {
+  background: rgba(74, 144, 226, 0.25);
+}
+
+.canvas-context-menu-item.is-danger {
+  color: #f08080;
+}
+
+.canvas-context-menu-item.is-danger:hover {
+  background: rgba(220, 80, 80, 0.2);
+}
+
+.canvas-context-menu-empty {
+  padding: 8px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+/* Draggable palette items */
+
+.node-palette-item[draggable="true"] {
+  cursor: grab;
+}
+
+.node-palette-item[draggable="true"]:active {
+  cursor: grabbing;
+}

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -37,6 +37,7 @@ export const NODE_LAYOUT_MAX_COLS = 50;
  * @typedef {
  *   | { type: 'addNode',     node: EditorNode }
  *   | { type: 'removeNode',  id: string }
+ *   | { type: 'removeNodes', ids: string[] }
  *   | { type: 'updateParam', id: string, key: string, value: any }
  *   | { type: 'moveNode',    id: string, position: { x: number, y: number } }
  *   | { type: 'addEdge',     edge: EditorEdge }
@@ -281,6 +282,22 @@ export function applyEditorOperation(em, op) {
     for (const id of Object.keys(next.edgesById)) {
       const edge = next.edgesById[id];
       if (edge.fromNodeId === op.id || edge.toNodeId === op.id) {
+        delete next.edgesById[id];
+      }
+    }
+    return next;
+  }
+
+  if (op.type === 'removeNodes') {
+    const ids = new Set((op.ids || []).filter((id) => next.nodesById[id]));
+    if (ids.size === 0) return next;
+    for (const id of ids) {
+      delete next.nodesById[id];
+    }
+    next.order = next.order.filter((id) => !ids.has(id));
+    for (const id of Object.keys(next.edgesById)) {
+      const edge = next.edgesById[id];
+      if (ids.has(edge.fromNodeId) || ids.has(edge.toNodeId)) {
         delete next.edgesById[id];
       }
     }

--- a/src/source-dsl-patch.js
+++ b/src/source-dsl-patch.js
@@ -62,6 +62,10 @@ function patchAstSource(source, ast, operation) {
     return patchRemoveNode(source, ast, operation);
   }
 
+  if (operation.type === 'removeNodes') {
+    return patchRemoveNodes(source, ast, operation);
+  }
+
   return fail('UNSUPPORTED_OPERATION');
 }
 
@@ -150,6 +154,26 @@ function patchRemoveNode(source, ast, operation) {
 
   const range = lineRangeForSpan(source, stmt.span);
   return ok(`${source.slice(0, range.start)}${source.slice(range.end)}`, 'source-patch');
+}
+
+function patchRemoveNodes(source, ast, operation) {
+  const ids = operation.ids || [];
+  if (!ids.length) return fail('MISSING_REMOVE_IDS');
+
+  let currentSource = source;
+  let currentAst = ast;
+
+  for (const id of ids) {
+    const result = patchRemoveNode(currentSource, currentAst, { id });
+    if (!result.ok) return result;
+
+    currentSource = result.source;
+    const parsed = parseDSLToAST(currentSource);
+    if (parsed.errors.length || !parsed.ast) return fail('PATCHED_SOURCE_PARSE_ERROR');
+    currentAst = parsed.ast;
+  }
+
+  return ok(currentSource, 'source-patch');
 }
 
 function validatePatchedSource(source, expectedGraph) {

--- a/test/source-dsl-patch.test.mjs
+++ b/test/source-dsl-patch.test.mjs
@@ -190,6 +190,54 @@ test('source patch: removeNode removes only the assignment line', () => {
   assert.equal(patched, '# keep this standalone comment\nclk = clock()\nwave = sine(freq: 0.5)\n');
 });
 
+test('source patch: removeNodes removes all assignment lines in one operation', () => {
+  const source = [
+    '# keep this standalone comment',
+    'clk = clock()',
+    'unused_a = sine(freq: 0.3)',
+    'unused_b = sine(freq: 0.7)',
+    'wave = sine(freq: 0.5)',
+    ''
+  ].join('\n');
+
+  const patched = applyOperation(source, {
+    type: 'removeNodes',
+    ids: ['unused_a', 'unused_b']
+  });
+
+  assert.equal(patched, '# keep this standalone comment\nclk = clock()\nwave = sine(freq: 0.5)\n');
+});
+
+test('source patch: removeNodes with connected references falls back to canonical DSL', () => {
+  const source = [
+    'clk = clock()',
+    'wave = sine(t: clk, freq: 0.3)',
+    'wave2 = sine(t: wave, freq: 0.2)',
+    ''
+  ].join('\n');
+  const graph = compileSource(source);
+  const result = applyNodeEditorOperationState({
+    graph,
+    editorModel: graphToEditorModel(graph),
+    errors: []
+  }, {
+    type: 'removeNodes',
+    ids: ['clk', 'wave']
+  });
+  if (result.error) throw result.error;
+
+  assert.equal(result.state.editorModel.nodesById.clk, undefined);
+  assert.equal(result.state.editorModel.nodesById.wave, undefined);
+  assert.equal(
+    Object.values(result.state.editorModel.edgesById)
+      .some((edge) => edge.fromNodeId === 'wave' || edge.toNodeId === 'wave'),
+    false
+  );
+
+  const fallback = patchOrCanonicalDslSource(source, result.change.operation, result.state.graph);
+  assert.equal(fallback.ok, true);
+});
+
 test('source patch: removeNode with connected references falls back to canonical DSL', () => {
   const source = [
     'import math',


### PR DESCRIPTION
## Summary
This PR enhances the node editor with improved user interactions including drag-and-drop node placement from the palette, right-click context menus for node management, canvas zoom controls, and multi-node deletion support.

## Key Changes

- **Drag-and-drop node placement**: Node palette items are now draggable onto the canvas. Added `NODE_DRAG_MIME` constant and `setupNodeCanvasDragAndDrop()` to handle drop events and place nodes at the dropped position.

- **Canvas context menu**: Implemented `openCanvasContextMenu()` with two modes:
  - Right-click on empty canvas: searchable menu to add nodes at the clicked position
  - Right-click on a node: inspect or delete the node
  - Menu automatically clamps to viewport and closes on escape or outside click

- **Canvas zoom toolbar**: Added four new buttons in the top-right corner:
  - Zoom in/out with configurable factors (1.25x / 0.8x)
  - Zoom to fit all nodes in view
  - Add node button that opens the context menu

- **Multi-node deletion**: Refactored `deleteSelectedNode()` into `deleteNodes(nodeIds)` to support deleting multiple nodes at once. Delete key now removes all canvas-selected nodes (via `nodeEditor.getSelectedNodeIds()`) or the inspector-selected node.

- **Node selection enhancements**: Added selector and multi-select support to `NodeEditorView` using Rete's `AreaExtensions.selector()` and `selectableNodes()` with Ctrl+click accumulation.

- **Position-aware node creation**: Modified `addNodeFromPalette()` to accept an optional `position` parameter, allowing nodes to be placed at specific coordinates rather than auto-positioned.

## Implementation Details

- Added DOM element references for new toolbar buttons in the `elements` object
- Extended `NodeEditorView` constructor to accept `onContextMenu` callback
- Implemented `clientPointToGraph()` to convert screen coordinates to canvas coordinates
- Added `_setupContextMenu()` handler for right-click events with node detection via `_findNodeIdFromEventTarget()`
- Updated `handleGlobalKeyDown()` to support multi-node deletion and escape key to close context menu
- Added CSS styling for toolbar buttons, context menu, and draggable palette items
- Made node palette items draggable with visual feedback (grab cursor)

https://claude.ai/code/session_011mST6GZ8n5BNggcNk86JcG