### PR TITLE
Promote scene.setColor / scene.setVisible to portable nodes with capabilities

### DIFF
--- a/docs/HOST_CAPABILITY_GUIDE.md
+++ b/docs/HOST_CAPABILITY_GUIDE.md
@@ -77,10 +77,10 @@ check.
   behavior are designed (see [Output Conflict Policy v0](./design/output-conflict-policy-v0.md)),
   but some Scene Sync-side edit-override behavior is still deferred.
 - **planned**: viewer/distance input, hover/activate/gaze.
-- Note: `scene.setColor` / `scene.setVisible` are implemented on the Scene Sync
-  path (graph adapter + browser runtime), but are not yet in the portable JS
-  node registry (`src/nodes/scene.js`) and have no #286 capability token. The
-  capability check therefore does not model color/visibility yet.
+- Note: `scene.setColor` / `scene.setVisible` are portable JS nodes with
+  `scene.object.material.write@1` / `scene.object.visibility.write@1` capability
+  tokens, so the #286 compatibility check models them. Scene Sync Web and Export
+  Viewer grant both tokens; Unity and CLI do not.
 
 ### Unity Runtime (`unity-runtime`)
 
@@ -127,13 +127,11 @@ check.
 
 ## Notes on unsupported items
 
-- **Color / Visibility**: `scene.setColor` / `scene.setVisible` run today on the
-  Scene Sync path (Scene Sync Web and Export Viewer), but only there — they live
-  in the Scene Sync graph adapter and browser runtime, not in the portable JS
-  node registry (`src/nodes/scene.js`), and they have no #286 capability token.
-  Promoting them to portable nodes with `scene.object.material.write@1` /
-  `scene.object.visibility.write@1` tokens would make Unity a candidate and let
-  the compatibility check model them (see `docs/NODE_GAPS.md`).
+- **Color / Visibility**: `scene.setColor` / `scene.setVisible` are portable JS
+  nodes carrying `scene.object.material.write@1` /
+  `scene.object.visibility.write@1` capabilities, and run today on Scene Sync Web
+  and Export Viewer. Unity is the remaining candidate: it needs host-side
+  material/visibility write support before its cells move off `planned`.
 - **Viewer / distance input** and **Hover / activate / gaze**: these are host
   interaction facts. There are DOM `pointerClick` / `pointerPosition` nodes for
   the simple web editor, but no portable viewer/interaction input vocabulary in
@@ -149,10 +147,10 @@ check.
 
 - Add `godot-runtime` as a real (initially minimal) host once a runtime exists,
   and give it a capability profile in `src/runtime/capabilities.js`.
-- Promote `scene.setColor` / `scene.setVisible` from the Scene Sync-only path to
-  portable JS nodes with `scene.object.material.write@1` /
-  `scene.object.visibility.write@1` capabilities, then extend host support
-  (Unity) and update this matrix.
+- Add Unity host-side material/visibility write support so `scene.setColor` /
+  `scene.setVisible` (already portable nodes with
+  `scene.object.material.write@1` / `scene.object.visibility.write@1`) can move
+  off `planned` for Unity, then update this matrix.
 - Define a portable viewer/distance and hover/activate/gaze input vocabulary,
   then map it onto host capabilities.
 - Promote Unity transform write from `experimental` to `full` after host-side

--- a/docs/STANDARD_LIBRARY_REFERENCE.md
+++ b/docs/STANDARD_LIBRARY_REFERENCE.md
@@ -352,6 +352,40 @@ Arguments:
 | y | number | no | Y offset. |
 | z | number | no | Z offset. |
 
+### scene.setVisible
+
+Signature: `scene.setVisible(objectId: "...", visible: true)`
+
+Returns: `void`
+Status: `implemented`
+
+Shows or hides a scene object.
+
+Arguments:
+
+| Name | Type | Positional | Description |
+|---|---|---:|---|
+| objectId | string | yes | ID of the object. |
+| visible | boolean | no | Whether the object is visible. |
+
+### scene.setColor
+
+Signature: `scene.setColor(objectId: "...", r: 1, g: 1, b: 1)`
+
+Returns: `void`
+Status: `implemented`
+
+Sets the material color of a scene object (RGB, 0..1).
+
+Arguments:
+
+| Name | Type | Positional | Description |
+|---|---|---:|---|
+| objectId | string | yes | ID of the object. |
+| r | number | no | Red channel, 0..1. |
+| g | number | no | Green channel, 0..1. |
+| b | number | no | Blue channel, 0..1. |
+
 ## audioSource
 
 AudioSource component playback control through a host adapter

--- a/docs/design/graph-capability-metadata-v0.md
+++ b/docs/design/graph-capability-metadata-v0.md
@@ -70,6 +70,8 @@ Capability tokens are `name@version` strings. v0 set:
 | `env.events@1` | Host-provided committed events (`onEvent`) |
 | `event.emit@1` | Emitting events back to the host (`sendEvent`) |
 | `scene.object.transform.write@1` | Writing object transform (position/rotation/scale) |
+| `scene.object.visibility.write@1` | Writing object visibility (`scene.setVisible`) |
+| `scene.object.material.write@1` | Writing object material color (`scene.setColor`) |
 | `scene.object.audio.control@1` | Controlling an object AudioSource component |
 
 Effect classes (v0): `TimeRead`, `InputRead`, `EventRead`, `EventWrite`,
@@ -120,14 +122,17 @@ Each host declares the capability tokens it provides. v0 profiles:
 | `env.events@1` | ✅ | – | – | ✅ |
 | `event.emit@1` | ✅ | – | – | ✅ |
 | `scene.object.transform.write@1` | ✅ | ✅ | ✅ | – |
-| `scene.object.audio.control@1` | ✅ | ✅ | ✅ | – |
+| `scene.object.visibility.write@1` | ✅ | – | ✅ | – |
+| `scene.object.material.write@1` | ✅ | – | ✅ | – |
+| `scene.object.audio.control@1` | ✅ | – | ✅ | – |
 
 Notes:
 
 - `cli` has no scene/audio host, so `SceneWrite` / `AudioControl` are meaningless
   there.
-- `unity-runtime` and `export-viewer` are conservative for live input/events in
-  v0; promote tokens as those runtimes mature.
+- `unity-runtime` is conservative in v0: no live input/events, and no audio or
+  material/visibility writes until the Unity runtime implements them. `export-viewer`
+  is conservative for live input/events. Promote tokens as those runtimes mature.
 - These sets are intentionally editable data, not a frozen contract.
 
 ## Compatibility report

--- a/extensions/vscode-loomlet/generated/library-metadata.json
+++ b/extensions/vscode-loomlet/generated/library-metadata.json
@@ -466,6 +466,64 @@
               "description": "Z offset."
             }
           ]
+        },
+        {
+          "name": "setVisible",
+          "fullName": "scene.setVisible",
+          "status": "implemented",
+          "signature": "scene.setVisible(objectId: \"...\", visible: true)",
+          "description": "Shows or hides a scene object.",
+          "returns": "void",
+          "allowsTwoPositionalArgs": false,
+          "inputs": [
+            {
+              "name": "objectId",
+              "type": "string",
+              "positional": true,
+              "description": "ID of the object."
+            },
+            {
+              "name": "visible",
+              "type": "boolean",
+              "positional": false,
+              "description": "Whether the object is visible."
+            }
+          ]
+        },
+        {
+          "name": "setColor",
+          "fullName": "scene.setColor",
+          "status": "implemented",
+          "signature": "scene.setColor(objectId: \"...\", r: 1, g: 1, b: 1)",
+          "description": "Sets the material color of a scene object (RGB, 0..1).",
+          "returns": "void",
+          "allowsTwoPositionalArgs": false,
+          "inputs": [
+            {
+              "name": "objectId",
+              "type": "string",
+              "positional": true,
+              "description": "ID of the object."
+            },
+            {
+              "name": "r",
+              "type": "number",
+              "positional": false,
+              "description": "Red channel, 0..1."
+            },
+            {
+              "name": "g",
+              "type": "number",
+              "positional": false,
+              "description": "Green channel, 0..1."
+            },
+            {
+              "name": "b",
+              "type": "number",
+              "positional": false,
+              "description": "Blue channel, 0..1."
+            }
+          ]
         }
       ]
     },

--- a/src/nodes/scene.js
+++ b/src/nodes/scene.js
@@ -121,4 +121,60 @@ export function registerSceneNodes(registry) {
       return {};
     }
   });
+  registry.registerNodeType('scene.setVisible', {
+    category: 'sink',
+    effects: ['SceneWrite'],
+    requires: ['scene.object.visibility.write@1'],
+    writes: ['object.self.visible'],
+    determinism: 'deterministic-with-env',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'visible', type: 'boolean', default: true, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'visible', type: 'boolean', default: true }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.setVisible',
+        objectId: inputs.objectId,
+        visible: Boolean(inputs.visible),
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  });
+  registry.registerNodeType('scene.setColor', {
+    category: 'sink',
+    effects: ['SceneWrite'],
+    requires: ['scene.object.material.write@1'],
+    writes: ['object.self.material.color'],
+    determinism: 'deterministic-with-env',
+    inputs: [
+      { name: 'objectId', type: 'string', default: '', kind: 'behavior' },
+      { name: 'r', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'g', type: 'number', default: 1, kind: 'behavior' },
+      { name: 'b', type: 'number', default: 1, kind: 'behavior' }
+    ],
+    outputs: [],
+    params: [
+      { name: 'objectId', type: 'string', default: '' },
+      { name: 'r', type: 'number', default: 1 },
+      { name: 'g', type: 'number', default: 1 },
+      { name: 'b', type: 'number', default: 1 }
+    ],
+    evaluate: (inputs, params, ctx) => {
+      ctx.engine?._recordEffect({
+        type: 'scene.setColor',
+        objectId: inputs.objectId,
+        color: [inputs.r, inputs.g, inputs.b].map(Number),
+        target: 'scenesync',
+        nodeId: ctx.currentNodeId
+      });
+      return {};
+    }
+  });
 }

--- a/src/runtime/capabilities.js
+++ b/src/runtime/capabilities.js
@@ -19,6 +19,8 @@ export const KNOWN_CAPABILITIES = [
   'env.events@1',
   'event.emit@1',
   'scene.object.transform.write@1',
+  'scene.object.visibility.write@1',
+  'scene.object.material.write@1',
   'scene.object.audio.control@1'
 ];
 
@@ -31,6 +33,8 @@ export const HOST_CAPABILITIES = {
     'env.events@1',
     'event.emit@1',
     'scene.object.transform.write@1',
+    'scene.object.visibility.write@1',
+    'scene.object.material.write@1',
     'scene.object.audio.control@1'
   ],
   'unity-runtime': [
@@ -43,6 +47,8 @@ export const HOST_CAPABILITIES = {
     'pure.compute@1',
     'env.time.seconds@1',
     'scene.object.transform.write@1',
+    'scene.object.visibility.write@1',
+    'scene.object.material.write@1',
     'scene.object.audio.control@1'
   ],
   cli: [

--- a/src/toolchain/library-metadata.js
+++ b/src/toolchain/library-metadata.js
@@ -367,6 +367,66 @@ export const LIBRARY_METADATA = {
         examples: [
           'scene.offsetPosition("sample-cube", x: 1, y: 0.5, z: 0)'
         ]
+      },
+      setVisible: {
+        name: 'setVisible',
+        signature: 'scene.setVisible(objectId: "...", visible: true)',
+        description: 'Shows or hides a scene object.',
+        args: [
+          {
+            name: 'objectId',
+            type: 'string',
+            positional: true,
+            description: 'ID of the object.'
+          },
+          {
+            name: 'visible',
+            type: 'boolean',
+            positional: false,
+            description: 'Whether the object is visible.'
+          }
+        ],
+        returns: 'void',
+        targets: LIBRARY_COMPATIBILITY.scene.targets,
+        examples: [
+          'scene.setVisible("sample-cube", visible: false)'
+        ]
+      },
+      setColor: {
+        name: 'setColor',
+        signature: 'scene.setColor(objectId: "...", r: 1, g: 1, b: 1)',
+        description: 'Sets the material color of a scene object (RGB, 0..1).',
+        args: [
+          {
+            name: 'objectId',
+            type: 'string',
+            positional: true,
+            description: 'ID of the object.'
+          },
+          {
+            name: 'r',
+            type: 'number',
+            positional: false,
+            description: 'Red channel, 0..1.'
+          },
+          {
+            name: 'g',
+            type: 'number',
+            positional: false,
+            description: 'Green channel, 0..1.'
+          },
+          {
+            name: 'b',
+            type: 'number',
+            positional: false,
+            description: 'Blue channel, 0..1.'
+          }
+        ],
+        returns: 'void',
+        targets: LIBRARY_COMPATIBILITY.scene.targets,
+        examples: [
+          'scene.setColor("sample-cube", r: 1, g: 0, b: 0)'
+        ]
       }
     }
   },

--- a/test/graph-capabilities.test.mjs
+++ b/test/graph-capabilities.test.mjs
@@ -22,7 +22,21 @@ test('built-in MVP nodes carry explicit capability metadata', () => {
   assert.deepEqual(NODE_TYPES.onEvent.requires, ['env.events@1']);
   assert.deepEqual(NODE_TYPES.sendEvent.requires, ['event.emit@1']);
   assert.deepEqual(NODE_TYPES['scene.setPosition'].requires, ['scene.object.transform.write@1']);
+  assert.deepEqual(NODE_TYPES['scene.setVisible'].requires, ['scene.object.visibility.write@1']);
+  assert.deepEqual(NODE_TYPES['scene.setColor'].requires, ['scene.object.material.write@1']);
   assert.deepEqual(NODE_TYPES['audioSource.play'].requires, ['scene.object.audio.control@1']);
+});
+
+test('color/visibility graphs are full on web-scenesync and export-viewer, unsupported on unity/cli', () => {
+  const graph = compileGraph('import scene\nscene.setColor("box", r: 1, g: 0, b: 0)\nscene.setVisible("box", visible: false)');
+  for (const host of ['web-scenesync', 'export-viewer']) {
+    assert.equal(checkHostCompatibility(graph, NODE_TYPES, host).status, 'full', host);
+  }
+  const unity = checkHostCompatibility(graph, NODE_TYPES, 'unity-runtime');
+  assert.equal(unity.status, 'unsupported');
+  const unityCaps = unity.unsupported.map((u) => u.capability).sort();
+  assert.deepEqual(unityCaps, ['scene.object.material.write@1', 'scene.object.visibility.write@1']);
+  assert.equal(checkHostCompatibility(graph, NODE_TYPES, 'cli').status, 'unsupported');
 });
 
 test('pure library nodes resolve to pure.compute via the built-in default', () => {


### PR DESCRIPTION
## 概要

Host Capability Guide (#290) が筆頭の次タスクとして挙げていた項目です。`scene.setColor` / `scene.setVisible` はこれまで Scene Sync の graph-adapter / browser runtime 経路にのみ存在し、portable な JS ノードレジストリ（`src/nodes/scene.js`）にも #286 の capability metadata にもありませんでした。これらを portable ノードに昇格し、ランタイム・ライブラリメタデータ・#286 互換チェックのすべてが色／可視性を扱えるようにします。

## 変更内容

- **`src/nodes/scene.js`**: `scene.setVisible(objectId, visible)` / `scene.setColor(objectId, r, g, b)` を登録。capability metadata（`SceneWrite`、`scene.object.visibility.write@1` / `scene.object.material.write@1`）付き。effect 形状は既存 scene ノード・browser runtime と一致（`{ visible }` / `{ color: [r,g,b] }`）。
- **`src/runtime/capabilities.js`**: 2 つの新トークンを `KNOWN_CAPABILITIES` に追加し、`web-scenesync` と `export-viewer` profile に付与（Unity / CLI には未付与）。
- **`src/toolchain/library-metadata.js`**: `scene.setVisible` / `scene.setColor` のメタデータを追加し、VS Code metadata と標準ライブラリリファレンスを再生成。
- **ドキュメント**: Host Capability Guide と #286 設計ドキュメントを更新（色／可視性が portable + capability-checked になった旨）。設計ドキュメントの host 表に残っていた **Unity audio の ✅ 誤記**も併せて修正。
- **テスト**: 新トークンと host compatibility（web/export=full、unity/cli=unsupported）のテストを追加。

## テスト

- `test/graph-capabilities.test.mjs`（16 件）+ 影響範囲のユニットテスト（runtime-metadata-drift / library-metadata-schema / scenesync-graph-adapter / vscode-metadata-generation / library-reference-docs ほか）を含め全パス。

## 補足

これにより #286 互換チェックが色・可視性を含むグラフに対し、各 host で `full` / `unsupported` を正しく判定できるようになります。Unity の色・可視性は host 側の material/visibility write 実装待ちで `planned` のままです（ガイドの次タスクに記載）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_