### PR TITLE
Add host compatibility panel to the Web Node Editor

### DIFF
--- a/docs/HOST_CAPABILITY_GUIDE.md
+++ b/docs/HOST_CAPABILITY_GUIDE.md
@@ -18,7 +18,8 @@ authors) can see at a glance:
 For the machine-checkable, per-graph version of "will this run here", see the
 capability metadata and `checkHostCompatibility()` from
 [Graph Capability Metadata v0](./design/graph-capability-metadata-v0.md) (#286),
-or run `loomlet check-compat <file> --target <host>` (see the [CLI guide](./cli.md)).
+run `loomlet check-compat <file> --target <host>` (see the [CLI guide](./cli.md)),
+or open the **Compatibility** tab in the Web Node Editor.
 
 The #286 profiles are a **coarse, declared capability contract** (the tokens a
 host is expected to provide). This guide is **finer-grained and reflects current

--- a/docs/design/graph-capability-metadata-v0.md
+++ b/docs/design/graph-capability-metadata-v0.md
@@ -181,6 +181,7 @@ Status rules:
 ## Future extensions
 
 - ✅ `loomlet check-compat <file> [--target <host>]` CLI (implemented; see [CLI guide](../cli.md)).
-- Node Editor target-host compatibility badge and VS Code diagnostics.
+- ✅ Node Editor compatibility panel (implemented; `describeGraphHostCompatibility` powers the Compatibility tab).
+- VS Code diagnostics for target-host compatibility.
 - Feed Host Capability Guide ([#290](https://github.com/afjk/loomlet/issues/290)).
 - `wasm.call.pure@1` / `wasm.call.component@1`, coordinate/unit semantic profiles.

--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -88,6 +88,7 @@
           <div class="tab-buttons">
             <button class="tab-btn active" data-tab="graph">GraphJSON</button>
             <button class="tab-btn" data-tab="errors">Errors</button>
+            <button class="tab-btn" data-tab="compat">Compatibility</button>
             <button class="tab-btn" data-tab="inspector">Inspector</button>
             <button class="tab-btn" data-tab="nodes">Nodes</button>
             <button class="tab-btn" data-tab="palette">Palette</button>
@@ -102,6 +103,9 @@
           </div>
           <div id="errors-tab" class="tab-pane">
             <div id="errors-list" class="errors-list"></div>
+          </div>
+          <div id="compat-tab" class="tab-pane">
+            <div id="compat-panel" class="compat-panel"></div>
           </div>
           <div id="inspector-tab" class="tab-pane">
             <div id="inspector-panel" class="inspector-panel"></div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -7,6 +7,7 @@ import { closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirro
 import { forceLinting } from '@codemirror/lint';
 
 import { Loom, NODE_TYPES } from '../../src/loom.js';
+import { describeGraphHostCompatibility } from '../../src/runtime/capabilities.js';
 import { getLatestNodeValues } from '../../src/value-preview.js';
 import { loomletDslExtensions } from './loomlet-codemirror.js';
 import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
@@ -150,6 +151,7 @@ const elements = {
   previewCanvas: document.getElementById('preview-canvas'),
   graphJson: document.getElementById('graph-json'),
   errorsList: document.getElementById('errors-list'),
+  compatPanel: document.getElementById('compat-panel'),
   inspectorPanel: document.getElementById('inspector-panel'),
   applyDslBtn: document.getElementById('applyDslBtn'),
   generateDslBtn: document.getElementById('generateDslBtn'),
@@ -1104,6 +1106,54 @@ function renderOutput() {
 function renderGraphJSON(graph) {
   const json = JSON.stringify(graph, null, 2);
   elements.graphJson.textContent = json;
+  renderCompatibility(graph);
+}
+
+function renderCompatibility(graph) {
+  if (!elements.compatPanel) {
+    return;
+  }
+  if (!graph || !Array.isArray(graph.nodes) || graph.nodes.length === 0) {
+    elements.compatPanel.innerHTML = '<div class="empty-state">No graph to check</div>';
+    return;
+  }
+
+  let view;
+  try {
+    view = describeGraphHostCompatibility(graph, NODE_TYPES);
+  } catch (error) {
+    elements.compatPanel.innerHTML =
+      `<div class="empty-state">Compatibility unavailable: ${escapeHtml(error.message)}</div>`;
+    return;
+  }
+
+  const requiresText = view.requires.length > 0
+    ? view.requires.map(escapeHtml).join(', ')
+    : '(none)';
+
+  const hostRows = view.hosts.map((report) => {
+    const detail = [];
+    for (const entry of report.unsupported) {
+      const nodes = entry.nodes.length > 0 ? ` (${entry.nodes.map(escapeHtml).join(', ')})` : '';
+      detail.push(`<li class="compat-unsupported">missing ${escapeHtml(entry.capability)}${nodes}</li>`);
+    }
+    for (const entry of report.unclassified) {
+      detail.push(`<li class="compat-unclassified">unclassified: ${escapeHtml(entry.nodeId)} (${escapeHtml(entry.type)})</li>`);
+    }
+    const detailHtml = detail.length > 0 ? `<ul class="compat-detail">${detail.join('')}</ul>` : '';
+    return `
+      <div class="compat-host">
+        <div class="compat-host-head">
+          <span class="compat-badge compat-${report.status}">${report.status}</span>
+          <span class="compat-host-name">${escapeHtml(report.targetHost)}</span>
+        </div>
+        ${detailHtml}
+      </div>`;
+  }).join('');
+
+  elements.compatPanel.innerHTML = `
+    <div class="compat-requires"><strong>Requires:</strong> ${requiresText}</div>
+    <div class="compat-hosts">${hostRows}</div>`;
 }
 
 function renderErrors() {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1268,3 +1268,80 @@ button:disabled:hover,
 .node-palette-item[draggable="true"]:active {
   cursor: grabbing;
 }
+
+/* Host compatibility panel */
+.compat-panel {
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  overflow: auto;
+}
+
+.compat-requires {
+  margin-bottom: 12px;
+  color: var(--text-dim);
+  word-break: break-all;
+}
+
+.compat-requires strong {
+  color: var(--text-color);
+}
+
+.compat-hosts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.compat-host {
+  background: var(--editor-bg-subtle);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.compat-host-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.compat-host-name {
+  font-family: var(--mono-font, monospace);
+  color: var(--text-color);
+}
+
+.compat-badge {
+  display: inline-block;
+  min-width: 84px;
+  text-align: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #111;
+}
+
+.compat-full { background: #80ed99; }
+.compat-partial { background: #ffd166; }
+.compat-unsupported { background: #ff70a6; }
+
+.compat-detail {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: var(--text-dim);
+}
+
+.compat-detail li {
+  margin: 2px 0;
+}
+
+.compat-detail .compat-unsupported {
+  background: none;
+  color: #ff9ec4;
+}
+
+.compat-detail .compat-unclassified {
+  color: #b0b0b0;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -40,5 +40,6 @@ export {
   listHostProfiles,
   resolveNodeCapabilities,
   summarizeGraphCapabilities,
-  checkHostCompatibility
+  checkHostCompatibility,
+  describeGraphHostCompatibility
 } from './runtime/capabilities.js';

--- a/src/runtime/capabilities.js
+++ b/src/runtime/capabilities.js
@@ -310,3 +310,17 @@ export function checkHostCompatibility(graph, nodeTypes, host) {
     unclassified
   };
 }
+
+// Presentation helper: describe a graph's required capabilities and its
+// compatibility status against every known host profile. Intended for UI
+// surfaces (Node Editor compatibility panel, etc.) that want a single, sorted
+// view without re-implementing the host loop.
+export function describeGraphHostCompatibility(graph, nodeTypes) {
+  const summary = summarizeGraphCapabilities(graph, nodeTypes);
+  const hosts = listHostProfiles().map((host) => checkHostCompatibility(graph, nodeTypes, host));
+  return {
+    requires: summary.requires,
+    unclassified: summary.unclassified,
+    hosts
+  };
+}

--- a/test/graph-capabilities.test.mjs
+++ b/test/graph-capabilities.test.mjs
@@ -7,6 +7,7 @@ import {
   checkHostCompatibility,
   resolveNodeCapabilities,
   listHostProfiles,
+  describeGraphHostCompatibility,
   HOST_CAPABILITIES
 } from '../src/runtime/capabilities.js';
 
@@ -146,6 +147,28 @@ test('host profiles are listed and stable', () => {
   for (const profile of listHostProfiles()) {
     assert.ok(Array.isArray(HOST_CAPABILITIES[profile]));
   }
+});
+
+test('describeGraphHostCompatibility returns requires plus a report per host', () => {
+  const graph = compileGraph('import scene\nscene.setColor("box", r: 1, g: 0, b: 0)\nscene.setPosition("box", x: clock())');
+  const view = describeGraphHostCompatibility(graph, NODE_TYPES);
+
+  assert.ok(view.requires.includes('scene.object.material.write@1'));
+  assert.deepEqual(view.hosts.map((h) => h.targetHost), listHostProfiles());
+
+  const web = view.hosts.find((h) => h.targetHost === 'web-scenesync');
+  assert.equal(web.status, 'full');
+  const unity = view.hosts.find((h) => h.targetHost === 'unity-runtime');
+  assert.equal(unity.status, 'partial');
+  assert.ok(unity.unsupported.some((u) => u.capability === 'scene.object.material.write@1'));
+});
+
+test('describeGraphHostCompatibility surfaces unclassified nodes once at the top level', () => {
+  const graph = { nodes: [{ id: 'c1', type: 'my.customNode' }], edges: [] };
+  const view = describeGraphHostCompatibility(graph, NODE_TYPES);
+  assert.deepEqual(view.requires, []);
+  assert.equal(view.unclassified.length, 1);
+  assert.equal(view.unclassified[0].nodeId, 'c1');
 });
 
 test('unity-runtime does not declare audio control (no runtime implementation yet)', () => {


### PR DESCRIPTION
## 概要

#286 の capability チェックを **Web Node Editor の UI に表示**します。これまで CLI（`loomlet check-compat`）とライブラリ API だけだった互換チェックを、ノードエディタ上でライブに見せ、編集中に「このグラフはどの host で動くか」が分かるようにします。

## 変更内容

- **`src/runtime/capabilities.js`**: `describeGraphHostCompatibility(graph, nodeTypes)` を追加。グラフの必要 capability（`requires`）と、全 host profile に対する per-host レポートをまとめて返す純粋な表示用ヘルパー。package index からエクスポートし、ユニットテスト済み。
- **editor-studio（Web Node Editor）**: 下部パネルに **「Compatibility」タブ**を追加。`renderCompatibility()` がグラフ更新のたびに走り、`requires` 一覧と host ごとの status バッジ（full / partial / unsupported）、未対応 capability・unclassified ノードの詳細を表示。既存の `escapeHtml` を再利用し、`style.css` にバッジ等のスタイルを追加。
- ドキュメント（Host Capability Guide / #286 設計ドキュメント）に Node Editor の Compatibility タブを追記。

## テスト

- `test/graph-capabilities.test.mjs` に `describeGraphHostCompatibility` のテストを追加（全 18 件パス）。
- editor-studio の本番ビルド（`vite build`、CI の `test:editor-studio-build`）が通ることを確認。UI ロジックの中核は src/ 側の純粋ヘルパーに切り出してテスト済み、UI はそれを薄く消費。

## 補足

ビルド成果物（`editor-studio/dist`）は gitignore 対象のためコミットに含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_