### PR TITLE
Add VS Code host compatibility diagnostics

### DIFF
--- a/docs/HOST_CAPABILITY_GUIDE.md
+++ b/docs/HOST_CAPABILITY_GUIDE.md
@@ -19,7 +19,8 @@ For the machine-checkable, per-graph version of "will this run here", see the
 capability metadata and `checkHostCompatibility()` from
 [Graph Capability Metadata v0](./design/graph-capability-metadata-v0.md) (#286),
 run `loomlet check-compat <file> --target <host>` (see the [CLI guide](./cli.md)),
-or open the **Compatibility** tab in the Web Node Editor.
+open the **Compatibility** tab in the Web Node Editor, or set `loomlet.targetHost`
+in the VS Code extension to get inline compatibility warnings.
 
 The #286 profiles are a **coarse, declared capability contract** (the tokens a
 host is expected to provide). This guide is **finer-grained and reflects current

--- a/docs/design/graph-capability-metadata-v0.md
+++ b/docs/design/graph-capability-metadata-v0.md
@@ -182,6 +182,6 @@ Status rules:
 
 - ✅ `loomlet check-compat <file> [--target <host>]` CLI (implemented; see [CLI guide](../cli.md)).
 - ✅ Node Editor compatibility panel (implemented; `describeGraphHostCompatibility` powers the Compatibility tab).
-- VS Code diagnostics for target-host compatibility.
+- ✅ VS Code diagnostics for target-host compatibility (implemented; set `loomlet.targetHost`).
 - Feed Host Capability Guide ([#290](https://github.com/afjk/loomlet/issues/290)).
 - `wasm.call.pure@1` / `wasm.call.component@1`, coordinate/unit semantic profiles.

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -9,6 +9,14 @@ It includes:
 - diagnostics
 - preview support
 
+## Host compatibility diagnostics
+
+Set the `loomlet.targetHost` setting to one of `web-scenesync`, `unity-runtime`,
+`export-viewer`, or `cli` to get inline warnings when a `.loom` file uses nodes
+that require a capability the target host does not provide (for example,
+`scene.setColor` on `cli`). The default `none` disables these warnings. See the
+[Host Capability Guide](HOST_CAPABILITY_GUIDE.md) for what each host supports.
+
 See:
 
 - [Extension README](../extensions/vscode-loomlet/README.md)

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -32,30 +32,6 @@
     "onCommand:loomlet.clearSceneSyncSceneBehaviorGraph"
   ],
   "contributes": {
-    "configuration": {
-      "title": "Loomlet",
-      "properties": {
-        "loomlet.targetHost": {
-          "type": "string",
-          "enum": [
-            "none",
-            "web-scenesync",
-            "unity-runtime",
-            "export-viewer",
-            "cli"
-          ],
-          "enumDescriptions": [
-            "Disable host compatibility diagnostics.",
-            "Scene Sync Web live host.",
-            "Unity runtime package.",
-            "Scene Sync export viewer.",
-            "Command-line evaluation."
-          ],
-          "default": "none",
-          "description": "Target host to check graph capability compatibility against. When set, nodes that require a capability the host does not provide are reported as warnings. 'none' disables these diagnostics."
-        }
-      }
-    },
     "languages": [
       {
         "id": "loomlet",
@@ -134,6 +110,25 @@
           "type": "boolean",
           "default": true,
           "description": "Open the Node Preview automatically after inserting a Loomlet example."
+        },
+        "loomlet.targetHost": {
+          "type": "string",
+          "enum": [
+            "none",
+            "web-scenesync",
+            "unity-runtime",
+            "export-viewer",
+            "cli"
+          ],
+          "enumDescriptions": [
+            "Disable host compatibility diagnostics.",
+            "Scene Sync Web live host.",
+            "Unity runtime package.",
+            "Scene Sync export viewer.",
+            "Command-line evaluation."
+          ],
+          "default": "none",
+          "description": "Target host to check graph capability compatibility against. When set, nodes that require a capability the host does not provide are reported as warnings. 'none' disables these diagnostics."
         }
       }
     }

--- a/extensions/vscode-loomlet/package.json
+++ b/extensions/vscode-loomlet/package.json
@@ -32,6 +32,30 @@
     "onCommand:loomlet.clearSceneSyncSceneBehaviorGraph"
   ],
   "contributes": {
+    "configuration": {
+      "title": "Loomlet",
+      "properties": {
+        "loomlet.targetHost": {
+          "type": "string",
+          "enum": [
+            "none",
+            "web-scenesync",
+            "unity-runtime",
+            "export-viewer",
+            "cli"
+          ],
+          "enumDescriptions": [
+            "Disable host compatibility diagnostics.",
+            "Scene Sync Web live host.",
+            "Unity runtime package.",
+            "Scene Sync export viewer.",
+            "Command-line evaluation."
+          ],
+          "default": "none",
+          "description": "Target host to check graph capability compatibility against. When set, nodes that require a capability the host does not provide are reported as warnings. 'none' disables these diagnostics."
+        }
+      }
+    },
     "languages": [
       {
         "id": "loomlet",

--- a/extensions/vscode-loomlet/src/diagnostics.js
+++ b/extensions/vscode-loomlet/src/diagnostics.js
@@ -1,4 +1,5 @@
 let parseDSLToAST, compileToGraph, stripEditorMetadataFromDsl;
+let NODE_TYPES, checkHostCompatibility, listHostProfiles;
 let modulesLoaded = false;
 let loadPromise = null;
 
@@ -85,6 +86,9 @@ async function ensureModulesLoaded() {
       const indexModule = await importLoomletIndex();
       parseDSLToAST = indexModule.parseDSLToAST;
       compileToGraph = indexModule.compileToGraph;
+      NODE_TYPES = indexModule.NODE_TYPES;
+      checkHostCompatibility = indexModule.checkHostCompatibility;
+      listHostProfiles = indexModule.listHostProfiles;
 
       const metadataModule = await importLoomletMetadata();
       stripEditorMetadataFromDsl = metadataModule.stripEditorMetadataFromDsl;
@@ -125,10 +129,70 @@ function toZeroBased(value, fallback = 0) {
   return Math.max(0, value - 1);
 }
 
+function getKnownHostProfiles() {
+  return typeof listHostProfiles === 'function' ? listHostProfiles() : [];
+}
+
+// Build host-compatibility diagnostic items for a configured target host.
+// Returns warning-style items: { message, code, capability, nodes }.
+// Returns [] when diagnostics are disabled, the host is unknown, the modules
+// are unavailable, or the source does not parse/compile (regular diagnostics
+// already report parse/compile errors, so we do not double-report here).
+function collectCompatibilityDiagnosticItems(sourceText, targetHost) {
+  if (!targetHost || targetHost === 'none') {
+    return [];
+  }
+  if (!modulesLoaded || !stripEditorMetadataFromDsl || !parseDSLToAST || !compileToGraph) {
+    return [];
+  }
+  if (typeof checkHostCompatibility !== 'function' || !NODE_TYPES) {
+    return [];
+  }
+  if (!getKnownHostProfiles().includes(targetHost)) {
+    return [];
+  }
+
+  const cleanText = preprocessPreviewOnlyRender(
+    preprocessPreviewHostInputs(stripEditorMetadataFromDsl(sourceText || ''))
+  );
+  if (cleanText.trim() === '') {
+    return [];
+  }
+
+  const { ast, errors: parseErrors } = parseDSLToAST(cleanText);
+  if (parseErrors.length > 0) {
+    return [];
+  }
+
+  const { graph, errors: compileErrors } = compileToGraph(ast);
+  if (compileErrors.length > 0 || !graph) {
+    return [];
+  }
+
+  let report;
+  try {
+    report = checkHostCompatibility(graph, NODE_TYPES, targetHost);
+  } catch {
+    return [];
+  }
+
+  return report.unsupported.map((entry) => {
+    const nodes = entry.nodes.length > 0 ? ` (required by: ${entry.nodes.join(', ')})` : '';
+    return {
+      message: `Target host '${targetHost}' does not provide ${entry.capability}${nodes}.`,
+      code: 'HOST_INCOMPATIBLE',
+      capability: entry.capability,
+      nodes: entry.nodes
+    };
+  });
+}
+
 module.exports = {
   isLoomletDocument,
   normalizeLoomletErrorLocation,
   collectLoomletDiagnosticItems,
+  collectCompatibilityDiagnosticItems,
+  getKnownHostProfiles,
   ensureModulesLoaded,
   preprocessPreviewHostInputs,
   preprocessPreviewOnlyRender

--- a/extensions/vscode-loomlet/src/extension.js
+++ b/extensions/vscode-loomlet/src/extension.js
@@ -7,7 +7,7 @@ const { getCompletionContext } = require('./completion-context');
 const { buildCompletions: buildRawCompletions, getIncludePlanned } = require('./completion-engine');
 const { VSCODE_EXAMPLES } = require('./examples.js');
 const { LIBRARY_REFERENCE, getLibraryReference } = require('./library-reference.js');
-const { isLoomletDocument, normalizeLoomletErrorLocation, collectLoomletDiagnosticItems, ensureModulesLoaded } = require('./diagnostics.js');
+const { isLoomletDocument, normalizeLoomletErrorLocation, collectLoomletDiagnosticItems, collectCompatibilityDiagnosticItems, ensureModulesLoaded } = require('./diagnostics.js');
 const { clampCoordinates } = require('./range-utils.js');
 const { ensurePreviewModulesLoaded, buildPreviewModelFromDsl } = require('./preview-model.js');
 
@@ -671,14 +671,17 @@ function validateLoomletDocument(document, diagnosticCollection) {
     const sourceText = document.getText();
     const errorItems = collectLoomletDiagnosticItems(sourceText);
 
-    if (errorItems.length === 0) {
-      diagnosticCollection.set(document.uri, []);
-      return;
-    }
-
     const diagnostics = errorItems
       .map((error) => diagnosticFromLoomletError(error, document))
       .filter((d) => d !== null);
+
+    const targetHost = vscode.workspace
+      .getConfiguration()
+      .get('loomlet.targetHost', 'none');
+    const compatItems = collectCompatibilityDiagnosticItems(sourceText, targetHost);
+    for (const item of compatItems) {
+      diagnostics.push(diagnosticFromCompatItem(item, document));
+    }
 
     diagnosticCollection.set(document.uri, diagnostics);
   } catch (err) {
@@ -716,6 +719,29 @@ function diagnosticFromLoomletError(error, document) {
   if (normalized.code) {
     diagnostic.code = normalized.code;
   }
+
+  return diagnostic;
+}
+
+function diagnosticFromCompatItem(item, document) {
+  // Capability requirements are graph-level, not tied to a source span, so
+  // anchor compatibility warnings at the start of the document.
+  const clamped = clampCoordinates(0, 0, 0, 1, document);
+  const range = new vscode.Range(
+    clamped.startLine,
+    clamped.startColumn,
+    clamped.endLine,
+    clamped.endColumn
+  );
+
+  const diagnostic = new vscode.Diagnostic(
+    range,
+    item.message,
+    vscode.DiagnosticSeverity.Warning
+  );
+
+  diagnostic.source = 'loomlet';
+  diagnostic.code = item.code || 'HOST_INCOMPATIBLE';
 
   return diagnostic;
 }

--- a/extensions/vscode-loomlet/test/diagnostics.test.mjs
+++ b/extensions/vscode-loomlet/test/diagnostics.test.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 
 const require = createRequire(import.meta.url);
-const { isLoomletDocument, normalizeLoomletErrorLocation, collectLoomletDiagnosticItems, ensureModulesLoaded } = require('../src/diagnostics.js');
+const { isLoomletDocument, normalizeLoomletErrorLocation, collectLoomletDiagnosticItems, collectCompatibilityDiagnosticItems, getKnownHostProfiles, ensureModulesLoaded } = require('../src/diagnostics.js');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -194,6 +194,54 @@ await ensureModulesLoaded();
     assert.equal(clamped.startLine, 0, 'Start line should be 0');
     assert.equal(clamped.endLine, 0, 'End line should be clamped to last line (0)');
   }
+}
+
+// Compatibility diagnostics
+const SCENE_COLOR_DSL = 'import scene\nscene.setColor("box", r: 1, g: 0, b: 0)';
+
+// Test: known host profiles are available
+{
+  const hosts = getKnownHostProfiles();
+  assert.deepEqual(hosts, ['cli', 'export-viewer', 'unity-runtime', 'web-scenesync'], 'Should list the known host profiles');
+}
+
+// Test: disabled (none) target produces no compatibility diagnostics
+{
+  const items = collectCompatibilityDiagnosticItems(SCENE_COLOR_DSL, 'none');
+  assert.equal(items.length, 0, "Target 'none' should disable compatibility diagnostics");
+}
+
+// Test: unknown host produces no diagnostics
+{
+  const items = collectCompatibilityDiagnosticItems(SCENE_COLOR_DSL, 'bogus-host');
+  assert.equal(items.length, 0, 'Unknown host should produce no diagnostics');
+}
+
+// Test: a host that lacks the required capability is flagged
+{
+  const items = collectCompatibilityDiagnosticItems(SCENE_COLOR_DSL, 'cli');
+  assert.ok(items.length > 0, 'cli should be flagged for scene color');
+  assert.ok(items.some((i) => i.capability === 'scene.object.material.write@1'), 'Should name the missing capability');
+  assert.equal(items[0].code, 'HOST_INCOMPATIBLE', 'Should use the HOST_INCOMPATIBLE code');
+  assert.ok(items[0].message.includes('cli'), 'Message should mention the target host');
+}
+
+// Test: a fully-supported host produces no diagnostics
+{
+  const items = collectCompatibilityDiagnosticItems(SCENE_COLOR_DSL, 'web-scenesync');
+  assert.equal(items.length, 0, 'web-scenesync supports scene color, so no diagnostics');
+}
+
+// Test: source that does not compile produces no compatibility diagnostics (errors are handled separately)
+{
+  const items = collectCompatibilityDiagnosticItems('x = math.sine(t, frequency:', 'cli');
+  assert.equal(items.length, 0, 'Parse errors should not yield compatibility diagnostics');
+}
+
+// Test: empty source produces no compatibility diagnostics
+{
+  const items = collectCompatibilityDiagnosticItems('', 'cli');
+  assert.equal(items.length, 0, 'Empty source should produce no compatibility diagnostics');
 }
 
 console.log('All diagnostics tests passed!');


### PR DESCRIPTION
## 概要

#286 の capability チェックを **VS Code 拡張の inline diagnostics に表示**します。これで #286 Future extensions の最後の一項目が埋まり、capability システムが CLI・Node Editor・VS Code の 3 サーフェスすべてで利用可能になります。

`.loom` ファイルが、設定したターゲット host が提供しない capability を要求するノード（例: `cli` に対する `scene.setColor`）を使っている場合に、警告を出します。

## 変更内容

- **設定 `loomlet.targetHost`**（`none` / `web-scenesync` / `unity-runtime` / `export-viewer` / `cli`、デフォルト `none`）を追加。
- **`diagnostics.js`**: `collectCompatibilityDiagnosticItems(sourceText, targetHost)` を追加。ソースをコンパイルして `checkHostCompatibility` を実行し、未対応 capability を warning item として返す。無効時・未知 host・パース/コンパイルエラー時は何も返さない（パース/コンパイルエラーは既存の diagnostics が報告するため二重報告しない）。`getKnownHostProfiles()` も公開。
- **`extension.js`**: それらを Warning diagnostic として出力。capability 要件はグラフ全体に対するもので個別 span に紐づかないため、ドキュメント先頭にアンカー。`HOST_INCOMPATIBLE` コード付き。
- 拡張の diagnostics テストに新ロジックのケースを追加。VS Code 拡張ガイド / Host Capability Guide / #286 設計ドキュメントに設定を記載。

## 設計メモ

- 拡張は既存の `@afjk/loomlet`（fallback で `src/index.js`）import 経路を踏襲し、`NODE_TYPES` / `checkHostCompatibility` / `listHostProfiles` を取得。別途生成ファイルは不要。
- コンパイル済みグラフのノードはソース位置を持たないため、v0 ではファイルレベル（行頭）の警告とした。個別ノード位置への紐づけは将来の改善候補。

## テスト

- `extensions/vscode-loomlet/test/diagnostics.test.mjs` に追加（拡張の `npm test` で全パス）。`none`/未知host/未対応host/対応host/パースエラー/空ソースをカバー。
- 拡張テストは root の `test:unit`（CI "unit"）には含まれず、publish CI（`publish-vscode-extension.yml`）が実行する既存構成のため、ローカルで全パスを確認済み。
- root 側の変更なし（`vscode-metadata-generation` 等の root テストも影響なしを確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_