### PR TITLE
Add Functions panel to the Web Node Editor (#306 Phase 2a)

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -89,6 +89,7 @@
             <button class="tab-btn active" data-tab="graph">GraphJSON</button>
             <button class="tab-btn" data-tab="errors">Errors</button>
             <button class="tab-btn" data-tab="compat">Compatibility</button>
+            <button class="tab-btn" data-tab="functions">Functions</button>
             <button class="tab-btn" data-tab="inspector">Inspector</button>
             <button class="tab-btn" data-tab="nodes">Nodes</button>
             <button class="tab-btn" data-tab="palette">Palette</button>
@@ -106,6 +107,9 @@
           </div>
           <div id="compat-tab" class="tab-pane">
             <div id="compat-panel" class="compat-panel"></div>
+          </div>
+          <div id="functions-tab" class="tab-pane">
+            <div id="functions-panel" class="functions-panel"></div>
           </div>
           <div id="inspector-tab" class="tab-pane">
             <div id="inspector-panel" class="inspector-panel"></div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -21,7 +21,7 @@ import {
   findNonOverlappingPosition,
   NODE_LAYOUT_STEP_Y
 } from '../../src/node-editor-core.js';
-import { graphToCanonicalDSL } from '../../src/canonical-dsl.js';
+import { graphToCanonicalDSL, subgraphsToFnDefinitions } from '../../src/canonical-dsl.js';
 import { patchOrCanonicalDslSource } from '../../src/source-dsl-patch.js';
 import { createStore } from './studio-store.js';
 import { NodeEditorView } from './node-editor-view.js';
@@ -152,6 +152,7 @@ const elements = {
   graphJson: document.getElementById('graph-json'),
   errorsList: document.getElementById('errors-list'),
   compatPanel: document.getElementById('compat-panel'),
+  functionsPanel: document.getElementById('functions-panel'),
   inspectorPanel: document.getElementById('inspector-panel'),
   applyDslBtn: document.getElementById('applyDslBtn'),
   generateDslBtn: document.getElementById('generateDslBtn'),
@@ -1107,6 +1108,48 @@ function renderGraphJSON(graph) {
   const json = JSON.stringify(graph, null, 2);
   elements.graphJson.textContent = json;
   renderCompatibility(graph);
+  renderFunctions();
+}
+
+// Read-only "Functions" panel: list the `fn` definitions the current source
+// declares as reusable units. Derived from a subgraph-mode compile of the
+// stored AST, so the node canvas (compiled inline) is untouched.
+function renderFunctions() {
+  if (!elements.functionsPanel) {
+    return;
+  }
+  const emptyState = '<div class="empty-state">No functions defined</div>';
+  const ast = store.getState().sourceAst;
+  if (!ast) {
+    elements.functionsPanel.innerHTML = emptyState;
+    return;
+  }
+
+  let defs;
+  try {
+    const { graph, errors } = compileToGraph(ast, { functionLowering: 'subgraph' });
+    if (errors && errors.length) {
+      elements.functionsPanel.innerHTML = emptyState;
+      return;
+    }
+    defs = subgraphsToFnDefinitions(graph);
+  } catch (error) {
+    elements.functionsPanel.innerHTML =
+      `<div class="empty-state">Functions unavailable: ${escapeHtml(error.message)}</div>`;
+    return;
+  }
+
+  if (!defs.length) {
+    elements.functionsPanel.innerHTML = emptyState;
+    return;
+  }
+
+  const rows = defs.map((fn) => `
+    <div class="fn-item">
+      <div class="fn-sig"><span class="fn-keyword">fn</span> ${escapeHtml(fn.name)}(${fn.params.map(escapeHtml).join(', ')})</div>
+      <div class="fn-body">=&gt; ${escapeHtml(fn.body)}</div>
+    </div>`).join('');
+  elements.functionsPanel.innerHTML = `<div class="fn-list">${rows}</div>`;
 }
 
 function renderCompatibility(graph) {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1345,3 +1345,39 @@ button:disabled:hover,
 .compat-detail .compat-unclassified {
   color: #b0b0b0;
 }
+
+/* Functions panel (fn definitions) */
+.functions-panel {
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  overflow: auto;
+}
+
+.fn-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fn-item {
+  background: var(--editor-bg-subtle);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: var(--mono-font, monospace);
+}
+
+.fn-sig {
+  color: var(--text-color);
+}
+
+.fn-keyword {
+  color: #80ed99;
+  font-weight: 600;
+}
+
+.fn-body {
+  margin-top: 2px;
+  color: var(--text-dim);
+  word-break: break-word;
+}

--- a/src/canonical-dsl.js
+++ b/src/canonical-dsl.js
@@ -76,6 +76,24 @@ function renderSubgraphBody(def, subgraphs) {
   return renderNode(splitRef(def.output)[0]);
 }
 
+// Describe each shared subgraph definition in a graph as a reusable function
+// unit: { name, params, body, signature }. Intended for UI surfaces (the Node
+// Editor "Functions" panel) that list the functions a graph defines without
+// re-implementing body rendering. Returns [] when the graph defines none.
+export function subgraphsToFnDefinitions(graph) {
+  const subgraphs = (graph && graph.subgraphs) || {};
+  return Object.entries(subgraphs).map(([name, def]) => {
+    const params = [...def.params];
+    const body = renderSubgraphBody(def, subgraphs);
+    return {
+      name,
+      params,
+      body,
+      signature: `fn ${name}(${params.join(', ')}) => ${body}`
+    };
+  });
+}
+
 // Order nodes so that a node's dependencies (the `from` endpoints of its
 // incoming edges) are emitted before it. Canonical DSL references nodes by name,
 // and the compiler requires definition-before-use, so creation order is not

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ export {
   NODE_LAYOUT_MAX_COLS
 } from './node-editor-core.js';
 export {
-  graphToCanonicalDSL
+  graphToCanonicalDSL,
+  subgraphsToFnDefinitions
 } from './canonical-dsl.js';
 
 export {

--- a/test/canonical-dsl-subgraphs.test.mjs
+++ b/test/canonical-dsl-subgraphs.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { parseDSLToAST, compileToGraph, graphToCanonicalDSL, Loom } from '../src/index.js';
+import { parseDSLToAST, compileToGraph, graphToCanonicalDSL, subgraphsToFnDefinitions, Loom } from '../src/index.js';
 
 function compileSubgraph(src) {
   const { ast, errors } = parseDSLToAST(src);
@@ -15,6 +15,30 @@ function evalRef(graph, ref, env = { time: 5 }) {
   engine.evaluateOnce({ env });
   return engine.getValue(ref);
 }
+
+test('subgraphsToFnDefinitions lists each function as a reusable unit', () => {
+  const defs = subgraphsToFnDefinitions(compileSubgraph('fn double(x) => add(x, x)\na = double(5)'));
+  assert.equal(defs.length, 1);
+  assert.equal(defs[0].name, 'double');
+  assert.deepEqual(defs[0].params, ['x']);
+  assert.match(defs[0].signature, /^fn double\(x\) => add\(/);
+});
+
+test('subgraphsToFnDefinitions covers nested function references', () => {
+  const defs = subgraphsToFnDefinitions(
+    compileSubgraph('fn double(x) => add(x, x)\nfn quadruple(x) => double(double(x))\nv = quadruple(3)')
+  );
+  const names = defs.map((d) => d.name).sort();
+  assert.deepEqual(names, ['double', 'quadruple']);
+  const quad = defs.find((d) => d.name === 'quadruple');
+  assert.match(quad.body, /double\(double\(x\)\)/);
+});
+
+test('subgraphsToFnDefinitions returns [] for a graph with no functions', () => {
+  const { ast } = parseDSLToAST('a = add(1, 2)');
+  const { graph } = compileToGraph(ast);
+  assert.deepEqual(subgraphsToFnDefinitions(graph), []);
+});
 
 test('canonical DSL renders subgraphs as fn definitions', () => {
   const dsl = graphToCanonicalDSL(compileSubgraph('fn double(x) => add(x, x)\na = double(5)'));


### PR DESCRIPTION
## 概要

[#306](https://github.com/afjk/loomlet/issues/306) の **Phase 2a**。Node Editor で `fn` 定義を**再利用可能な単位（reusable units）として可視化**する、小さく安全なスライスです。ノードキャンバス・既定の inline コンパイル・エディタモデル・DSL round-trip には一切触れません。

rete.js のキャンバス上での collapsible group ノード化は大きく、ヘッドレスでは視覚検証できないため、Phase 2b の follow-up に分離しています。

## 変更内容

- **`src/canonical-dsl.js`**: `subgraphsToFnDefinitions(graph)` をエクスポート。既存の `renderSubgraphBody` を再利用し、各 subgraph 定義を `{ name, params, body, signature }` として返す（無ければ `[]`）。package index からも export。
- **editor-studio**: read-only な **「Functions」タブ**を追加。`renderFunctions()` は保存済み AST を **subgraph モードでコンパイルして定義を抽出**し、各 `fn` のシグネチャを一覧表示。関数が無ければ空状態。ノードキャンバスは引き続き inline コンパイルのままなので、node id・レイアウト・編集・round-trip は不変。
- **テスト**: `subgraphsToFnDefinitions`（単一 / ネスト / 無し）を `test/canonical-dsl-subgraphs.test.mjs` に追加。editor-studio ビルドで配線を検証。

## テスト

- `test/canonical-dsl-subgraphs.test.mjs`（8件）パス、`test:unit` 登録済み。
- editor-studio 本番ビルド（`vite build`）通過。影響範囲の回帰（canonical / round-trip / subgraph）も green。

## 検証メモ

中核ロジック（`subgraphsToFnDefinitions`）は src 側の純粋関数としてユニットテスト済み、UI はそれを薄く消費。視覚的な確認（Functions タブに `fn` が並ぶ）はローカルの `npm run dev` で可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_