### PR TITLE
Inline trivial projection functions in subgraph lowering (#306)

### DIFF
--- a/docs/labs/FUNCTION_DEFINITIONS_V0.md
+++ b/docs/labs/FUNCTION_DEFINITIONS_V0.md
@@ -30,12 +30,11 @@ The runtime expands subgraphs back into an equivalent flat graph on load
 (`expandSubgraphs`, exported from the package index), so evaluation is identical
 to inline mode. Scene Sync also flattens compact graphs before evaluation.
 
-Known Phase 1 limitation: a pure passthrough/projection function whose result is a
-dynamic node reference (not a literal) and is read directly by its own binding
-name — e.g. `fn id(x) => x` then `v = id(clock())` read as `v.t` — does not
-materialize a node named `v` in subgraph mode. Literal passthroughs
-(`v = first(3, 9)`) and passthroughs feeding a downstream consumer behave
-identically to inline mode.
+Trivial projection functions whose body is a bare parameter (e.g. `fn id(x) => x`
+or `fn first(a, b) => a`) have no shareable body, so subgraph mode inlines them
+exactly like inline mode — including reads of the binding by its own name
+(`v = id(clock())` read as `v.t`). Only functions with a real body are emitted as
+shared `graph.subgraphs` entries.
 
 Canonical DSL rendering supports subgraph-lowered graphs: `graphToCanonicalDSL`
 emits `fn name(params) => body` definitions and renders `subgraph.call` nodes as

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -303,6 +303,13 @@ function defaultOutputPort(nodeTypeName, nodeTypes = NODE_TYPES) {
   return def.outputs.find(o => o.name === 'out') ? 'out' : def.outputs[0].name;
 }
 
+// A trivial projection returns one of its parameters unchanged (body is a bare
+// parameter identifier). It has no shareable body, so subgraph lowering inlines
+// it like inline mode does.
+function isTrivialProjection(fn) {
+  return Boolean(fn && fn.body && fn.body.type === 'ident' && fn.params.some((p) => p.name === fn.body.name));
+}
+
 export function compileToGraph(ast, options = {}) { /* bridge via existing shape */
   const errors = []; if (!ast) return { graph: { nodes: [], edges: [] }, errors };
   try {
@@ -513,8 +520,15 @@ function buildGraph(stmts, options = {}) { /* mostly original */
     return id;
   }
   function buildFunctionDefinitionCall(call, resultId, pipeFrom, locals) {
-    if (functionLowering === 'subgraph') return buildSubgraphCall(call, resultId, pipeFrom, locals);
     const fn = functionDefs.get(call.name);
+    // Trivial projections (body is just a parameter, e.g. `fn id(x) => x` or
+    // `fn first(a, b) => a`) have no shareable body, so inline them even in
+    // subgraph mode. This matches inline semantics exactly and avoids the
+    // passthrough-read-by-name divergence (a projection bound to a name and read
+    // by that name now materializes the same node inline mode would).
+    if (functionLowering === 'subgraph' && !isTrivialProjection(fn)) {
+      return buildSubgraphCall(call, resultId, pipeFrom, locals);
+    }
     const pos = call.args.filter(a => !a.named);
     if (call.args.length !== pos.length) throw new LoomDSLError(`Function '${call.name}' only accepts positional arguments`, call.line, call.col, 'MISSING_ARGUMENT_NAME');
     const suppliedArity = pos.length + (pipeFrom ? 1 : 0);

--- a/test/loom-subgraph.test.mjs
+++ b/test/loom-subgraph.test.mjs
@@ -60,6 +60,24 @@ test('subgraph mode evaluates identically to inline mode', () => {
   }
 });
 
+test('trivial projection functions are inlined, matching inline reads by name', () => {
+  // A projection bound to a name and read by that name must resolve identically
+  // to inline mode (previously diverged for dynamic ref passthroughs).
+  const cases = [
+    ['fn id(x) => x\nv = id(clock())', 'v.t'],
+    ['fn first(a, b) => a\nv = first(3, 9)', 'v.out'],
+    ['fn second(a, b) => b\nv = second(3, 9)', 'v.out']
+  ];
+  for (const [src, ref] of cases) {
+    const inline = evalValue(compile(src), ref, { time: 5 });
+    const sub = evalValue(compile(src, 'subgraph'), ref, { time: 5 });
+    assert.deepEqual(sub, inline, `mismatch for: ${src}`);
+  }
+  // A trivial projection has no shareable body, so it is not emitted as a subgraph.
+  const graph = compile('fn id(x) => x\nfn double(x) => add(x, x)\na = id(double(3))', 'subgraph');
+  assert.deepEqual(Object.keys(graph.subgraphs || {}), ['double']);
+});
+
 test('subgraph graph survives JSON round-trip and runs', () => {
   const compact = compile('fn double(x) => add(x, x)\nv = double(21)', 'subgraph');
   const roundTripped = JSON.parse(JSON.stringify(compact));


### PR DESCRIPTION
## 概要

[#306](https://github.com/afjk/loomlet/issues/306) の最後の小制限（passthrough 完全一致）を解消します。

body が単なるパラメータの**自明な射影関数**（`fn id(x) => x`、`fn first(a, b) => a` 等）は共有すべき body を持たないため、subgraph モードでも `subgraph.call` を出さず **inline 展開**します（実際に inline モードと同一処理）。これにより、射影を名前に束縛して**その名前で読む**ケース（`v = id(clock())` を `v.t` で読む）が inline と完全一致します。

当初案（`expandSubgraphs` 内での source ノードのリネーム）は「無名 vs 名前付き束縛」を見分けるヒューリスティックが脆く新たな乖離を生む懸念があったため、より安全なコンパイラレベルの対応にしました。

## 変更内容

- **`src/loom-dsl.js`**: `isTrivialProjection(fn)` を追加。`buildFunctionDefinitionCall` は自明射影なら subgraph モードでも inline パスを取る。実体ある body の関数は引き続き共有 `graph.subgraphs` エントリとして出力。
- **テスト**: 自明射影の name-read 等価性（inline vs subgraph）と「自明射影は subgraph 化されない」をロック。
- **ドキュメント**: 既知制限の記述を「自明射影は inline される」挙動説明に置換。

## テスト

- フル `npm test`（editor-studio ビルド含む）EXIT=0・失敗 0。
- 関連回帰（loom-subgraph / canonical-dsl-subgraphs / loom-editor-model-subgraph / stabilization / runtime-parity）green。

## 補足

このブランチは当初 Phase 2b（#311、マージ済み）の上に誤って積まれていたため、最新 main に rebase して差分を本変更（3 ファイル）のみに整理しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)