### PR TITLE
Replace native confirm with an in-app modal for node deletion

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -221,6 +221,16 @@
     </div>
   </div>
 
+  <div id="confirm-overlay" class="confirm-overlay" hidden>
+    <div class="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-message">
+      <div id="confirm-message" class="confirm-message"></div>
+      <div class="confirm-actions">
+        <button id="confirm-cancel" class="btn">Cancel</button>
+        <button id="confirm-ok" class="btn btn-danger">Delete</button>
+      </div>
+    </div>
+  </div>
+
   <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -158,6 +158,10 @@ const elements = {
   fnSubviewTitle: document.getElementById('fn-subview-title'),
   fnSubviewClose: document.getElementById('fn-subview-close'),
   fnSubviewCanvas: document.getElementById('fn-subview-canvas'),
+  confirmOverlay: document.getElementById('confirm-overlay'),
+  confirmMessage: document.getElementById('confirm-message'),
+  confirmCancel: document.getElementById('confirm-cancel'),
+  confirmOk: document.getElementById('confirm-ok'),
   inspectorPanel: document.getElementById('inspector-panel'),
   applyDslBtn: document.getElementById('applyDslBtn'),
   generateDslBtn: document.getElementById('generateDslBtn'),
@@ -1877,6 +1881,44 @@ async function deleteSelectedNode() {
   await deleteNodes([node.id]);
 }
 
+// In-app confirmation modal (replaces native window.confirm for a better UX).
+// Resolves to true on confirm, false on cancel / Escape / backdrop.
+let confirmResolver = null;
+
+function showConfirmDialog({ message, confirmLabel = 'Confirm', cancelLabel = 'Cancel', danger = false } = {}) {
+  if (!elements.confirmOverlay) {
+    // Fallback if the overlay markup is unavailable.
+    return Promise.resolve(window.confirm(message));
+  }
+  // Resolve any dialog still open as cancelled before showing a new one.
+  resolveConfirmDialog(false);
+
+  if (elements.confirmMessage) elements.confirmMessage.textContent = message;
+  if (elements.confirmOk) {
+    elements.confirmOk.textContent = confirmLabel;
+    elements.confirmOk.classList.toggle('btn-danger', Boolean(danger));
+    elements.confirmOk.classList.toggle('btn-primary', !danger);
+  }
+  if (elements.confirmCancel) elements.confirmCancel.textContent = cancelLabel;
+
+  elements.confirmOverlay.hidden = false;
+  // Focus the confirm action so Enter/Space act on it.
+  elements.confirmOk?.focus();
+
+  return new Promise((resolve) => {
+    confirmResolver = resolve;
+  });
+}
+
+function resolveConfirmDialog(value) {
+  if (elements.confirmOverlay) elements.confirmOverlay.hidden = true;
+  if (confirmResolver) {
+    const resolve = confirmResolver;
+    confirmResolver = null;
+    resolve(value);
+  }
+}
+
 async function deleteNodes(nodeIds) {
   const state = store.getState();
   const existing = (nodeIds || []).filter((id) => state.editorModel?.nodesById?.[id]);
@@ -1885,7 +1927,7 @@ async function deleteNodes(nodeIds) {
   const message = existing.length === 1
     ? `Delete node '${existing[0]}'? Connected edges will also be removed.`
     : `Delete ${existing.length} nodes (${existing.join(', ')})? Connected edges will also be removed.`;
-  if (!window.confirm(message)) return;
+  if (!(await showConfirmDialog({ message, confirmLabel: 'Delete', danger: true }))) return;
 
   const removesSelected = selectedNodeId && existing.includes(selectedNodeId);
 
@@ -2923,6 +2965,28 @@ function setupEventListeners() {
       closeFunctionSubview();
     }
   });
+
+  // Confirmation modal
+  elements.confirmOk?.addEventListener('click', () => resolveConfirmDialog(true));
+  elements.confirmCancel?.addEventListener('click', () => resolveConfirmDialog(false));
+  elements.confirmOverlay?.addEventListener('click', (event) => {
+    if (event.target === elements.confirmOverlay) {
+      resolveConfirmDialog(false);
+    }
+  });
+  // Capture phase so Escape/Enter act on the open dialog before other handlers.
+  document.addEventListener('keydown', (event) => {
+    if (!elements.confirmOverlay || elements.confirmOverlay.hidden) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      resolveConfirmDialog(false);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      resolveConfirmDialog(true);
+    }
+  }, true);
 
   // Scene Sync event listeners
   elements.sceneSyncEndpoint?.addEventListener('input', saveSceneSyncSettings);

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -2984,7 +2984,8 @@ function setupEventListeners() {
     } else if (event.key === 'Enter') {
       event.preventDefault();
       event.stopImmediatePropagation();
-      resolveConfirmDialog(true);
+      // Enter confirms by default (OK is focused on open), but respects Cancel focus.
+      resolveConfirmDialog(document.activeElement !== elements.confirmCancel);
     }
   }, true);
 

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1450,3 +1450,41 @@ button:disabled:hover,
   color: var(--text-dim);
   border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
+
+/* Confirmation modal */
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.confirm-overlay[hidden] {
+  display: none;
+}
+
+.confirm-dialog {
+  width: min(420px, 88vw);
+  background: var(--panel-bg-strong, rgba(20, 20, 20, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  padding: 18px 18px 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.confirm-message {
+  color: var(--text-color);
+  font-size: 14px;
+  line-height: 1.5;
+  margin-bottom: 16px;
+  word-break: break-word;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}


### PR DESCRIPTION
## 概要

Web Editor のノード削除がネイティブの `window.confirm`（ブラウザ標準ダイアログ）を使っており、体験が悪い・アプリの見た目と不一致でした。これを**アプリ内のスタイル付き確認モーダル**に置き換えます。

## 変更内容

- **`editor-studio/index.html`**: 確認オーバーレイ（メッセージ + Cancel / Delete アクション）を追加。
- **`editor-studio/src/main.js`**: `showConfirmDialog()` が `Promise<boolean>` を返し、`deleteNodes()` が `await`。確定 / キャンセル / 背景クリック / Escape で解決、Enter で確定。**capture フェーズの keydown** で、ダイアログが開いている間の Escape/Enter を他のショートカット（Delete/Backspace 削除、undo/redo、サブビュー Escape）より先に処理。マークアップが無い場合は `window.confirm` にフォールバック。
- **`editor-studio/src/style.css`**: モーダルのスタイル。

ノード削除の全経路（Delete キー / インスペクタの削除ボタン / コンテキストメニュー）は `deleteNodes` を通るため、これ 1 箇所の変更で全トリガーをカバーします。

## テスト

- フル `npm test`（editor-studio ビルド含む）EXIT=0・失敗 0。root 側の変更なし（editor-studio のみ）。
- 視覚・対話の確認はローカル `npm run dev`（ヘッドレス環境ではビルド検証まで）。

## 補足

ファイルを開く際の「未保存変更」確認など、他の `window.confirm` 箇所は今回のスコープ外（同じ `showConfirmDialog` ヘルパーで follow-up として統一可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_