### PR TITLE
Add a mobile/small-screen layout to the Web Node Editor

### DIFF
--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1488,3 +1488,62 @@ button:disabled:hover,
   justify-content: flex-end;
   gap: 8px;
 }
+
+/* --- Mobile / small-screen layout --- */
+@media (max-width: 720px) {
+  /* Toolbar: keep a single row but let it scroll horizontally instead of
+     clipping the many actions. */
+  .studio-toolbar {
+    left: 6px;
+    right: 6px;
+    gap: 6px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+  }
+  .studio-toolbar > * {
+    flex: 0 0 auto;
+  }
+  .studio-toolbar .btn {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+
+  /* Stack the DSL editor, node editor, and bottom panel vertically. Using a
+     flex column keeps the maximize modes working: a pane hidden via
+     display:none simply drops out and the remaining flex pane fills. */
+  .editor-panels {
+    left: 6px;
+    right: 6px;
+    bottom: 6px;
+    top: 58px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .editor-panels .dsl-pane,
+  .editor-panels .node-pane {
+    flex: 1 1 0;
+    min-height: 140px;
+    width: auto;
+  }
+  .editor-panels .editor-split-resize-handle {
+    display: none;
+  }
+  .editor-panels .bottom-panel-resize-handle,
+  .editor-panels .graph-errors-panel {
+    flex: 0 0 auto;
+  }
+  /* Keep the bottom panel from dominating short screens (still resizable). */
+  .editor-panels .graph-errors-panel {
+    height: min(260px, 38vh);
+  }
+
+  /* Slightly tighter tab buttons in the bottom panel. */
+  .tab-btn {
+    padding: 8px 11px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
## 概要

Web Node Editor（editor-studio）はデスクトップ向けの固定 2 カラム（DSL エディタ｜ノードエディタ）レイアウトと 1 行ツールバーで、スマホ幅では横にはみ出して使いづらい状態でした。狭い画面（≤720px）向けのレスポンシブレイアウトを追加します。

## 変更内容（CSS のみ）

`editor-studio/src/style.css` にメディアクエリ（`@media (max-width: 720px)`）を追加：

- **ツールバー**: 1 行のまま**横スクロール**化（アクションがクリップされない）+ ボタンを小さめに。
- **エディタパネル**: DSL エディタ・ノードエディタ・下部パネルを**縦積み**（`display:flex; flex-direction:column`）。flex 列にしたことで**最大化モード**（片方のペインを `display:none`）もそのまま機能（隠れたペインが流れから外れ、残ったペインが伸びる）。
- 不要になった**縦分割ハンドルを非表示**。
- **下部パネルの高さ**を短い画面で抑制（`min(260px, 38vh)`、引き続きリサイズ/折りたたみ可）。
- 下部パネルの**タブボタン**を少しコンパクトに。

viewport メタとタブバーの横スクロールは既存。

## テスト

- フル `npm test`（editor-studio ビルド含む）EXIT=0・失敗 0。root 側の変更なし。
- レイアウトは CSS のみ。実機/エミュレータでの見た目確認はローカル `npm run dev` 推奨（ヘッドレスではビルド検証まで）。

## 補足

ブレークポイントは 720px（スマホ portrait 想定）。タブレット portrait（768px）は従来のデスクトップレイアウトのままです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_