### PR TITLE
Open the node context menu via long-press on touch devices

### DIFF
--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -222,11 +222,15 @@ export class NodeEditorView {
       }
     };
 
+    // Capture phase: rete's NodeView drag handler calls stopPropagation() on the
+    // node element's pointerdown, so a bubble-phase listener on the container
+    // would never see a press that lands on a node. Capturing runs the container
+    // listener first, so long-press works on nodes (Inspect/Delete) too.
     this._longPress = { onPointerDown, onPointerMove, clear };
-    this.container.addEventListener('pointerdown', onPointerDown);
-    this.container.addEventListener('pointermove', onPointerMove);
-    this.container.addEventListener('pointerup', clear);
-    this.container.addEventListener('pointercancel', clear);
+    this.container.addEventListener('pointerdown', onPointerDown, true);
+    this.container.addEventListener('pointermove', onPointerMove, true);
+    this.container.addEventListener('pointerup', clear, true);
+    this.container.addEventListener('pointercancel', clear, true);
   }
 
   _findNodeIdFromEventTarget(target) {
@@ -582,10 +586,10 @@ export class NodeEditorView {
     }
     if (this._longPress) {
       this._longPress.clear();
-      this.container.removeEventListener('pointerdown', this._longPress.onPointerDown);
-      this.container.removeEventListener('pointermove', this._longPress.onPointerMove);
-      this.container.removeEventListener('pointerup', this._longPress.clear);
-      this.container.removeEventListener('pointercancel', this._longPress.clear);
+      this.container.removeEventListener('pointerdown', this._longPress.onPointerDown, true);
+      this.container.removeEventListener('pointermove', this._longPress.onPointerMove, true);
+      this.container.removeEventListener('pointerup', this._longPress.clear, true);
+      this.container.removeEventListener('pointercancel', this._longPress.clear, true);
       this._longPress = null;
     }
     this.area.destroy();

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -176,6 +176,57 @@ export class NodeEditorView {
       });
     };
     this.container.addEventListener('contextmenu', this._contextMenuHandler);
+    this._setupLongPress();
+  }
+
+  // Touch devices have no right-click, so a long-press opens the same context
+  // menu. Cancels if the finger moves (a drag/pan) or lifts before the delay.
+  _setupLongPress() {
+    const LONG_PRESS_MS = 500;
+    const MOVE_CANCEL_PX = 12;
+    let timer = null;
+    let startX = 0;
+    let startY = 0;
+    let startTarget = null;
+
+    const clear = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const onPointerDown = (event) => {
+      if (event.pointerType !== 'touch') return;
+      startX = event.clientX;
+      startY = event.clientY;
+      startTarget = event.target;
+      clear();
+      timer = setTimeout(() => {
+        timer = null;
+        const nodeId = this._findNodeIdFromEventTarget(startTarget);
+        this.onContextMenu({
+          clientX: startX,
+          clientY: startY,
+          graphPosition: this.clientPointToGraph(startX, startY),
+          nodeId
+        });
+      }, LONG_PRESS_MS);
+    };
+
+    const onPointerMove = (event) => {
+      if (!timer) return;
+      if (Math.abs(event.clientX - startX) > MOVE_CANCEL_PX ||
+          Math.abs(event.clientY - startY) > MOVE_CANCEL_PX) {
+        clear();
+      }
+    };
+
+    this._longPress = { onPointerDown, onPointerMove, clear };
+    this.container.addEventListener('pointerdown', onPointerDown);
+    this.container.addEventListener('pointermove', onPointerMove);
+    this.container.addEventListener('pointerup', clear);
+    this.container.addEventListener('pointercancel', clear);
   }
 
   _findNodeIdFromEventTarget(target) {
@@ -528,6 +579,14 @@ export class NodeEditorView {
     if (this._contextMenuHandler) {
       this.container.removeEventListener('contextmenu', this._contextMenuHandler);
       this._contextMenuHandler = null;
+    }
+    if (this._longPress) {
+      this._longPress.clear();
+      this.container.removeEventListener('pointerdown', this._longPress.onPointerDown);
+      this.container.removeEventListener('pointermove', this._longPress.onPointerMove);
+      this.container.removeEventListener('pointerup', this._longPress.clear);
+      this.container.removeEventListener('pointercancel', this._longPress.clear);
+      this._longPress = null;
     }
     this.area.destroy();
     this.container.innerHTML = '';

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -224,6 +224,11 @@ body.panels-hidden .editor-panels {
   border: none;
   overflow: hidden;
   position: relative;
+  /* Suppress the native touch callout / text selection so a long-press opens
+     the node context menu instead of the browser selection UI. */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 /* Rete.js v2 dark theme overrides */
@@ -270,6 +275,9 @@ body.panels-hidden .editor-panels {
   border: 1px solid var(--border-color) !important;
   border-radius: 3px !important;
   padding: 2px 4px !important;
+  /* Re-enable selection/editing inside node param fields. */
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 /* Graph/Errors panel */


### PR DESCRIPTION
## 概要

スマホ等のタッチ端末には**右クリックが無い**ため、ノードの右クリックメニュー（Inspect / Delete、空きキャンバスでの Add Node）がキャンバスから開けませんでした。モバイル標準の **long-press（長押し）** で同じコンテキストメニューを開けるようにします。

## 変更内容

- **`editor-studio/src/node-editor-view.js`**: `_setupLongPress()` を追加。タッチの `pointerdown` で 500ms タイマーを開始し、指が動かなければ既存の `onContextMenu`（`_findNodeIdFromEventTarget` / `clientPointToGraph` を再利用＝右クリックと同一ロジック）を発火。指の移動（>12px = ドラッグ/パン/ピンチ）・`pointerup`・`pointercancel` でキャンセル。`pointerType === 'touch'` に限定するのでマウス/ペンは従来どおり右クリック。`destroy()` でリスナ解除。
- **`editor-studio/src/style.css`**: キャンバスの**ネイティブ長押しコールアウト/選択を抑制**（`-webkit-touch-callout/user-select: none`）。ノードのパラメータ入力はテキスト選択を維持。メニューは `document.body` 直下なので影響なし。

## 振る舞い

- ノード上で長押し → Inspect / Delete メニュー（既存の削除は前回追加したアプリ内確認モーダルに繋がる）。
- 空きキャンバスで長押し → Add Node メニュー。
- ノードのドラッグ・キャンバスのパン・ピンチズームは指が動くため長押しはキャンセル（共存）。
- マウス/ペンは従来の右クリックのまま。

## テスト

- フル `npm test`（editor-studio ビルド含む）EXIT=0・失敗 0。root 変更なし。
- 実機/エミュレータの体感はローカル `npm run dev` でご確認ください（ヘッドレスはビルド検証まで）。

## 補足

代替として「ノードをタップ選択 → Inspector タブの Delete ボタン」も従来から可能ですが、long-press の方が直接的で発見しやすいです。長押し時間（500ms）や移動しきい値（12px）は調整可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_