### PR TITLE
Add Copy buttons to the Scene Sync panel for the paste-onto-object flow

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -183,7 +183,9 @@
 
               <div class="scene-sync-actions">
                 <button id="compileSceneSyncPayloadBtn" type="button" class="btn">Compile Payload</button>
-                <button id="applySceneSyncBehaviorBtn" type="button" class="btn btn-primary">Apply Behavior</button>
+                <button id="copySceneSyncPayloadBtn" type="button" class="btn btn-primary" title="Copy the scene-graph-set message JSON, ready to paste onto a Scene Sync object">Copy Payload</button>
+                <button id="copySceneSyncGraphBtn" type="button" class="btn" title="Copy only the behavior graph (nodes/edges) JSON">Copy Graph JSON</button>
+                <button id="applySceneSyncBehaviorBtn" type="button" class="btn">Apply Behavior</button>
                 <button id="clearSceneSyncBehaviorBtn" type="button" class="btn btn-danger">Clear Behavior</button>
               </div>
 
@@ -193,8 +195,10 @@
               </div>
 
               <p class="scene-sync-note">
-                Prototype: this panel sends Scene Sync Behavior Graph payloads by REST broadcast.
-                It does not integrate with Scene Sync undo/redo or object selection yet.
+                Recommended flow: build your motion graph, confirm it in the preview, then
+                <strong>Copy Payload</strong> and paste it onto your Scene Sync object.
+                <strong>Apply Behavior</strong> instead broadcasts the same payload by REST.
+                This panel does not integrate with Scene Sync undo/redo or object selection yet.
               </p>
 
               <p class="scene-sync-note">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -198,6 +198,8 @@ const elements = {
   sceneSyncObjectId: document.getElementById('sceneSyncObjectId'),
   sceneSyncNickname: document.getElementById('sceneSyncNickname'),
   compileSceneSyncPayloadBtn: document.getElementById('compileSceneSyncPayloadBtn'),
+  copySceneSyncPayloadBtn: document.getElementById('copySceneSyncPayloadBtn'),
+  copySceneSyncGraphBtn: document.getElementById('copySceneSyncGraphBtn'),
   applySceneSyncBehaviorBtn: document.getElementById('applySceneSyncBehaviorBtn'),
   clearSceneSyncBehaviorBtn: document.getElementById('clearSceneSyncBehaviorBtn'),
   sceneSyncPayloadPreview: document.getElementById('sceneSyncPayloadPreview'),
@@ -1511,6 +1513,71 @@ async function handleCompileSceneSyncPayload() {
     appendOutput({
       level: 'error',
       message: `Scene Sync compile failed: ${error.message}`
+    });
+  }
+}
+
+async function copyTextToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  // Fallback for non-secure contexts where the async clipboard API is absent.
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    const ok = document.execCommand('copy');
+    if (!ok) {
+      throw new Error('Clipboard copy was rejected by the browser.');
+    }
+  } finally {
+    textarea.remove();
+  }
+}
+
+async function handleCopySceneSyncPayload() {
+  try {
+    saveSceneSyncSettings();
+
+    const payload = compileCurrentSceneSyncPayload();
+    renderSceneSyncPayloadPreview(payload);
+
+    await copyTextToClipboard(JSON.stringify(payload, null, 2));
+
+    appendOutput({
+      level: 'info',
+      message: 'Copied Scene Sync payload (scene-graph-set) to clipboard. Paste it onto your Scene Sync object.'
+    });
+  } catch (error) {
+    appendOutput({
+      level: 'error',
+      message: `Copy Scene Sync payload failed: ${error.message}`
+    });
+  }
+}
+
+async function handleCopySceneSyncGraphJson() {
+  try {
+    saveSceneSyncSettings();
+
+    const payload = compileCurrentSceneSyncPayload();
+    renderSceneSyncPayloadPreview(payload);
+
+    await copyTextToClipboard(JSON.stringify(payload.graph, null, 2));
+
+    appendOutput({
+      level: 'info',
+      message: 'Copied Scene Sync behavior graph (nodes/edges) to clipboard.'
+    });
+  } catch (error) {
+    appendOutput({
+      level: 'error',
+      message: `Copy Scene Sync graph failed: ${error.message}`
     });
   }
 }
@@ -3001,6 +3068,8 @@ function setupEventListeners() {
   });
 
   elements.compileSceneSyncPayloadBtn?.addEventListener('click', handleCompileSceneSyncPayload);
+  elements.copySceneSyncPayloadBtn?.addEventListener('click', handleCopySceneSyncPayload);
+  elements.copySceneSyncGraphBtn?.addEventListener('click', handleCopySceneSyncGraphJson);
   elements.applySceneSyncBehaviorBtn?.addEventListener('click', handleApplySceneSyncBehavior);
   elements.clearSceneSyncBehaviorBtn?.addEventListener('click', handleClearSceneSyncBehavior);
 


### PR DESCRIPTION
## Why

The desired authoring flow is: **build a motion graph in the Web Editor → confirm the motion in the preview → paste the result onto a Scene Sync object**. The Scene Sync panel previously only had **Compile Payload** (preview) and **Apply Behavior** (REST broadcast) — there was no way to get the payload out for pasting, so users had to manually select the preview JSON.

## What

Adds two one-click copy actions to the Scene Sync panel, both reusing the existing compile path (`compileCurrentSceneSyncPayload`):

- **Copy Payload** — the full `scene-graph-set` message (`{ type, scope, graph }`), i.e. exactly what Unity's `LoomSceneSyncBehaviour.HandleJsonMessage` consumes and what the preview pane shows. Made the primary action.
- **Copy Graph JSON** — just the behavior graph (`{ nodes, edges }`), for paste targets that want the graph alone. Having both removes the ambiguity about which form the SceneSync object's paste field expects.

Clipboard write uses `navigator.clipboard.writeText` with a `textarea` + `execCommand('copy')` fallback for non-secure contexts. **Apply Behavior** is demoted from primary styling since copy/paste is now the recommended path, and the panel note documents the flow.

## Scope / verification

- Touches only `editor-studio/` (`index.html`, `src/main.js`).
- `npm test` green (84/84 unit + editor-studio Vite build).
- UI is build-verified (no headless visual test harness for editor-studio).

## Follow-up (not in this PR)

Confirming the motion currently still relies on a hand-written `render point` (as the Jump/Circle presets do). Auto-visualizing `scene.offsetPosition`/`setPosition` motion in the preview without a separate render statement is a larger, separate increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mjfpGsCFJjR18qctZdHqH)_