### PR TITLE
Add math operator syntax (infix +, -, *, /, %) with Formula node

### DIFF
--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -27,6 +27,7 @@ const TT = {
   ASSIGN: 'ASSIGN', COLON: 'COLON', COMMA: 'COMMA', DOT: 'DOT',
   LPAREN: 'LPAREN', RPAREN: 'RPAREN', LBRACKET: 'LBRACKET', RBRACKET: 'RBRACKET',
   LBRACE: 'LBRACE', RBRACE: 'RBRACE', PIPE: 'PIPE', ARROW: 'ARROW', COMMENT: 'COMMENT', NEWLINE: 'NEWLINE', EOF: 'EOF',
+  PLUS: 'PLUS', MINUS: 'MINUS', STAR: 'STAR', SLASH: 'SLASH', PERCENT: 'PERCENT',
 };
 
 const posFrom = (line, column, offset) => ({ line, column, offset });
@@ -65,7 +66,7 @@ function tokenize(src) {
       tok(TT.COMMENT, text, sLine, sCol, sOff);
       continue;
     }
-    if (/\d/.test(ch) || (ch === '-' && /\d/.test(src[i + 1]))) {
+    if (/\d/.test(ch)) {
       let raw = '';
       raw += adv();
       while (i < src.length && /[\d.]/.test(cur())) raw += adv();
@@ -93,7 +94,7 @@ function tokenize(src) {
       tok(TT.IDENT, id, sLine, sCol, sOff);
       continue;
     }
-    const map = { '=': TT.ASSIGN, ':': TT.COLON, ',': TT.COMMA, '.': TT.DOT, '(': TT.LPAREN, ')': TT.RPAREN, '[': TT.LBRACKET, ']': TT.RBRACKET, '{': TT.LBRACE, '}': TT.RBRACE };
+    const map = { '=': TT.ASSIGN, ':': TT.COLON, ',': TT.COMMA, '.': TT.DOT, '(': TT.LPAREN, ')': TT.RPAREN, '[': TT.LBRACKET, ']': TT.RBRACKET, '{': TT.LBRACE, '}': TT.RBRACE, '+': TT.PLUS, '-': TT.MINUS, '*': TT.STAR, '/': TT.SLASH, '%': TT.PERCENT };
     if (ch === '=' && src[i + 1] === '>') { adv(); adv(); tok(TT.ARROW, undefined, sLine, sCol, sOff); continue; }
     if (ch === '|') { adv(); if (cur() !== '>') throw new LoomDSLError("Expected '>' after '|'", sLine, sCol, 'UNEXPECTED_TOKEN'); adv(); tok(TT.PIPE, undefined, sLine, sCol, sOff); continue; }
     if (map[ch]) { adv(); tok(map[ch], undefined, sLine, sCol, sOff); continue; }
@@ -176,7 +177,37 @@ export function parseDSLToAST(source) {
       }
       return { type: 'FunctionDefinition', name: mkIdent(name), params, body, span: spanFrom(start.span.start, end) };
     }
-    function parsePipe() { let left = parseAtom(); while (true) { if (peek().type === TT.PIPE || (peek().type === TT.NEWLINE && peek(1).type === TT.PIPE)) { if (peek().type === TT.NEWLINE) take(); const pt = take(); const right = parseCall(); left = { type: 'PipeExpression', left, right, span: spanFrom(left.span.start, right.span.end) }; } else break; } return left; }
+    function parsePipe() { let left = parseAdditive(); while (true) { if (peek().type === TT.PIPE || (peek().type === TT.NEWLINE && peek(1).type === TT.PIPE)) { if (peek().type === TT.NEWLINE) take(); const pt = take(); const right = parseCall(); left = { type: 'PipeExpression', left, right, span: spanFrom(left.span.start, right.span.end) }; } else break; } return left; }
+    function parseAdditive() {
+      let left = parseMultiplicative();
+      while (peek().type === TT.PLUS || peek().type === TT.MINUS) {
+        const op = take();
+        const right = parseMultiplicative();
+        left = { type: 'BinaryExpression', operator: op.type === TT.PLUS ? '+' : '-', left, right, span: spanFrom(left.span.start, right.span.end) };
+      }
+      return left;
+    }
+    function parseMultiplicative() {
+      let left = parseUnary();
+      while (peek().type === TT.STAR || peek().type === TT.SLASH || peek().type === TT.PERCENT) {
+        const op = take();
+        const opChar = op.type === TT.STAR ? '*' : op.type === TT.SLASH ? '/' : '%';
+        const right = parseUnary();
+        left = { type: 'BinaryExpression', operator: opChar, left, right, span: spanFrom(left.span.start, right.span.end) };
+      }
+      return left;
+    }
+    function parseUnary() {
+      if (peek().type === TT.MINUS) {
+        const op = take();
+        const operand = parseUnary();
+        if (operand.type === 'NumberLiteral') {
+          return { type: 'NumberLiteral', value: -operand.value, raw: `-${operand.raw}`, span: spanFrom(op.span.start, operand.span.end) };
+        }
+        return { type: 'UnaryExpression', operator: '-', operand, span: spanFrom(op.span.start, operand.span.end) };
+      }
+      return parseAtom();
+    }
     function isCallStart() {
       if (peek().type !== TT.IDENT) return false;
       let lookahead = 1;
@@ -205,6 +236,12 @@ export function parseDSLToAST(source) {
       if (t.type === TT.NULL) { take(); return { type: 'NullLiteral', span: t.span }; }
       if (t.type === TT.LBRACKET) return parseMemberPostfix(parseArray());
       if (t.type === TT.LBRACE) return parseMemberPostfix(parseObject());
+      if (t.type === TT.LPAREN) {
+        take();
+        const expr = parseExpr();
+        expect(TT.RPAREN);
+        return expr;
+      }
       if (t.type === TT.IDENT) {
         if (isCallStart()) return parseMemberPostfix(parseCall());
         take();
@@ -331,6 +368,11 @@ export function compileToGraph(ast, options = {}) { /* bridge via existing shape
 
 function astToLegacy(program) {
   function convExpr(e) {
+    if (e.type === 'BinaryExpression') {
+      const opToNode = { '+': 'math.add', '-': 'math.subtract', '*': 'math.multiply', '/': 'math.divide', '%': 'math.mod' };
+      return { type: 'call', name: opToNode[e.operator], args: [{ named: false, value: convExpr(e.left) }, { named: false, value: convExpr(e.right) }], line: e.span.start.line, col: e.span.start.column };
+    }
+    if (e.type === 'UnaryExpression' && e.operator === '-') return { type: 'call', name: 'negate', args: [{ named: false, value: convExpr(e.operand) }], line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'CallExpression') return { type: 'call', name: e.callee.name, args: e.args.map(a => a.type === 'NamedArg' ? { named: true, name: a.name.name, value: convExpr(a.value) } : { named: false, value: convExpr(a.value) }), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'FunctionLiteral') return { type: 'fn', params: e.params.map((p) => p.name), body: convExpr(e.body), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'PipeExpression') return { type: 'pipe', left: convExpr(e.left), call: convExpr(e.right) };
@@ -348,7 +390,7 @@ function astToLegacy(program) {
     if (node.type === 'NumberLiteral' || node.type === 'StringLiteral' || node.type === 'BooleanLiteral') return node.value;
     if (node.type === 'NullLiteral') return null;
     if (node.type === 'ArrayLiteral') return node.elements.map((e) => {
-      if (['Identifier', 'CallExpression', 'PipeExpression'].includes(e.type)) throw new LoomDSLError('Nested non-literal in array is not supported', e.span.start.line, e.span.start.column, 'UNEXPECTED_TOKEN');
+      if (['Identifier', 'CallExpression', 'PipeExpression', 'BinaryExpression', 'UnaryExpression'].includes(e.type)) throw new LoomDSLError('Nested non-literal in array is not supported', e.span.start.line, e.span.start.column, 'UNEXPECTED_TOKEN');
       return convJsonLiteral(e, line, col);
     });
     if (node.type === 'ObjectLiteral') {
@@ -589,7 +631,22 @@ export function formatDSL(ast, options = {}) {
   const maxInlineParams = options.maxInlineParams ?? 2;
   const maxWidth = options.maxLineWidth ?? 80;
 
+  function opPrec(op) { return (op === '*' || op === '/' || op === '%') ? 2 : 1; }
+  function fmtBinaryChild(child, parentOp, side, level) {
+    const s = fmtExpr(child, level);
+    if (child.type === 'PipeExpression') return `(${s})`;
+    if (child.type !== 'BinaryExpression') return s;
+    const cp = opPrec(child.operator), pp = opPrec(parentOp);
+    if (cp < pp) return `(${s})`;
+    if (cp === pp && side === 'right' && (parentOp === '-' || parentOp === '/' || parentOp === '%')) return `(${s})`;
+    return s;
+  }
   function fmtExpr(e, level = 0) {
+    if (e.type === 'BinaryExpression') return `${fmtBinaryChild(e.left, e.operator, 'left', level)} ${e.operator} ${fmtBinaryChild(e.right, e.operator, 'right', level)}`;
+    if (e.type === 'UnaryExpression' && e.operator === '-') {
+      const s = fmtExpr(e.operand, level);
+      return (e.operand.type === 'BinaryExpression' || e.operand.type === 'PipeExpression') ? `-(${s})` : `-${s}`;
+    }
     if (e.type === 'PipeExpression') {
       const chain = [];
       let cur = e;

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -368,11 +368,9 @@ export function compileToGraph(ast, options = {}) { /* bridge via existing shape
 
 function astToLegacy(program) {
   function convExpr(e) {
-    if (e.type === 'BinaryExpression') {
-      const opToNode = { '+': 'math.add', '-': 'math.subtract', '*': 'math.multiply', '/': 'math.divide', '%': 'math.mod' };
-      return { type: 'call', name: opToNode[e.operator], args: [{ named: false, value: convExpr(e.left) }, { named: false, value: convExpr(e.right) }], line: e.span.start.line, col: e.span.start.column };
+    if (e.type === 'BinaryExpression' || (e.type === 'UnaryExpression' && e.operator === '-')) {
+      return buildFormulaExpr(e);
     }
-    if (e.type === 'UnaryExpression' && e.operator === '-') return { type: 'call', name: 'negate', args: [{ named: false, value: convExpr(e.operand) }], line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'CallExpression') return { type: 'call', name: e.callee.name, args: e.args.map(a => a.type === 'NamedArg' ? { named: true, name: a.name.name, value: convExpr(a.value) } : { named: false, value: convExpr(a.value) }), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'FunctionLiteral') return { type: 'fn', params: e.params.map((p) => p.name), body: convExpr(e.body), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'PipeExpression') return { type: 'pipe', left: convExpr(e.left), call: convExpr(e.right) };
@@ -385,6 +383,24 @@ function astToLegacy(program) {
     if (e.type === 'ArrayLiteral') return { type: 'array', value: convJsonLiteral(e, e.span.start.line, e.span.start.column), line: e.span.start.line, col: e.span.start.column };
     if (e.type === 'ObjectLiteral') return { type: 'object', value: convJsonLiteral(e, e.span.start.line, e.span.start.column), line: e.span.start.line, col: e.span.start.column };
     throw new LoomDSLError('Unsupported expression in compileToGraph', e.span.start.line, e.span.start.column, 'UNEXPECTED_TOKEN');
+  }
+  function buildFormulaExpr(root) {
+    const vars = {};
+    let vc = 0;
+    function walk(node) {
+      if (node.type === 'BinaryExpression') return `(${walk(node.left)} ${node.operator} ${walk(node.right)})`;
+      if (node.type === 'UnaryExpression' && node.operator === '-') return `(-${walk(node.operand)})`;
+      if (node.type === 'NumberLiteral') return String(node.value);
+      if (node.type === 'Identifier') {
+        if (!vars[node.name]) vars[node.name] = convExpr(node);
+        return node.name;
+      }
+      const name = `_v${vc++}`;
+      vars[name] = convExpr(node);
+      return name;
+    }
+    const formula = walk(root);
+    return { type: 'formula', formula, vars, line: root.span.start.line, col: root.span.start.column };
   }
   function convJsonLiteral(node, line, col) {
     if (node.type === 'NumberLiteral' || node.type === 'StringLiteral' || node.type === 'BooleanLiteral') return node.value;
@@ -505,6 +521,10 @@ function buildGraph(stmts, options = {}) { /* mostly original */
       validateFunctionExpr(expr.call, fn, seenCalls);
       return;
     }
+    if (expr.type === 'formula') {
+      for (const varExpr of Object.values(expr.vars)) validateFunctionExpr(varExpr, fn, seenCalls);
+      return;
+    }
   }
   if (isTopLevel) for (const fn of functionDefs.values()) validateFunctionExpr(fn.body, fn, new Set([fn.name]));
   function buildFunctionLiteral(fn, resultId) {
@@ -600,7 +620,7 @@ function buildGraph(stmts, options = {}) { /* mostly original */
     else if (expr.type === 'ref') edges.push({ from: expr.ref, to: `${id}.${port}` });
     else if (expr.type === 'ident' && locals?.has(expr.name)) wireToNode(locals.get(expr.name), id, port, locals);
     else if (expr.type === 'ident') edges.push({ from: resolveIdent(expr.name, expr.line, expr.col, locals), to: `${id}.${port}` });
-    else if (expr.type === 'call' || expr.type === 'pipe' || expr.type === 'fn' || expr.type === 'member') { const inId = buildExpr(expr, null, null, locals); const inNode = nodes.find(n => n.id === inId); edges.push({ from: `${inId}.${defaultOutputPort(inNode.type, nodeTypes)}`, to: `${id}.${port}` }); }
+    else if (expr.type === 'call' || expr.type === 'pipe' || expr.type === 'fn' || expr.type === 'member' || expr.type === 'formula') { const inId = buildExpr(expr, null, null, locals); const inNode = nodes.find(n => n.id === inId); edges.push({ from: `${inId}.${defaultOutputPort(inNode.type, nodeTypes)}`, to: `${id}.${port}` }); }
     else { const nodeObj = nodes.find(n => n.id === id); nodeObj.params ||= {}; nodeObj.params[port] = expr.value; }
   }
   function buildNode(call, resultId, pipeFrom, locals = null) { const fnName = call.name; if (functionDefs.has(fnName)) return buildFunctionDefinitionCall(call, resultId, pipeFrom, locals); if (!nodeTypes[fnName]) { if (scope[fnName]) return buildUserCall(call, resultId); if (hasFunctionDefinitions && !fnName.includes('.')) throw new LoomDSLError(`Unknown function: ${fnName}`, call.line, call.col, 'UNKNOWN_FUNCTION'); throw new LoomDSLError(`Unknown node type: ${fnName}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); } const typeDef = nodeTypes[fnName]; const id = resultId || anonId(); const nodeObj = { id, type: fnName }; nodes.push(nodeObj); const inputNames = typeDef.inputs.map(i => i.name); const paramNames = (typeDef.params || []).map(p => p.name); const pos = call.args.filter(a => !a.named); const named = call.args.filter(a => a.named); const hasUnknownNamed = named.some(a => !inputNames.includes(a.name) && !paramNames.includes(a.name)); if (typeDef.commutative && pos.length && named.length && !hasUnknownNamed) throw new LoomDSLError(`Node '${fnName}' is commutative: arguments must be all positional or all named`, call.line, call.col, 'MISSING_ARGUMENT_NAME'); if (!canUseTwoPositionalArgs(fnName, typeDef) && pos.length > (pipeFrom ? 0 : 1)) throw new LoomDSLError(`Argument at position 2 for '${fnName}' requires a name`, call.line, call.col, 'MISSING_ARGUMENT_NAME'); let idx = 0;
@@ -609,7 +629,13 @@ function buildGraph(stmts, options = {}) { /* mostly original */
     for (const a of pos) wire(a.value, inputNames[idx++]);
     for (const a of named) { if (inputNames.includes(a.name)) wire(a.value, a.name); else if (paramNames.includes(a.name)) { if (a.value.type === 'ident' || a.value.type === 'call' || a.value.type === 'fn' || a.value.type === 'member') throw new LoomDSLError(`Parameter '${a.name}' for '${fnName}' must be a literal`, call.line, call.col, 'UNEXPECTED_TOKEN'); nodeObj.params ||= {}; nodeObj.params[a.name] = a.value.value; } else throw new LoomDSLError(`Unknown argument '${a.name}' for '${fnName}'`, call.line, call.col, 'UNKNOWN_ARGUMENT'); }
     return id; };
-  const buildExpr = (expr, resultId, pipeFrom, locals = null) => expr.type === 'binding' ? buildExpr(expr.expr, resultId, null, expr.locals) : expr.type === 'call' ? buildNode(expr, resultId, pipeFrom, locals) : expr.type === 'fn' ? buildFunctionLiteral(expr, resultId) : ['number', 'string', 'bool', 'null', 'array', 'object'].includes(expr.type) ? buildLiteral(expr, resultId) : expr.type === 'member' ? buildMember(expr, resultId) : expr.type === 'pipe' ? (() => { const lId = buildExpr(expr.left, null, null, locals); const ln = nodes.find(n => n.id === lId); return buildNode(expr.call, resultId, `${lId}.${defaultOutputPort(ln.type, nodeTypes)}`, locals); })() : expr.type === 'ref' ? expr.ref.split('.')[0] : expr.type === 'ident' ? (locals?.has(expr.name) ? buildExpr(locals.get(expr.name), resultId, null, locals) : scope[expr.name] || (()=>{throw new LoomDSLError(`Undefined identifier: ${expr.name}`, expr.line, expr.col, 'UNDEFINED_IDENTIFIER');})()) : (()=>{throw new LoomDSLError('Cannot use literal as expression', expr.line, expr.col, 'UNEXPECTED_TOKEN');})();
+  function buildFormula(expr, resultId, locals) {
+    const id = resultId || anonId();
+    nodes.push({ id, type: 'formula', params: { formula: expr.formula } });
+    for (const [varName, varExpr] of Object.entries(expr.vars)) wireToNode(varExpr, id, varName, locals);
+    return id;
+  }
+  const buildExpr = (expr, resultId, pipeFrom, locals = null) => expr.type === 'binding' ? buildExpr(expr.expr, resultId, null, expr.locals) : expr.type === 'formula' ? buildFormula(expr, resultId, locals) : expr.type === 'call' ? buildNode(expr, resultId, pipeFrom, locals) : expr.type === 'fn' ? buildFunctionLiteral(expr, resultId) : ['number', 'string', 'bool', 'null', 'array', 'object'].includes(expr.type) ? buildLiteral(expr, resultId) : expr.type === 'member' ? buildMember(expr, resultId) : expr.type === 'pipe' ? (() => { const lId = buildExpr(expr.left, null, null, locals); const ln = nodes.find(n => n.id === lId); return buildNode(expr.call, resultId, `${lId}.${defaultOutputPort(ln.type, nodeTypes)}`, locals); })() : expr.type === 'ref' ? expr.ref.split('.')[0] : expr.type === 'ident' ? (locals?.has(expr.name) ? buildExpr(locals.get(expr.name), resultId, null, locals) : scope[expr.name] || (()=>{throw new LoomDSLError(`Undefined identifier: ${expr.name}`, expr.line, expr.col, 'UNDEFINED_IDENTIFIER');})()) : (()=>{throw new LoomDSLError('Cannot use literal as expression', expr.line, expr.col, 'UNEXPECTED_TOKEN');})();
   const buildRender = (call) => { const named = {}; for (const a of call.args) { if (!a.named) throw new LoomDSLError('render arguments must be named', call.line, call.col, 'MISSING_ARGUMENT_NAME'); named[a.name] = a.value; } const rv = (e) => { if (e.type === 'ident') return resolveIdent(e.name, e.line, e.col); if (e.type === 'member' || e.type === 'call' || e.type === 'pipe') { const id = buildExpr(e, null, null); const node = nodes.find(n => n.id === id); return `${id}.${defaultOutputPort(node.type, nodeTypes)}`; } return e.value; }; if (call.name === 'point') return { type: 'point', x: named.x ? rv(named.x) : undefined, y: named.y ? rv(named.y) : undefined, color: named.color ? named.color.value : '#00ff00', trail: named.trail ? named.trail.value : 0.1 }; if (call.name === 'bar') return { type: 'bar', width: named.width ? rv(named.width) : undefined, color: named.color ? named.color.value : '#00ccff', height: named.height ? named.height.value : 40, y: named.y ? rv(named.y) : undefined }; throw new LoomDSLError(`Unknown render function: ${call.name}`, call.line, call.col, 'UNKNOWN_NODE_TYPE'); };
   for (const s of stmts) {
     if (s.type === 'render') renderConfig = buildRender(s.call);

--- a/src/loom.js
+++ b/src/loom.js
@@ -870,6 +870,26 @@ export class Loom {
 
       }
 
+      if (nodeType.dynamicInputs) {
+        const prefix = nodeId + '.';
+        for (const edge of this._currentGraph.edges) {
+          if (edge.to.startsWith(prefix)) {
+            const portName = edge.to.slice(prefix.length);
+            if (!(portName in inputs)) {
+              inputs[portName] = this._values.get(edge.from);
+            }
+          }
+        }
+        if (node.params) {
+          const declaredParams = new Set((nodeType.params || []).map(p => p.name));
+          for (const [key, value] of Object.entries(node.params)) {
+            if (!declaredParams.has(key) && !(key in inputs)) {
+              inputs[key] = value;
+            }
+          }
+        }
+      }
+
       // パラメータ値の解決
       const params = {};
       for (const paramDef of nodeType.params) {
@@ -1212,13 +1232,13 @@ export class Loom {
       const toNode = graph.nodes.find(n => n.id === toNodeId);
       const toNodeType = this._nodeTypes[toNode.type];
       const toPort = toNodeType.inputs.find(i => i.name === toPortName);
-      if (!toPort) {
+      if (!toPort && !toNodeType.dynamicInputs) {
         throw new LoomError('UNKNOWN_PORT', `Unknown port: ${toNodeId}.${toPortName}`, { nodeId: toNodeId, port: toPortName, side: 'input' });
       }
 
       // 6. 型チェック（Behavior/Event の混在禁止、ただし sample.value は例外）
       const fromKind = fromPort.kind;
-      const toKind = toPort.kind;
+      const toKind = toPort ? toPort.kind : 'behavior';
       const isSampleValueException = toNode.type === 'sample' && toPortName === 'value';
 
       if (fromKind !== toKind && !isSampleValueException) {

--- a/src/nodes/math.js
+++ b/src/nodes/math.js
@@ -1,5 +1,73 @@
 import { coerceFiniteNumber, resolveStateInputValue, sanitizeStateValue } from './helpers.js';
 
+export function evaluateFormula(formula, vars) {
+  let pos = 0;
+  const len = formula.length;
+  const skip = () => { while (pos < len && (formula[pos] === ' ' || formula[pos] === '\t')) pos++; };
+  const parseExpr = () => parseAdd();
+
+  function parseAdd() {
+    let left = parseMul();
+    while (pos < len) {
+      skip();
+      const ch = formula[pos];
+      if (ch === '+') { pos++; left = left + parseMul(); }
+      else if (ch === '-') { pos++; left = left - parseMul(); }
+      else break;
+    }
+    return left;
+  }
+
+  function parseMul() {
+    let left = parseUnary();
+    while (pos < len) {
+      skip();
+      const ch = formula[pos];
+      if (ch === '*') { pos++; left = left * parseUnary(); }
+      else if (ch === '/') { pos++; const r = parseUnary(); left = r === 0 ? 0 : left / r; }
+      else if (ch === '%') { pos++; const r = parseUnary(); left = r === 0 ? 0 : ((left % r) + r) % r; }
+      else break;
+    }
+    return left;
+  }
+
+  function parseUnary() {
+    skip();
+    if (formula[pos] === '-') { pos++; return -parseUnary(); }
+    return parsePrimary();
+  }
+
+  function parsePrimary() {
+    skip();
+    if (formula[pos] === '(') {
+      pos++;
+      const val = parseExpr();
+      skip();
+      if (formula[pos] === ')') pos++;
+      return val;
+    }
+    if (/\d/.test(formula[pos]) || (formula[pos] === '.' && pos + 1 < len && /\d/.test(formula[pos + 1]))) {
+      let num = '';
+      while (pos < len && /[\d.]/.test(formula[pos])) num += formula[pos++];
+      if (pos < len && /[eE]/.test(formula[pos])) {
+        num += formula[pos++];
+        if (pos < len && /[+-]/.test(formula[pos])) num += formula[pos++];
+        while (pos < len && /\d/.test(formula[pos])) num += formula[pos++];
+      }
+      return parseFloat(num);
+    }
+    if (/[a-zA-Z_]/.test(formula[pos])) {
+      let name = '';
+      while (pos < len && /[a-zA-Z0-9_]/.test(formula[pos])) name += formula[pos++];
+      const v = vars[name];
+      return typeof v === 'number' ? v : 0;
+    }
+    return 0;
+  }
+
+  return parseExpr();
+}
+
 export function registerMathNodes(registry) {
   registry.registerNodeType('abs', {
     category: 'transform',
@@ -310,5 +378,13 @@ export function registerMathNodes(registry) {
       { name: 'b', type: 'number', default: 0 }
     ],
     evaluate: (inputs, params, ctx) => ({ out: inputs.a - inputs.b })
+  });
+  registry.registerNodeType('formula', {
+    category: 'transform',
+    dynamicInputs: true,
+    inputs: [],
+    outputs: [{ name: 'out', type: 'number', kind: 'behavior' }],
+    params: [{ name: 'formula', type: 'string', default: '0' }],
+    evaluate: (inputs, params) => ({ out: evaluateFormula(params.formula, inputs) })
   });
 }

--- a/test/fixtures/stabilization/operator-math.loom
+++ b/test/fixtures/stabilization/operator-math.loom
@@ -1,0 +1,9 @@
+# Stabilization fixture: math operator syntax
+import math
+
+a = 1 + 2
+b = 10 - 3
+c = 4 * 5
+d = 20 / 4
+e = 7 % 3
+f = a + b * c

--- a/test/operator-syntax.test.mjs
+++ b/test/operator-syntax.test.mjs
@@ -21,10 +21,11 @@ function evalSrc(src, ref, env) {
   return evalRef(compile(src), ref, env);
 }
 
-test('x = y + z lowers to math.add', () => {
+test('x = y + z lowers to formula node', () => {
   const graph = compile('a = 1 + 2');
   const node = graph.nodes.find(n => n.id === 'a');
-  assert.equal(node.type, 'math.add');
+  assert.equal(node.type, 'formula');
+  assert.equal(node.params.formula, '(1 + 2)');
   assert.equal(evalRef(graph, 'a.out'), 3);
 });
 

--- a/test/operator-syntax.test.mjs
+++ b/test/operator-syntax.test.mjs
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDSLToAST, compileToGraph, formatDSL } from '../src/loom-dsl.js';
+import { Loom } from '../src/loom.js';
+
+function compile(src) {
+  const { ast, errors } = parseDSLToAST(src);
+  assert.equal(errors.length, 0, JSON.stringify(errors));
+  const { graph, errors: ce } = compileToGraph(ast);
+  assert.equal(ce.length, 0, JSON.stringify(ce));
+  return graph;
+}
+
+function evalRef(graph, ref, env = { time: 0 }) {
+  const engine = new Loom(graph);
+  engine.evaluateOnce({ env });
+  return engine.getValue(ref);
+}
+
+function evalSrc(src, ref, env) {
+  return evalRef(compile(src), ref, env);
+}
+
+test('x = y + z lowers to math.add', () => {
+  const graph = compile('a = 1 + 2');
+  const node = graph.nodes.find(n => n.id === 'a');
+  assert.equal(node.type, 'math.add');
+  assert.equal(evalRef(graph, 'a.out'), 3);
+});
+
+test('x = y - z lowers to math.subtract', () => {
+  assert.equal(evalSrc('a = 10 - 3', 'a.out'), 7);
+});
+
+test('x = y * z lowers to math.multiply', () => {
+  assert.equal(evalSrc('a = 4 * 5', 'a.out'), 20);
+});
+
+test('x = y / z lowers to math.divide', () => {
+  assert.equal(evalSrc('a = 20 / 4', 'a.out'), 5);
+});
+
+test('x = y % z lowers to math.mod', () => {
+  assert.equal(evalSrc('a = 7 % 3', 'a.out'), 1);
+});
+
+test('operator precedence: * before +', () => {
+  assert.equal(evalSrc('a = 1 + 2 * 3', 'a.out'), 7);
+});
+
+test('operator precedence: / before -', () => {
+  assert.equal(evalSrc('a = 10 - 6 / 2', 'a.out'), 7);
+});
+
+test('grouping with parentheses', () => {
+  assert.equal(evalSrc('a = (1 + 2) * 3', 'a.out'), 9);
+});
+
+test('unary minus on identifier', () => {
+  assert.equal(evalSrc('a = 5\nb = -a', 'b.out'), -5);
+});
+
+test('unary minus folds into number literal', () => {
+  const { ast } = parseDSLToAST('a = -3');
+  const value = ast.body[0].value;
+  assert.equal(value.type, 'NumberLiteral');
+  assert.equal(value.value, -3);
+});
+
+test('negative literal in named arg still works', () => {
+  assert.equal(evalSrc('a = math.add(a: -1, b: 2)', 'a.out'), 1);
+});
+
+test('operators with identifiers', () => {
+  assert.equal(evalSrc('a = 10\nb = 3\nc = a + b', 'c.out'), 13);
+});
+
+test('chained addition', () => {
+  assert.equal(evalSrc('a = 1 + 2 + 3', 'a.out'), 6);
+});
+
+test('mixed operators and function calls', () => {
+  assert.equal(evalSrc('a = math.add(2, 3) + 1', 'a.out'), 6);
+});
+
+test('operator in function body', () => {
+  assert.equal(evalSrc('fn double(x) => x + x\na = double(5)', 'a.out'), 10);
+});
+
+test('operator in pipe input', () => {
+  assert.equal(evalSrc('a = 1 + 2 |> math.multiply(b: 3)', 'a.out'), 9);
+});
+
+test('formatDSL preserves operator syntax', () => {
+  const { ast } = parseDSLToAST('a = 1 + 2\n');
+  const out = formatDSL(ast);
+  assert.match(out, /a = 1 \+ 2/);
+});
+
+test('formatDSL preserves precedence via parens', () => {
+  const { ast } = parseDSLToAST('a = (1 + 2) * 3\n');
+  const out = formatDSL(ast);
+  assert.match(out, /\(1 \+ 2\) \* 3/);
+});
+
+test('formatDSL omits unnecessary parens', () => {
+  const { ast } = parseDSLToAST('a = 1 + 2 * 3\n');
+  const out = formatDSL(ast);
+  assert.match(out, /a = 1 \+ 2 \* 3/);
+});
+
+test('operator fixture compiles and evaluates', () => {
+  const graph = compile(
+    'import math\na = 1 + 2\nb = 10 - 3\nc = 4 * 5\nd = 20 / 4\ne = 7 % 3\nf = a + b * c'
+  );
+  assert.equal(evalRef(graph, 'a.out'), 3);
+  assert.equal(evalRef(graph, 'b.out'), 7);
+  assert.equal(evalRef(graph, 'c.out'), 20);
+  assert.equal(evalRef(graph, 'd.out'), 5);
+  assert.equal(evalRef(graph, 'e.out'), 1);
+  assert.equal(evalRef(graph, 'f.out'), 143);
+});


### PR DESCRIPTION
## Summary

- DSLパーサーに中置演算子構文を追加し、`x = math.add(y, z)` の代わりに `x = y + z` と記述可能に
- 演算子式をUnity Visual ScriptingのFormulaノードのように単一の `formula` ノードに変換（複数のmathノードに分解せず）
- `+`, `-`, `*`, `/`, `%` をサポートし、正しい演算子優先順位（乗除 > 加減）、括弧によるグルーピング、単項マイナスに対応
- `formatDSL` で演算子構文を正しく復元（不要な括弧を省略）

## Changes

- **src/loom-dsl.js**: トークナイザーに演算子トークンを追加、優先順位付き式パーサー（parseAdditive → parseMultiplicative → parseUnary）を実装、AST→グラフ変換でFormula式を生成、formatDSLで演算子構文をサポート
- **src/loom.js**: `dynamicInputs` フラグを持つノードタイプの動的入力解決とバリデーション緩和を追加
- **src/nodes/math.js**: `evaluateFormula()` 関数と `formula` ノードタイプを登録
- **test/operator-syntax.test.mjs**: 20件のテストケース（全演算子、優先順位、グルーピング、単項マイナス、識別子、パイプ、formatDSL等）
- **test/fixtures/stabilization/operator-math.loom**: 安定化テスト用フィクスチャ

## Test plan

- [x] 全20件の新規テストが通過
- [x] 既存テストスイート（約30ファイル）に影響なし（0 failures）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds38f5mEvjHnpndboAoMHY)_