### PR TITLE
Add inputs metadata to formula node for editor port display

### DIFF
--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -631,7 +631,8 @@ function buildGraph(stmts, options = {}) { /* mostly original */
     return id; };
   function buildFormula(expr, resultId, locals) {
     const id = resultId || anonId();
-    nodes.push({ id, type: 'formula', params: { formula: expr.formula } });
+    const inputsMeta = Object.keys(expr.vars).map(name => ({ name, type: 'number', kind: 'behavior' }));
+    nodes.push({ id, type: 'formula', params: { formula: expr.formula }, inputs: inputsMeta });
     for (const [varName, varExpr] of Object.entries(expr.vars)) wireToNode(varExpr, id, varName, locals);
     return id;
   }

--- a/test/operator-syntax.test.mjs
+++ b/test/operator-syntax.test.mjs
@@ -73,7 +73,13 @@ test('negative literal in named arg still works', () => {
 });
 
 test('operators with identifiers', () => {
-  assert.equal(evalSrc('a = 10\nb = 3\nc = a + b', 'c.out'), 13);
+  const graph = compile('a = 10\nb = 3\nc = a + b');
+  const node = graph.nodes.find(n => n.id === 'c');
+  assert.deepEqual(node.inputs, [
+    { name: 'a', type: 'number', kind: 'behavior' },
+    { name: 'b', type: 'number', kind: 'behavior' },
+  ]);
+  assert.equal(evalRef(graph, 'c.out'), 13);
 });
 
 test('chained addition', () => {


### PR DESCRIPTION
## Summary

- Formula ノードのコンパイル時に、式中の変数名から `inputs` メタデータ配列をノードインスタンスに付与
- これによりビジュアルエディタが動的入力ポートを描画可能に（`dynamicInputs: true` だけでは `inputs: []` のため表示されなかった）

## Changes

- **src/loom-dsl.js**: `buildFormula` で `expr.vars` のキーから `{ name, type: 'number', kind: 'behavior' }` の配列を生成し、ノードに追加
- **test/operator-syntax.test.mjs**: `inputs` メタデータの構造を `deepEqual` で検証するテストを追加

## Test plan

- [x] 全20件の operator-syntax テストが通過
- [x] 既存テストスイートに影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds38f5mEvjHnpndboAoMHY)_