### PR TITLE
Wire formula node dynamic inputs to editor port display

### DIFF
--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -45,7 +45,10 @@ function createReteNode(editorNode, onControl, previewText) {
   node._editorNode = editorNode;
 
   if (nodeTypeDef) {
-    for (const input of nodeTypeDef.inputs || []) {
+    const inputDefs = (nodeTypeDef.dynamicInputs && editorNode.inputPorts)
+      ? editorNode.inputPorts.map(name => ({ name }))
+      : (nodeTypeDef.inputs || []);
+    for (const input of inputDefs) {
       const name = getPortName(input);
       node.addInput(name, new ClassicPreset.Input(socket, name));
     }
@@ -54,8 +57,6 @@ function createReteNode(editorNode, onControl, previewText) {
       node.addOutput(name, new ClassicPreset.Output(socket, name));
     }
   } else if (editorNode.inputPorts || editorNode.outputPorts) {
-    // Unregistered types (e.g. subgraph.param / subgraph.call in the function
-    // drill-in subview) carry explicit port names derived from their edges.
     for (const name of editorNode.inputPorts || []) {
       node.addInput(name, new ClassicPreset.Input(socket, name));
     }

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -162,13 +162,17 @@ export function graphToEditorModel(graph) {
       ? { x: metaPosition.x, y: metaPosition.y }
       : null;
 
-    return {
+    const result = {
       id: node.id,
       type: node.type,
       category,
       params: { ...(node.params || {}) },
       position
     };
+    if (node.inputs && node.inputs.length > 0) {
+      result.inputPorts = node.inputs.map(i => i.name);
+    }
+    return result;
   });
 
   const positioned = layoutFallback(rawNodes);


### PR DESCRIPTION
## Summary

- `graphToEditorModel` でノードインスタンスの `inputs` メタデータを `inputPorts` としてエディタモデルに伝播
- `createReteNode` で `dynamicInputs` ノードの場合、インスタンスの `inputPorts` から入力ポートを描画するよう修正
- これにより formula ノード（`z = x + y`）にエディタ上で `x`, `y` の入力ポートが表示される

## Changes

- **src/loom-editor-model.js**: `node.inputs` 配列がある場合に `inputPorts` をエディタモデルノードに追加
- **editor-studio/src/node-editor-view.js**: `nodeTypeDef.dynamicInputs && editorNode.inputPorts` の条件で動的入力ポートを優先描画

## Test plan

- [x] operator-syntax テスト全20件通過
- [x] editor-model-subgraph テスト全3件通過
- [x] 既存テストスイートに影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds38f5mEvjHnpndboAoMHY)_