### PR TITLE
Extract input ports from formula param for editor-created nodes

### DIFF
--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -3,6 +3,7 @@ import { AreaPlugin, AreaExtensions } from 'rete-area-plugin';
 import { ConnectionPlugin, Presets as ConnectionPresets } from 'rete-connection-plugin';
 import { ReactPlugin, Presets } from 'rete-react-plugin';
 import { NODE_TYPES } from '../../src/loom.js';
+import { extractFormulaVars } from '../../src/nodes/math.js';
 import { formatValuePreview } from '../../src/value-preview.js';
 import {
   connectionToAddEdgeOp,
@@ -45,9 +46,14 @@ function createReteNode(editorNode, onControl, previewText) {
   node._editorNode = editorNode;
 
   if (nodeTypeDef) {
-    const inputDefs = (nodeTypeDef.dynamicInputs && editorNode.inputPorts)
-      ? editorNode.inputPorts.map(name => ({ name }))
-      : (nodeTypeDef.inputs || []);
+    let inputDefs;
+    if (nodeTypeDef.dynamicInputs) {
+      const ports = editorNode.inputPorts
+        || (editorNode.params?.formula ? extractFormulaVars(editorNode.params.formula) : []);
+      inputDefs = ports.map(name => ({ name }));
+    } else {
+      inputDefs = nodeTypeDef.inputs || [];
+    }
     for (const input of inputDefs) {
       const name = getPortName(input);
       node.addInput(name, new ClassicPreset.Input(socket, name));

--- a/src/nodes/math.js
+++ b/src/nodes/math.js
@@ -68,6 +68,14 @@ export function evaluateFormula(formula, vars) {
   return parseExpr();
 }
 
+export function extractFormulaVars(formula) {
+  const vars = new Set();
+  const re = /[a-zA-Z_][a-zA-Z0-9_]*/g;
+  let m;
+  while ((m = re.exec(formula)) !== null) vars.add(m[0]);
+  return [...vars];
+}
+
 export function registerMathNodes(registry) {
   registry.registerNodeType('abs', {
     category: 'transform',

--- a/test/operator-syntax.test.mjs
+++ b/test/operator-syntax.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parseDSLToAST, compileToGraph, formatDSL } from '../src/loom-dsl.js';
 import { Loom } from '../src/loom.js';
+import { extractFormulaVars } from '../src/nodes/math.js';
 
 function compile(src) {
   const { ast, errors } = parseDSLToAST(src);
@@ -126,4 +127,11 @@ test('operator fixture compiles and evaluates', () => {
   assert.equal(evalRef(graph, 'd.out'), 5);
   assert.equal(evalRef(graph, 'e.out'), 1);
   assert.equal(evalRef(graph, 'f.out'), 143);
+});
+
+test('extractFormulaVars extracts variable names from formula', () => {
+  assert.deepEqual(extractFormulaVars('(x + y)'), ['x', 'y']);
+  assert.deepEqual(extractFormulaVars('(a + (b * 10))'), ['a', 'b']);
+  assert.deepEqual(extractFormulaVars('(-x)'), ['x']);
+  assert.deepEqual(extractFormulaVars('42'), []);
 });


### PR DESCRIPTION
## Summary

- ノードエディタから直接追加した formula ノードで入力ポートが表示されない問題を修正
- formula パラメータの文字列から変数名を抽出し、入力ポートとして描画するフォールバックを追加
- formula パラメータ変更時もポートが自動更新される（既存の `_patchModel` のノード再作成による）

## Changes

- **src/nodes/math.js**: `extractFormulaVars()` を追加 — 正規表現で formula 文字列から変数名を抽出
- **editor-studio/src/node-editor-view.js**: `dynamicInputs` ノードで `inputPorts` がない場合に `extractFormulaVars` にフォールバック
- **test/operator-syntax.test.mjs**: `extractFormulaVars` のテストを追加

## Test plan

- [x] operator-syntax テスト全21件通過
- [x] 既存テストスイートに影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds38f5mEvjHnpndboAoMHY)_