### PR TITLE
Render constant/formula nodes as DSL literals and operators

### DIFF
--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -335,7 +335,7 @@ export class NodeEditorView {
         this.onOperation(op);
       }
       if (op.type === 'updateParam' && op.key === 'formula') {
-        this._rebuildFormulaNode(op.id, op.value);
+        this._scheduleFormulaRebuild(op.id, op.value);
       }
     }, this._getNodePreviewText(editorNode.id));
 
@@ -345,6 +345,16 @@ export class NodeEditorView {
     await this.area.translate(reteNode.id, { x: pos.x, y: pos.y });
 
     return reteNode;
+  }
+
+  _scheduleFormulaRebuild(nodeId, newFormula) {
+    if (!this._formulaRebuildTimers) this._formulaRebuildTimers = new Map();
+    const existing = this._formulaRebuildTimers.get(nodeId);
+    if (existing) clearTimeout(existing);
+    this._formulaRebuildTimers.set(nodeId, setTimeout(() => {
+      this._formulaRebuildTimers.delete(nodeId);
+      this._rebuildFormulaNode(nodeId, newFormula);
+    }, 400));
   }
 
   async _rebuildFormulaNode(nodeId, newFormula) {

--- a/src/canonical-dsl.js
+++ b/src/canonical-dsl.js
@@ -159,6 +159,28 @@ export function graphToCanonicalDSL(graph) {
       continue;
     }
 
+    if (node.type === 'constant') {
+      const val = node.params?.value;
+      lines.push(`${node.id} = ${formatValue(val)}`);
+      continue;
+    }
+
+    if (node.type === 'formula') {
+      const formula = node.params?.formula || '0';
+      const inputEdges = {};
+      for (const edge of graph.edges || []) {
+        if (edge.to.startsWith(node.id + '.')) {
+          const [, toPort] = edge.to.split('.');
+          const [fromNodeId] = edge.from.split('.');
+          inputEdges[toPort] = fromNodeId;
+        }
+      }
+      let rendered = renderFormulaDSL(formula, inputEdges);
+      if (rendered.startsWith('(') && rendered.endsWith(')')) rendered = rendered.slice(1, -1);
+      lines.push(`${node.id} = ${rendered}`);
+      continue;
+    }
+
     const nodeType = NODE_TYPES[node.type];
     if (!nodeType) continue;
 
@@ -222,6 +244,69 @@ export function graphToCanonicalDSL(graph) {
   }
 
   return lines.join('\n') + '\n';
+}
+
+function renderFormulaDSL(formula, inputEdges) {
+  let pos = 0;
+  const len = formula.length;
+  const skip = () => { while (pos < len && formula[pos] === ' ') pos++; };
+
+  function parseAdd() {
+    let left = parseMul();
+    while (pos < len) {
+      skip();
+      if (formula[pos] === '+') { pos++; left = `${left} + ${parseMul()}`; }
+      else if (formula[pos] === '-') { pos++; left = `${left} - ${parseMul()}`; }
+      else break;
+    }
+    return left;
+  }
+
+  function parseMul() {
+    let left = parseUnary();
+    while (pos < len) {
+      skip();
+      const ch = formula[pos];
+      if (ch === '*' || ch === '/' || ch === '%') { pos++; left = `${left} ${ch} ${parseUnary()}`; }
+      else break;
+    }
+    return left;
+  }
+
+  function parseUnary() {
+    skip();
+    if (formula[pos] === '-') { pos++; return `-${parsePrimary()}`; }
+    return parsePrimary();
+  }
+
+  function parsePrimary() {
+    skip();
+    if (formula[pos] === '(') {
+      pos++;
+      const inner = parseAdd();
+      skip();
+      if (formula[pos] === ')') pos++;
+      return `(${inner})`;
+    }
+    if (/\d/.test(formula[pos]) || (formula[pos] === '.' && pos + 1 < len && /\d/.test(formula[pos + 1]))) {
+      let num = '';
+      while (pos < len && /[\d.]/.test(formula[pos])) num += formula[pos++];
+      if (pos < len && /[eE]/.test(formula[pos])) {
+        num += formula[pos++];
+        if (pos < len && /[+-]/.test(formula[pos])) num += formula[pos++];
+        while (pos < len && /\d/.test(formula[pos])) num += formula[pos++];
+      }
+      return num;
+    }
+    if (/[a-zA-Z_]/.test(formula[pos])) {
+      let name = '';
+      while (pos < len && /[a-zA-Z0-9_]/.test(formula[pos])) name += formula[pos++];
+      return inputEdges[name] || name;
+    }
+    return '0';
+  }
+
+  return parseAdd();
 }
 
 function formatValue(val, options = {}) {

--- a/test/operator-syntax.test.mjs
+++ b/test/operator-syntax.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parseDSLToAST, compileToGraph, formatDSL } from '../src/loom-dsl.js';
+import { graphToCanonicalDSL } from '../src/canonical-dsl.js';
 import { Loom } from '../src/loom.js';
 import { extractFormulaVars } from '../src/nodes/math.js';
 
@@ -134,4 +135,27 @@ test('extractFormulaVars extracts variable names from formula', () => {
   assert.deepEqual(extractFormulaVars('(a + (b * 10))'), ['a', 'b']);
   assert.deepEqual(extractFormulaVars('(-x)'), ['x']);
   assert.deepEqual(extractFormulaVars('42'), []);
+});
+
+test('canonical DSL renders constant as literal', () => {
+  const graph = compile('x = 1');
+  const dsl = graphToCanonicalDSL(graph);
+  assert.match(dsl, /x = 1/);
+  assert.ok(!dsl.includes('constant'));
+});
+
+test('canonical DSL renders formula as operator syntax', () => {
+  const graph = compile('x = 1\ny = 2\nz = x + y');
+  const dsl = graphToCanonicalDSL(graph);
+  assert.match(dsl, /z = x \+ y/);
+  assert.ok(!dsl.includes('formula'));
+});
+
+test('canonical DSL round-trips operator expression', () => {
+  const src = 'a = 10\nb = 3\nc = a + b * 10';
+  const graph = compile(src);
+  const dsl = graphToCanonicalDSL(graph);
+  assert.match(dsl, /c = a \+ \(b \* 10\)/);
+  const graph2 = compile(dsl.trim());
+  assert.equal(evalRef(graph2, 'c.out'), 40);
 });


### PR DESCRIPTION
## Summary

- `graphToCanonicalDSL` で constant ノードをリテラル表記（`x = 1`）、formula ノードを演算子構文（`z = x + y`）で出力するよう改善
- Node Editor 側の変更が DSL に反映される際、`constant(value: 1)` や `formula(formula: "(x + y)")` ではなく読みやすい形式で出力される
- formula パラメータ変更時のポート再構築デバウンス（400ms）を追加

## Changes

- **src/canonical-dsl.js**: `constant` / `formula` ノードの特別処理と `renderFormulaDSL` 関数を追加
- **editor-studio/src/node-editor-view.js**: `_scheduleFormulaRebuild` でデバウンス処理を追加
- **test/operator-syntax.test.mjs**: canonical DSL のリテラル出力・演算子構文出力・ラウンドトリップテストを追加

## Test plan

- [x] operator-syntax テスト全24件通過
- [x] canonical-dsl-subgraphs / stabilization-fixtures テスト通過
- [x] 既存テストスイートに影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds38f5mEvjHnpndboAoMHY)_