### PR TITLE
Use explicit formula() syntax when vars don't match connected nodes

### DIFF
--- a/src/canonical-dsl.js
+++ b/src/canonical-dsl.js
@@ -1,4 +1,5 @@
 import { NODE_TYPES } from './loom.js';
+import { extractFormulaVars } from './nodes/math.js';
 
 function splitRef(ref) {
   const dot = ref.indexOf('.');
@@ -175,9 +176,20 @@ export function graphToCanonicalDSL(graph) {
           inputEdges[toPort] = fromNodeId;
         }
       }
-      let rendered = renderFormulaDSL(formula, inputEdges);
-      if (rendered.startsWith('(') && rendered.endsWith(')')) rendered = rendered.slice(1, -1);
-      lines.push(`${node.id} = ${rendered}`);
+      const vars = extractFormulaVars(formula);
+      const allConnected = vars.length > 0 && vars.every(v => inputEdges[v]);
+      const allMatch = allConnected && vars.every(v => inputEdges[v] === v);
+      if (allMatch) {
+        let rendered = renderFormulaDSL(formula, inputEdges);
+        if (rendered.startsWith('(') && rendered.endsWith(')')) rendered = rendered.slice(1, -1);
+        lines.push(`${node.id} = ${rendered}`);
+      } else {
+        const args = [formatParam('formula', formula)];
+        for (const v of vars) {
+          if (inputEdges[v]) args.push(formatInputRefParam(v, inputEdges[v]));
+        }
+        lines.push(`${node.id} = formula(${args.join(', ')})`);
+      }
       continue;
     }
 

--- a/test/operator-syntax.test.mjs
+++ b/test/operator-syntax.test.mjs
@@ -159,3 +159,34 @@ test('canonical DSL round-trips operator expression', () => {
   const graph2 = compile(dsl.trim());
   assert.equal(evalRef(graph2, 'c.out'), 40);
 });
+
+test('canonical DSL uses explicit syntax when formula vars differ from node IDs', () => {
+  const graph = {
+    nodes: [
+      { id: 'x', type: 'constant', params: { value: 1 } },
+      { id: 'y', type: 'constant', params: { value: 2 } },
+      { id: 'z', type: 'formula', params: { formula: '(a + b)' }, inputs: [{ name: 'a' }, { name: 'b' }] },
+    ],
+    edges: [
+      { from: 'x.out', to: 'z.a' },
+      { from: 'y.out', to: 'z.b' },
+    ],
+  };
+  const dsl = graphToCanonicalDSL(graph);
+  assert.match(dsl, /z = formula\(formula: "\(a \+ b\)", a: x, b: y\)/);
+});
+
+test('canonical DSL uses explicit syntax when formula has disconnected vars', () => {
+  const graph = {
+    nodes: [
+      { id: 'x', type: 'constant', params: { value: 1 } },
+      { id: 'z', type: 'formula', params: { formula: '(x + y)' }, inputs: [{ name: 'x' }, { name: 'y' }] },
+    ],
+    edges: [
+      { from: 'x.out', to: 'z.x' },
+    ],
+  };
+  const dsl = graphToCanonicalDSL(graph);
+  assert.match(dsl, /z = formula\(formula: "\(x \+ y\)", x: x\)/);
+  assert.ok(!dsl.match(/z = x \+ y/));
+});


### PR DESCRIPTION
## Summary

- canonical DSL で formula ノードの演算子構文を使う条件を厳格化
- 全変数が接続済みかつ変数名が接続先ノードIDと一致する場合のみ `z = x + y` を出力
- それ以外は `z = formula(formula: "(x + y)", x: x)` の明示的構文にフォールバック
- 未接続の変数が同名ノードと意図しない接続を生む問題を修正

## Changes

- **src/canonical-dsl.js**: `extractFormulaVars` で変数名を取得し、接続状態・名前一致を判定してフォーマットを分岐
- **test/operator-syntax.test.mjs**: 変数名不一致・未接続変数のテストケースを追加

## Test plan

- [x] operator-syntax テスト全26件通過
- [x] canonical-dsl-subgraphs / stabilization-fixtures テスト通過
- [x] 既存テストスイートに影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds38f5mEvjHnpndboAoMHY)_