### PR TITLE
[codex] Add docked interactive preview layout

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -10,6 +10,7 @@
   <canvas id="preview-canvas" class="preview-canvas"></canvas>
   <div id="scene3d-host" class="scene3d-host" hidden>
     <div class="scene3d-badge">3D Scene Preview · drag to orbit / scroll to zoom</div>
+    <div id="previewEventStatus" class="scene3d-click-status" aria-live="polite" hidden></div>
   </div>
 
   <div class="studio-overlay">
@@ -20,6 +21,10 @@
       <button id="saveAsFileBtn" class="btn">Save As</button>
       <span id="file-status" class="file-status">No file</span>
       <button id="runPreviewBtn" class="btn btn-success">Run Preview</button>
+      <div class="segmented-control preview-layout-switch" aria-label="Preview layout">
+        <button class="segmented-btn active" data-preview-layout="background" title="Use preview as the background">Background</button>
+        <button class="segmented-btn" data-preview-layout="docked" title="Dock preview beside the editor">Docked</button>
+      </div>
       <button id="resetSampleBtn" class="btn">Reset Sample</button>
       <button id="undo-btn" class="btn" title="Undo graph edit (Ctrl/Cmd+Z)" disabled>
         Undo
@@ -45,6 +50,19 @@
     </div>
 
     <div id="editor-panels" class="editor-panels">
+      <!-- Docked preview pane: active only in Preview Docked mode -->
+      <div class="panel preview-pane">
+        <div class="pane-header">
+          <h2>Preview</h2>
+        </div>
+        <div id="preview-stage" class="preview-stage"></div>
+      </div>
+
+      <div class="docked-editor-tabs" role="tablist" aria-label="Docked editor view">
+        <button class="docked-editor-tab active" data-docked-editor-tab="node" role="tab" aria-selected="true">Node Editor</button>
+        <button class="docked-editor-tab" data-docked-editor-tab="dsl" role="tab" aria-selected="false">DSL Editor</button>
+      </div>
+
       <!-- Left pane: DSL Editor -->
       <div class="panel dsl-pane">
         <div class="pane-header">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -84,8 +84,11 @@ render point(x: previewX, y: previewY, radius: 8, color: "#80ed99", trail: 0.08)
 const BOTTOM_PANEL_HEIGHT_KEY = 'loomlet.editorStudio.bottomPanelHeight';
 const BOTTOM_PANEL_COLLAPSED_KEY = 'loomlet.editorStudio.bottomPanelCollapsed';
 const EDITOR_SPLIT_WIDTH_KEY = 'loomlet.editorStudio.editorSplitWidth';
+const PREVIEW_PANE_WIDTH_KEY = 'loomlet.editorStudio.previewPaneWidth';
 const ACTIVE_BOTTOM_TAB_KEY = 'loomlet.editorStudio.activeBottomTab';
 const EDITOR_MAXIMIZE_MODE_KEY = 'loomlet.editorStudio.editorMaximizeMode';
+const PREVIEW_LAYOUT_MODE_KEY = 'loomlet.editorStudio.previewLayoutMode';
+const DOCKED_EDITOR_TAB_KEY = 'loomlet.editorStudio.dockedEditorTab';
 
 const SCENE_SYNC_STORAGE_KEYS = {
   endpoint: 'loomlet.editorStudio.sceneSync.endpoint',
@@ -110,6 +113,9 @@ const MAX_BOTTOM_PANEL_RATIO = 0.6;
 const DEFAULT_DSL_PANE_WIDTH = 520;
 const MIN_DSL_PANE_WIDTH = 280;
 const MIN_NODE_PANE_WIDTH = 320;
+const DEFAULT_PREVIEW_PANE_WIDTH = 520;
+const MIN_PREVIEW_PANE_WIDTH = 320;
+const MIN_DOCKED_EDITOR_WIDTH = 360;
 const EDITOR_SPLIT_HANDLE_WIDTH = 8;
 const EDITOR_SPLIT_GRID_GAP = 12;
 const EDITOR_SPLIT_GRID_GAP_COUNT = 2;
@@ -138,6 +144,7 @@ let bottomPanelHeight = DEFAULT_BOTTOM_PANEL_HEIGHT;
 let isBottomPanelCollapsed = false;
 let isResizingBottomPanel = false;
 let dslPaneWidth = DEFAULT_DSL_PANE_WIDTH;
+let previewPaneWidth = DEFAULT_PREVIEW_PANE_WIDTH;
 let isResizingEditorSplit = false;
 
 let undoStack = [];
@@ -148,13 +155,20 @@ let moveHistoryCoalesceTimer = null;
 let activeParamHistoryKey = null;
 let paramHistoryCoalesceTimer = null;
 let editorMaximizeMode = 'split';
+let previewLayoutMode = 'background';
+let dockedEditorTab = 'node';
 let lastNodeValuePreviewAtMs = 0;
+let previewEventQueue = [];
+let previewEventScopeId = '';
+let previewEventSequence = 0;
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
   nodeEditorHost: document.getElementById('node-editor'),
   previewCanvas: document.getElementById('preview-canvas'),
+  previewStage: document.getElementById('preview-stage'),
   scene3dHost: document.getElementById('scene3d-host'),
+  previewEventStatus: document.getElementById('previewEventStatus'),
   graphJson: document.getElementById('graph-json'),
   errorsList: document.getElementById('errors-list'),
   compatPanel: document.getElementById('compat-panel'),
@@ -173,6 +187,8 @@ const elements = {
   runPreviewBtn: document.getElementById('runPreviewBtn'),
   resetSampleBtn: document.getElementById('resetSampleBtn'),
   togglePanelsBtn: document.getElementById('toggle-panels'),
+  previewLayoutBtns: document.querySelectorAll('[data-preview-layout]'),
+  dockedEditorTabBtns: document.querySelectorAll('[data-docked-editor-tab]'),
   tabBtns: document.querySelectorAll('.tab-btn'),
   tabPanes: document.querySelectorAll('.tab-pane'),
   fileStatus: document.getElementById('file-status'),
@@ -224,6 +240,10 @@ function setPanelsVisible(visible) {
   if (button) {
     button.textContent = visible ? 'Hide Editors' : 'Show Editors';
   }
+
+  mountPreviewSurface();
+  resizePreviewCanvas();
+  notifyNodeEditorLayoutChanged();
 }
 
 function getMaxBottomPanelHeight() {
@@ -320,6 +340,7 @@ function handleWindowResizeForBottomPanel() {
   applyBottomPanelLayout();
 
   dslPaneWidth = clampDslPaneWidth(dslPaneWidth);
+  previewPaneWidth = clampPreviewPaneWidth(previewPaneWidth);
   applyEditorSplitLayout();
 
   saveBottomPanelLayout();
@@ -348,10 +369,31 @@ function getMaxDslPaneWidth() {
   return Math.max(MIN_DSL_PANE_WIDTH, Math.floor(maxWidth));
 }
 
+function getMaxPreviewPaneWidth() {
+  const panels = elements.editorPanels;
+  if (!panels) return DEFAULT_PREVIEW_PANE_WIDTH;
+
+  const rect = panels.getBoundingClientRect();
+  const maxWidth =
+    rect.width
+    - MIN_DOCKED_EDITOR_WIDTH
+    - EDITOR_SPLIT_HANDLE_WIDTH
+    - EDITOR_SPLIT_GRID_GAP * EDITOR_SPLIT_GRID_GAP_COUNT;
+
+  return Math.max(MIN_PREVIEW_PANE_WIDTH, Math.floor(maxWidth));
+}
+
 function clampDslPaneWidth(width) {
   return Math.min(
     Math.max(width, MIN_DSL_PANE_WIDTH),
     getMaxDslPaneWidth()
+  );
+}
+
+function clampPreviewPaneWidth(width) {
+  return Math.min(
+    Math.max(width, MIN_PREVIEW_PANE_WIDTH),
+    getMaxPreviewPaneWidth()
   );
 }
 
@@ -360,7 +402,9 @@ function applyEditorSplitLayout() {
   if (!panels) return;
 
   dslPaneWidth = clampDslPaneWidth(dslPaneWidth);
+  previewPaneWidth = clampPreviewPaneWidth(previewPaneWidth);
   panels.style.setProperty('--dsl-pane-width-px', `${dslPaneWidth}px`);
+  panels.style.setProperty('--preview-pane-width-px', `${previewPaneWidth}px`);
 }
 
 function loadEditorSplitLayout() {
@@ -369,11 +413,117 @@ function loadEditorSplitLayout() {
     dslPaneWidth = savedWidth;
   }
 
+  const savedPreviewWidth = Number(localStorage.getItem(PREVIEW_PANE_WIDTH_KEY));
+  if (Number.isFinite(savedPreviewWidth)) {
+    previewPaneWidth = savedPreviewWidth;
+  }
+
   applyEditorSplitLayout();
 }
 
 function saveEditorSplitLayout() {
   localStorage.setItem(EDITOR_SPLIT_WIDTH_KEY, String(dslPaneWidth));
+  localStorage.setItem(PREVIEW_PANE_WIDTH_KEY, String(previewPaneWidth));
+}
+
+function isPreviewDockedInPanels() {
+  return previewLayoutMode === 'docked' && panelsVisible && Boolean(elements.previewStage);
+}
+
+function getPreviewSurfaceParent() {
+  return isPreviewDockedInPanels() ? elements.previewStage : document.body;
+}
+
+function mountPreviewSurface() {
+  const parent = getPreviewSurfaceParent();
+  if (!parent) return;
+
+  for (const element of [elements.previewCanvas, elements.scene3dHost]) {
+    if (!element || element.parentElement === parent) continue;
+    parent.appendChild(element);
+  }
+}
+
+function getPreviewSurfaceSize() {
+  if (isPreviewDockedInPanels()) {
+    const rect = elements.previewStage.getBoundingClientRect();
+    return {
+      width: Math.max(1, Math.floor(rect.width)),
+      height: Math.max(1, Math.floor(rect.height))
+    };
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight
+  };
+}
+
+function applyDockedEditorTab() {
+  const normalized = dockedEditorTab === 'dsl' ? 'dsl' : 'node';
+  dockedEditorTab = normalized;
+
+  document.body.classList.toggle('docked-editor-dsl', normalized === 'dsl');
+  document.body.classList.toggle('docked-editor-node', normalized === 'node');
+
+  elements.dockedEditorTabBtns?.forEach((button) => {
+    const active = button.getAttribute('data-docked-editor-tab') === normalized;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+}
+
+function setDockedEditorTab(tab, { save = true } = {}) {
+  if (!['node', 'dsl'].includes(tab)) return;
+  dockedEditorTab = tab;
+  applyDockedEditorTab();
+  notifyNodeEditorLayoutChanged();
+  if (save) {
+    localStorage.setItem(DOCKED_EDITOR_TAB_KEY, dockedEditorTab);
+  }
+}
+
+function updatePreviewLayoutButtons() {
+  elements.previewLayoutBtns?.forEach((button) => {
+    const active = button.getAttribute('data-preview-layout') === previewLayoutMode;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+}
+
+function applyPreviewLayoutMode() {
+  document.body.classList.toggle('preview-layout-docked', previewLayoutMode === 'docked');
+  document.body.classList.toggle('preview-layout-background', previewLayoutMode !== 'docked');
+
+  applyDockedEditorTab();
+  updatePreviewLayoutButtons();
+  mountPreviewSurface();
+  applyEditorSplitLayout();
+  resizePreviewCanvas();
+  notifyNodeEditorLayoutChanged();
+}
+
+function setPreviewLayoutMode(mode, { save = true } = {}) {
+  if (!['background', 'docked'].includes(mode)) return;
+  previewLayoutMode = mode;
+  applyPreviewLayoutMode();
+  if (save) {
+    localStorage.setItem(PREVIEW_LAYOUT_MODE_KEY, previewLayoutMode);
+  }
+}
+
+function loadPreviewLayoutMode() {
+  const savedLayout = localStorage.getItem(PREVIEW_LAYOUT_MODE_KEY);
+  if (savedLayout === 'background' || savedLayout === 'docked') {
+    previewLayoutMode = savedLayout;
+  }
+
+  const savedDockedTab = localStorage.getItem(DOCKED_EDITOR_TAB_KEY);
+  if (savedDockedTab === 'node' || savedDockedTab === 'dsl') {
+    dockedEditorTab = savedDockedTab;
+  }
+
+  applyPreviewLayoutMode();
 }
 
 function applyEditorMaximizeMode() {
@@ -421,16 +571,18 @@ function updateEditorMaximizeButtons() {
   const panels = elements.editorPanels;
   if (!panels) return;
 
+  const showMaximizeControls = previewLayoutMode === 'background';
+
   panels.querySelectorAll('[data-action="maximize-dsl"]').forEach((btn) => {
-    btn.style.display = editorMaximizeMode === 'split' ? 'block' : 'none';
+    btn.style.display = showMaximizeControls && editorMaximizeMode === 'split' ? 'block' : 'none';
   });
 
   panels.querySelectorAll('[data-action="maximize-node"]').forEach((btn) => {
-    btn.style.display = editorMaximizeMode === 'split' ? 'block' : 'none';
+    btn.style.display = showMaximizeControls && editorMaximizeMode === 'split' ? 'block' : 'none';
   });
 
   panels.querySelectorAll('[data-action="restore-split"]').forEach((btn) => {
-    btn.style.display = editorMaximizeMode !== 'split' ? 'block' : 'none';
+    btn.style.display = showMaximizeControls && editorMaximizeMode !== 'split' ? 'block' : 'none';
   });
 }
 
@@ -494,7 +646,11 @@ function resizeEditorSplit(event) {
   const rect = panels.getBoundingClientRect();
   const nextWidth = event.clientX - rect.left;
 
-  dslPaneWidth = clampDslPaneWidth(nextWidth);
+  if (previewLayoutMode === 'docked') {
+    previewPaneWidth = clampPreviewPaneWidth(nextWidth);
+  } else {
+    dslPaneWidth = clampDslPaneWidth(nextWidth);
+  }
   applyEditorSplitLayout();
 }
 
@@ -510,10 +666,11 @@ function resizePreviewCanvas() {
   const canvas = elements.previewCanvas;
   if (!canvas) return;
 
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
-  canvas.style.width = `${window.innerWidth}px`;
-  canvas.style.height = `${window.innerHeight}px`;
+  const { width, height } = getPreviewSurfaceSize();
+  canvas.width = width;
+  canvas.height = height;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
 
   if (scene3dPreview) {
     scene3dPreview.resize();
@@ -530,12 +687,103 @@ function setScene3DActive(active) {
   }
 
   if (active && !scene3dPreview && elements.scene3dHost) {
-    scene3dPreview = new Scene3DPreview(elements.scene3dHost);
+    scene3dPreview = new Scene3DPreview(elements.scene3dHost, {
+      onObjectPointerEvent: handleScenePreviewObjectPointerEvent
+    });
   }
 
   if (active && scene3dPreview) {
+    scene3dPreview.onObjectPointerEvent = handleScenePreviewObjectPointerEvent;
     scene3dPreview.resize();
   }
+}
+
+function setPreviewEventScope(target = '') {
+  const nextTarget = String(target || '').trim();
+  previewEventScopeId = nextTarget;
+}
+
+function renderPreviewEventStatus(text) {
+  if (!elements.previewEventStatus) return;
+  elements.previewEventStatus.hidden = !text;
+  elements.previewEventStatus.textContent = text || '';
+}
+
+function formatPreviewEventDescriptor(event) {
+  const target = event.target ? ` -> ${event.target}` : '';
+  return `${event.channel}${target}`;
+}
+
+function queuePreviewEvent(event) {
+  if (!event?.channel) return;
+
+  const target = typeof event.target === 'string' ? event.target.trim() : '';
+  const queued = {
+    id: ++previewEventSequence,
+    channel: event.channel,
+    ...(target ? { target } : {}),
+    ...(event.payload !== undefined ? { payload: event.payload } : {}),
+    ...(event.pointer ? { pointer: event.pointer } : {})
+  };
+
+  previewEventQueue.push(queued);
+  setPreviewEventScope(target);
+  renderPreviewEventStatus(formatPreviewEventDescriptor(queued));
+  appendOutput({
+    level: 'event',
+    message: `Queued preview event: ${formatPreviewEventDescriptor(queued)}`
+  });
+}
+
+function consumePreviewEvents(elapsed) {
+  if (!previewEventQueue.length) return [];
+
+  const queued = previewEventQueue;
+  previewEventQueue = [];
+
+  return queued.map((event) => ({
+    channel: event.channel,
+    timestamp: Number.isFinite(elapsed) ? elapsed : performance.now() / 1000,
+    source: 'editor.preview',
+    ...(event.target ? { target: event.target } : {}),
+    ...(event.payload !== undefined ? { payload: event.payload } : {}),
+    ...(event.pointer ? { pointer: event.pointer } : {})
+  }));
+}
+
+function createPreviewEnvironment(elapsed) {
+  const env = {
+    time: elapsed,
+    events: consumePreviewEvents(elapsed)
+  };
+
+  const scopeId = previewEventScopeId.trim();
+  if (scopeId) {
+    env.scope = { type: 'object', id: scopeId };
+  }
+
+  return env;
+}
+
+function handleScenePreviewObjectPointerEvent(event) {
+  const objectId = event?.objectId || '';
+  if (!objectId) return;
+
+  queuePreviewEvent({
+    channel: event.channel || 'pointer.click',
+    target: objectId,
+    payload: {
+      x: Math.round(event.clientX),
+      y: Math.round(event.clientY),
+      button: event.button ?? 0,
+      ...(event.payload && typeof event.payload === 'object' ? event.payload : {})
+    },
+    pointer: {
+      x: event.clientX,
+      y: event.clientY,
+      button: event.button ?? 0
+    }
+  });
 }
 
 function initDslEditor() {
@@ -2096,6 +2344,9 @@ function runPreview(graph) {
     engine.stop();
   }
   lastNodeValuePreviewAtMs = 0;
+  previewEventQueue = [];
+  setPreviewEventScope('');
+  renderPreviewEventStatus(null);
 
   const state = store.getState();
   if (!graph) graph = state.graph;
@@ -2119,7 +2370,7 @@ function runPreview(graph) {
     if (typeof engine.enableProbes === 'function') {
       engine.enableProbes({ values: true });
     }
-    engine.start({ getEnv: ({ elapsed }) => ({ time: elapsed }) });
+    engine.start({ getEnv: ({ elapsed }) => createPreviewEnvironment(elapsed) });
 
     animationFrameId = requestAnimationFrame(() => {
       tick(engine, graph);
@@ -2139,6 +2390,15 @@ function tick(engine, graph) {
     for (const effect of effects) {
       if (effect.type === 'log' && effect.message) {
         appendOutput({ level: 'log', message: effect.message });
+      } else if (effect.kind === 'event.send') {
+        const target = effect.target ? ` -> ${effect.target}` : '';
+        const payload = effect.payload !== undefined
+          ? ` ${JSON.stringify(effect.payload)}`
+          : '';
+        appendOutput({
+          level: 'event',
+          message: `sendEvent: ${effect.channel}${target}${payload}`
+        });
       }
     }
 
@@ -3018,6 +3278,18 @@ function setupEventListeners() {
   elements.togglePanelsBtn.addEventListener('click', () => {
     setPanelsVisible(!panelsVisible);
   });
+  elements.previewLayoutBtns?.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const mode = btn.getAttribute('data-preview-layout');
+      setPreviewLayoutMode(mode);
+    });
+  });
+  elements.dockedEditorTabBtns?.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const tab = btn.getAttribute('data-docked-editor-tab');
+      setDockedEditorTab(tab);
+    });
+  });
   elements.openFileBtn.addEventListener('click', openLoomFile);
   elements.saveFileBtn.addEventListener('click', saveDslFile);
   elements.saveAsFileBtn.addEventListener('click', saveDslAsFile);
@@ -3289,6 +3561,7 @@ async function init() {
   loadEditorSplitLayout();
   loadActiveBottomTab();
   loadEditorMaximizeMode();
+  loadPreviewLayoutMode();
   loadSceneSyncSettings();
   renderFileStatus();
   renderDirtyStatus();

--- a/editor-studio/src/scene3d-preview.js
+++ b/editor-studio/src/scene3d-preview.js
@@ -9,8 +9,11 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 const CUBE_COLORS = [0x4a90e2, 0xff70a6, 0x80ed99, 0xffd166, 0xc792ea];
 
 export class Scene3DPreview {
-  constructor(host) {
+  constructor(host, options = {}) {
     this.host = host;
+    this.onObjectPointerEvent = typeof options.onObjectPointerEvent === 'function'
+      ? options.onObjectPointerEvent
+      : null;
     this.initialized = false;
     this.scene = null;
     this.camera = null;
@@ -18,6 +21,16 @@ export class Scene3DPreview {
     this.controls = null;
     this.objects = new Map(); // objectId -> THREE.Mesh
     this._colorCursor = 0;
+    this._raycaster = new THREE.Raycaster();
+    this._pointer = new THREE.Vector2();
+    this._pointerDown = null;
+    this._hoverObjectId = null;
+    this._boundPointerDown = (event) => this._handlePointerDown(event);
+    this._boundPointerMove = (event) => this._handlePointerMove(event);
+    this._boundPointerUp = (event) => this._handlePointerUp(event);
+    this._boundPointerCancel = () => {
+      this._pointerDown = null;
+    };
   }
 
   _ensureInit() {
@@ -36,6 +49,10 @@ export class Scene3DPreview {
     this.renderer.setSize(width, height, false);
     this.renderer.setPixelRatio(window.devicePixelRatio || 1);
     this.host.appendChild(this.renderer.domElement);
+    this.renderer.domElement.addEventListener('pointerdown', this._boundPointerDown);
+    this.renderer.domElement.addEventListener('pointermove', this._boundPointerMove);
+    this.renderer.domElement.addEventListener('pointerup', this._boundPointerUp);
+    this.renderer.domElement.addEventListener('pointercancel', this._boundPointerCancel);
 
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     this.controls.enableDamping = true;
@@ -55,6 +72,99 @@ export class Scene3DPreview {
     this.initialized = true;
   }
 
+  _handlePointerDown(event) {
+    const picked = this._pickObject(event);
+    this._pointerDown = {
+      x: event.clientX,
+      y: event.clientY,
+      button: event.button,
+      time: performance.now(),
+      objectId: picked?.objectId || null
+    };
+
+    if (picked) {
+      this._emitObjectPointerEvent('pointer.down', picked.objectId, event);
+    }
+  }
+
+  _handlePointerMove(event) {
+    const picked = this._pickObject(event);
+    const nextObjectId = picked?.objectId || null;
+    const previousObjectId = this._hoverObjectId;
+
+    if (this.renderer?.domElement) {
+      this.renderer.domElement.style.cursor = nextObjectId ? 'pointer' : '';
+    }
+
+    if (nextObjectId === previousObjectId) return;
+
+    this._hoverObjectId = nextObjectId;
+
+    if (previousObjectId) {
+      this._emitObjectPointerEvent('pointer.leave', previousObjectId, event, {
+        relatedTarget: nextObjectId
+      });
+    }
+    if (nextObjectId) {
+      this._emitObjectPointerEvent('pointer.enter', nextObjectId, event, {
+        relatedTarget: previousObjectId
+      });
+    }
+  }
+
+  _handlePointerUp(event) {
+    if (!this._pointerDown || event.button !== this._pointerDown.button) {
+      this._pointerDown = null;
+      return;
+    }
+
+    const dx = event.clientX - this._pointerDown.x;
+    const dy = event.clientY - this._pointerDown.y;
+    const elapsed = performance.now() - this._pointerDown.time;
+    const moved = Math.hypot(dx, dy);
+    const downObjectId = this._pointerDown.objectId;
+    this._pointerDown = null;
+
+    const picked = this._pickObject(event);
+    if (picked) {
+      this._emitObjectPointerEvent('pointer.up', picked.objectId, event);
+    }
+
+    if (moved > 5 || elapsed > 650 || !picked || picked.objectId !== downObjectId) return;
+
+    this._emitObjectPointerEvent('pointer.click', picked.objectId, event);
+  }
+
+  _pickObject(event) {
+    if (!this.initialized) return null;
+
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+
+    this._pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    this._pointer.y = -(((event.clientY - rect.top) / rect.height) * 2 - 1);
+    this._raycaster.setFromCamera(this._pointer, this.camera);
+
+    const meshes = [...this.objects.values()].filter((mesh) => mesh.visible);
+    const intersects = this._raycaster.intersectObjects(meshes, false);
+    const mesh = intersects[0]?.object;
+    const objectId = mesh?.userData?.objectId;
+    return objectId ? { objectId, mesh } : null;
+  }
+
+  _emitObjectPointerEvent(channel, objectId, event, extraPayload = {}) {
+    if (!this.onObjectPointerEvent) return;
+
+    this.onObjectPointerEvent({
+      channel,
+      objectId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      button: event.button ?? 0,
+      payload: extraPayload
+    });
+  }
+
   _getOrCreateObject(objectId) {
     let mesh = this.objects.get(objectId);
     if (mesh) return mesh;
@@ -66,6 +176,7 @@ export class Scene3DPreview {
     const material = new THREE.MeshStandardMaterial({ color, metalness: 0.1, roughness: 0.6 });
     mesh = new THREE.Mesh(geometry, material);
     mesh.position.y = 0.5; // sit on the floor by default
+    mesh.userData.objectId = objectId;
     this.scene.add(mesh);
     this.objects.set(objectId, mesh);
     return mesh;
@@ -125,6 +236,12 @@ export class Scene3DPreview {
   dispose() {
     if (!this.initialized) return;
     this.controls.dispose();
+    this.renderer.domElement.removeEventListener('pointerdown', this._boundPointerDown);
+    this.renderer.domElement.removeEventListener('pointermove', this._boundPointerMove);
+    this.renderer.domElement.removeEventListener('pointerup', this._boundPointerUp);
+    this.renderer.domElement.removeEventListener('pointercancel', this._boundPointerCancel);
+    this.renderer.domElement.style.cursor = '';
+    this._hoverObjectId = null;
     for (const mesh of this.objects.values()) {
       mesh.geometry.dispose();
       mesh.material.dispose();

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -75,6 +75,24 @@ html, body {
   z-index: 1;
 }
 
+.scene3d-click-status {
+  position: absolute;
+  right: 20px;
+  top: 64px;
+  max-width: min(320px, calc(100vw - 40px));
+  padding: 5px 11px;
+  border-radius: 999px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11.5px;
+  color: #d7e4ff;
+  background: rgba(13, 16, 23, 0.72);
+  border: 1px solid #34415f;
+  pointer-events: none;
+  z-index: 1;
+}
+
 /* Overlay container */
 .studio-overlay {
   position: fixed;
@@ -96,6 +114,55 @@ html, body {
   pointer-events: auto;
 }
 
+@media (max-width: 1180px) {
+  .studio-toolbar {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+
+  .editor-panels {
+    top: 100px;
+  }
+
+  .scene3d-click-status {
+    top: 100px;
+  }
+}
+
+.segmented-control {
+  display: inline-flex;
+  align-items: center;
+  height: 30px;
+  padding: 2px;
+  gap: 2px;
+  border-radius: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(20, 20, 20, 0.78);
+}
+
+.segmented-btn {
+  height: 24px;
+  padding: 0 9px;
+  border: none;
+  border-radius: 5px;
+  color: var(--text-dim);
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.segmented-btn:hover {
+  color: var(--text-color);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.segmented-btn.active {
+  color: #ffffff;
+  background: rgba(74, 144, 226, 0.35);
+}
+
 /* Editor panels */
 .editor-panels {
   position: fixed;
@@ -105,6 +172,7 @@ html, body {
   bottom: 12px;
   display: grid;
   --dsl-pane-width-px: 520px;
+  --preview-pane-width-px: 520px;
   grid-template-columns:
     minmax(280px, var(--dsl-pane-width-px))
     8px
@@ -117,6 +185,11 @@ html, body {
 
 /* Hide editor panels */
 body.panels-hidden .editor-panels {
+  display: none;
+}
+
+.preview-pane,
+.docked-editor-tabs {
   display: none;
 }
 
@@ -174,6 +247,138 @@ body.panels-hidden .editor-panels {
   grid-row: 3;
 }
 
+body.preview-layout-docked:not(.panels-hidden) .editor-panels,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-dsl,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-node {
+  grid-template-columns:
+    minmax(320px, var(--preview-pane-width-px))
+    8px
+    minmax(360px, 1fr);
+  grid-template-rows: auto 1fr auto auto;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .preview-pane {
+  display: flex;
+  grid-column: 1;
+  grid-row: 1 / 3;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .editor-split-resize-handle,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-dsl .editor-split-resize-handle,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-node .editor-split-resize-handle {
+  display: block;
+  grid-column: 2;
+  grid-row: 1 / 3;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .docked-editor-tabs {
+  display: flex;
+  grid-column: 3;
+  grid-row: 1;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .dsl-pane,
+body.preview-layout-docked:not(.panels-hidden) .node-pane,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-dsl .dsl-pane,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-dsl .node-pane,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-node .dsl-pane,
+body.preview-layout-docked:not(.panels-hidden) .editor-panels.is-maximized-node .node-pane {
+  display: none;
+  grid-column: 3;
+  grid-row: 2;
+}
+
+body.preview-layout-docked.docked-editor-dsl:not(.panels-hidden) .dsl-pane,
+body.preview-layout-docked.docked-editor-node:not(.panels-hidden) .node-pane,
+body.preview-layout-docked.docked-editor-dsl:not(.panels-hidden) .editor-panels.is-maximized-node .dsl-pane,
+body.preview-layout-docked.docked-editor-node:not(.panels-hidden) .editor-panels.is-maximized-dsl .node-pane {
+  display: flex;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .bottom-panel-resize-handle {
+  grid-column: 1 / -1;
+  grid-row: 3;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .graph-errors-panel {
+  grid-column: 1 / -1;
+  grid-row: 4;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .pane-controls {
+  display: none;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .dsl-pane > .pane-header,
+body.preview-layout-docked:not(.panels-hidden) .node-pane > .pane-header {
+  display: none;
+}
+
+.preview-stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: radial-gradient(120% 90% at 50% 18%, #141b2b 0%, #0a0d14 70%);
+}
+
+body.preview-layout-docked:not(.panels-hidden) .preview-stage > .preview-canvas,
+body.preview-layout-docked:not(.panels-hidden) .preview-stage > .scene3d-host {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .preview-stage > .scene3d-host {
+  z-index: 1;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .scene3d-badge {
+  left: 14px;
+  bottom: 14px;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .scene3d-click-status {
+  top: 14px;
+  right: 14px;
+  max-width: calc(100% - 28px);
+}
+
+.docked-editor-tabs {
+  align-items: stretch;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: var(--panel-bg);
+}
+
+.docked-editor-tab {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 10px 14px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.docked-editor-tab:hover {
+  color: var(--text-color);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.docked-editor-tab.active {
+  color: var(--primary-color);
+  border-bottom-color: var(--primary-color);
+  background: rgba(74, 144, 226, 0.08);
+}
+
 /* Panel styling */
 .panel {
   background: var(--panel-bg);
@@ -183,6 +388,11 @@ body.panels-hidden .editor-panels {
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+
+.editor-panels > .preview-pane,
+.editor-panels > .docked-editor-tabs {
+  display: none;
 }
 
 .pane {
@@ -1588,5 +1798,15 @@ button:disabled:hover,
   .tab-btn {
     padding: 8px 11px;
     font-size: 12px;
+  }
+}
+
+@media (min-width: 721px) and (max-width: 1180px) {
+  body .editor-panels {
+    top: 100px;
+  }
+
+  body .scene3d-click-status {
+    top: 100px;
   }
 }

--- a/src/loom.js
+++ b/src/loom.js
@@ -1236,12 +1236,14 @@ export class Loom {
         throw new LoomError('UNKNOWN_PORT', `Unknown port: ${toNodeId}.${toPortName}`, { nodeId: toNodeId, port: toPortName, side: 'input' });
       }
 
-      // 6. 型チェック（Behavior/Event の混在禁止、ただし sample.value は例外）
+      // 6. 型チェック（Behavior/Event の混在禁止、ただし明示的な
+      // Event->Behavior adapters は例外）
       const fromKind = fromPort.kind;
       const toKind = toPort ? toPort.kind : 'behavior';
       const isSampleValueException = toNode.type === 'sample' && toPortName === 'value';
+      const isEventArrayAdapter = fromKind === 'event' && toKind === 'behavior' && toPort?.type === 'array';
 
-      if (fromKind !== toKind && !isSampleValueException) {
+      if (fromKind !== toKind && !isSampleValueException && !isEventArrayAdapter) {
         throw new LoomError('TYPE_MISMATCH',
           `Cannot connect ${fromKind} port to ${toKind} port`,
           { from: edge.from, to: edge.to, fromType: fromKind, toType: toKind });

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -1,11 +1,20 @@
 import { compileLoomSource } from '../toolchain/compile.js';
 
 const SUPPORTED_NODES = new Set([
+  'constant',
   'clock',
+  'onEvent',
+  'list.length',
+  'logic.greaterThan',
+  'logic.select',
+  'integrate',
+  'add',
+  'multiply',
   'math.sine',
   'math.cosine',
   'math.add',
   'math.multiply',
+  'math.lerp',
   'scene.setPosition',
   'scene.offsetPosition',
   'scene.setRotation',
@@ -24,11 +33,20 @@ const SUPPORTED_NODES = new Set([
 ]);
 
 const NODE_TYPE_MAPPING = {
+  'constant': 'constant',
   'clock': 'clock',
+  'onEvent': 'onEvent',
+  'list.length': 'list.length',
+  'logic.greaterThan': 'logic.greaterThan',
+  'logic.select': 'logic.select',
+  'integrate': 'integrate',
+  'add': 'add',
+  'multiply': 'multiply',
   'math.sine': 'sine',
   'math.cosine': 'cosine',
   'math.add': 'add',
   'math.multiply': 'multiply',
+  'math.lerp': 'lerp',
   'scene.setPosition': 'sceneSetPosition',
   'scene.offsetPosition': 'sceneOffsetPosition',
   'scene.setRotation': 'sceneSetRotation',
@@ -52,7 +70,15 @@ function isSceneSyncSink(nodeType) {
 }
 
 const OUTPUT_PORT_MAPPING = {
+  'constant': 'out',
   'clock': 't',
+  'onEvent': 'event',
+  'list.length': 'out',
+  'logic.greaterThan': 'out',
+  'logic.select': 'out',
+  'integrate': 'out',
+  'add': 'out',
+  'multiply': 'out',
   'math.sine': 'out',
   'sine': 'out',
   'math.cosine': 'out',
@@ -61,6 +87,8 @@ const OUTPUT_PORT_MAPPING = {
   'add': 'out',
   'math.multiply': 'out',
   'multiply': 'out',
+  'math.lerp': 'out',
+  'lerp': 'out',
   'scene.setPosition': undefined,
   'sceneSetPosition': undefined,
   'scene.offsetPosition': undefined,
@@ -95,11 +123,18 @@ const OUTPUT_PORT_MAPPING = {
 
 function generateStableNodeBase(nodeType) {
   const mapped = NODE_TYPE_MAPPING[nodeType] || nodeType;
+  if (mapped === 'constant') return 'constant';
   if (mapped === 'clock') return 'clock';
+  if (mapped === 'onEvent') return 'event';
+  if (mapped === 'list.length') return 'length';
+  if (mapped === 'logic.greaterThan') return 'greaterThan';
+  if (mapped === 'logic.select') return 'select';
+  if (mapped === 'integrate') return 'integrate';
   if (mapped === 'sine') return 'sine';
   if (mapped === 'cosine') return 'cosine';
   if (mapped === 'add') return 'add';
   if (mapped === 'multiply') return 'multiply';
+  if (mapped === 'lerp') return 'lerp';
   if (mapped === 'sceneSetPosition') return 'pos';
   if (mapped === 'sceneOffsetPosition') return 'offset';
   if (mapped === 'sceneSetRotation') return 'rot';
@@ -151,6 +186,21 @@ function normalizeScope(options = {}) {
 }
 
 function pickParams(nodeType, params = {}) {
+  if (
+    nodeType === 'constant' ||
+    nodeType === 'onEvent' ||
+    nodeType === 'integrate' ||
+    nodeType === 'add' ||
+    nodeType === 'multiply' ||
+    nodeType === 'math.add' ||
+    nodeType === 'math.multiply' ||
+    nodeType === 'math.lerp' ||
+    nodeType === 'logic.greaterThan' ||
+    nodeType === 'logic.select' ||
+    nodeType === 'list.length'
+  ) {
+    return { ...params };
+  }
   if (nodeType === 'scene.offsetPosition') {
     return {
       ...(params.objectId ? { target: params.objectId } : {}),

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -32,6 +32,57 @@ scene.setPosition("sample-cube", x: x, y: y, z: 0)
   assert.equal(result.graph.edges.length, 4);
 });
 
+test('compiles pointer click flash example to Scene Sync graph', () => {
+  const source = `
+import scene
+import logic
+import list
+
+click = onEvent(channel: "pointer.click")
+clickCount = list.length(list: click)
+clicked = logic.greaterThan(value: clickCount, other: 0)
+drive = logic.select(condition: clicked, whenTrue: 90, whenFalse: -2.8)
+flash = integrate(value: drive, initial: 0, min: 0, max: 1)
+
+rBoost = multiply(a: flash, b: 0.88)
+r = add(a: rBoost, b: 0.12)
+gBoost = multiply(a: flash, b: 0.58)
+g = add(a: gBoost, b: 0.42)
+
+scene.setColor(objectId: "sample-cube", r: r, g: g, b: 1)
+scene.offsetPosition(objectId: "sample-cube", y: 0)
+`;
+
+  const result = compileLoomToSceneSyncGraph(source);
+  const nodeTypes = result.graph.nodes.map((node) => node.type);
+
+  assert.deepEqual(result.scope, { object: 'sample-cube' });
+  assert.ok(nodeTypes.includes('onEvent'));
+  assert.ok(nodeTypes.includes('list.length'));
+  assert.ok(nodeTypes.includes('logic.greaterThan'));
+  assert.ok(nodeTypes.includes('logic.select'));
+  assert.ok(nodeTypes.includes('integrate'));
+  assert.ok(nodeTypes.includes('multiply'));
+  assert.ok(nodeTypes.includes('add'));
+  assert.ok(nodeTypes.includes('sceneSetColor'));
+  assert.ok(nodeTypes.includes('sceneOffsetPosition'));
+  assert.ok(result.graph.edges.some((edge) => edge.from === 'click.event' && edge.to === 'clickCount.list'));
+
+  const eventNode = result.graph.nodes.find((node) => node.id === 'click');
+  const driveNode = result.graph.nodes.find((node) => node.id === 'drive');
+  const flashNode = result.graph.nodes.find((node) => node.id === 'flash');
+  const colorNode = result.graph.nodes.find((node) => node.type === 'sceneSetColor');
+
+  assert.equal(eventNode.params.channel, 'pointer.click');
+  assert.equal(driveNode.params.whenTrue, 90);
+  assert.equal(driveNode.params.whenFalse, -2.8);
+  assert.equal(flashNode.params.min, 0);
+  assert.equal(flashNode.params.max, 1);
+  assert.ok(result.graph.edges.some((edge) => edge.to === `${colorNode.id}.r`));
+  assert.ok(result.graph.edges.some((edge) => edge.to === `${colorNode.id}.g`));
+  assert.equal(colorNode.params.b, 1);
+});
+
 test('--object option overrides DSL object id', () => {
   const source = `
 import math

--- a/test/stdlib-baseline.test.mjs
+++ b/test/stdlib-baseline.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { Loom, LoomError, NODE_TYPES } from '../src/loom.js';
+import { parseDSLToAST, compileToGraph } from '../src/loom-dsl.js';
 import { formatValuePreview } from '../src/value-preview.js';
 import { runLoomSource } from '../src/toolchain/run.js';
 import { LIBRARY_METADATA } from '../src/toolchain/library-metadata.js';
@@ -587,6 +588,80 @@ test('env.events omitted behaves as empty array', () => {
   engine.evaluateOnce({ env: { time: 1 } });
 
   assert.deepEqual(engine.getValue('listener.event'), []);
+});
+
+test('event arrays can feed list behavior adapters', () => {
+  const graph = {
+    nodes: [
+      { id: 'listener', type: 'onEvent', params: { channel: 'pointer.click' } },
+      { id: 'count', type: 'list.length' }
+    ],
+    edges: [{ from: 'listener.event', to: 'count.list' }]
+  };
+  const engine = new Loom(graph);
+
+  engine.evaluateOnce({ env: { time: 1, scope: { type: 'object', id: 'sample-cube' }, events: [] } });
+  assert.equal(engine.getValue('count.out'), 0);
+
+  engine.evaluateOnce({
+    env: {
+      time: 1.016,
+      scope: { type: 'object', id: 'sample-cube' },
+      events: [{ channel: 'pointer.click', target: 'sample-cube', timestamp: 1.016 }]
+    }
+  });
+  assert.equal(engine.getValue('count.out'), 1);
+});
+
+test('DSL pointer click can drive a white flash fade on scene color', () => {
+  const source = `
+import scene
+import logic
+import list
+
+click = onEvent(channel: "pointer.click")
+clickCount = list.length(list: click)
+clicked = logic.greaterThan(value: clickCount, other: 0)
+drive = logic.select(condition: clicked, whenTrue: 90, whenFalse: -2.8)
+flash = integrate(value: drive, initial: 0, min: 0, max: 1)
+
+rBoost = multiply(a: flash, b: 0.88)
+r = add(a: rBoost, b: 0.12)
+gBoost = multiply(a: flash, b: 0.58)
+g = add(a: gBoost, b: 0.42)
+
+scene.setColor(objectId: "sample-cube", r: r, g: g, b: 1)
+scene.offsetPosition(objectId: "sample-cube", y: 0)
+`;
+  const parsed = parseDSLToAST(source);
+  assert.deepEqual(parsed.errors, []);
+  const compiled = compileToGraph(parsed.ast);
+  assert.deepEqual(compiled.errors, []);
+
+  const engine = new Loom(compiled.graph);
+  engine.evaluateOnce({
+    env: {
+      time: 1,
+      deltaTime: 0.016,
+      scope: { type: 'object', id: 'sample-cube' },
+      events: [{ channel: 'pointer.click', target: 'sample-cube', timestamp: 1 }]
+    }
+  });
+  let color = engine.getEffects().find((effect) => effect.type === 'scene.setColor')?.color;
+  assert.deepEqual(color, [1, 1, 1]);
+
+  engine.evaluateOnce({
+    env: {
+      time: 1.1,
+      deltaTime: 0.1,
+      scope: { type: 'object', id: 'sample-cube' },
+      events: []
+    }
+  });
+  color = engine.getEffects().find((effect) => effect.type === 'scene.setColor')?.color;
+  assert.ok(color[0] < 1 && color[0] > 0.12);
+  assert.ok(color[1] < 1 && color[1] > 0.42);
+  assert.equal(color[2], 1);
 });
 
 test('invalid env.events shape fails clearly', () => {


### PR DESCRIPTION
## Summary
- Add a Background/Docked preview layout switch to the editor toolbar.
- In Docked mode, show a clickable Preview pane beside an editor pane with Node Editor / DSL Editor tabs.
- Feed real 3D object pointer events into preview `env.events`, allowing `onEvent(channel: "pointer.click")` DSL graphs to react to cube clicks while Output and node value previews remain visible.
- Allow event arrays to feed list adapter nodes and compile the click-flash graph shape into Scene Sync payloads.

## Root Cause
The 3D preview was only directly interactive when the editor overlay was hidden, so users could not click the cube while watching Node Editor values or Output.

## Validation
- `node --test test/stdlib-baseline.test.mjs test/scenesync-graph-adapter.test.mjs`
- `npm run build` in `editor-studio`
- Browser smoke check at `http://127.0.0.1:5173/`: Background returns to `DSL Editor | Node Editor`; Docked shows `Preview | Node Editor`; Docked tab switches to DSL; Docked preview click emits `pointer.click -> sample-cube`.