### PR TITLE
[codex] Keep docked preview aspect ratio stable

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -116,6 +116,7 @@ const MIN_NODE_PANE_WIDTH = 320;
 const DEFAULT_PREVIEW_PANE_WIDTH = 520;
 const MIN_PREVIEW_PANE_WIDTH = 320;
 const MIN_DOCKED_EDITOR_WIDTH = 360;
+const DOCKED_PREVIEW_ASPECT_RATIO = 16 / 9;
 const EDITOR_SPLIT_HANDLE_WIDTH = 8;
 const EDITOR_SPLIT_GRID_GAP = 12;
 const EDITOR_SPLIT_GRID_GAP_COUNT = 2;
@@ -325,6 +326,7 @@ function resizeBottomPanel(event) {
 
   bottomPanelHeight = clampBottomPanelHeight(newHeight);
   applyBottomPanelLayout();
+  resizePreviewCanvas();
 }
 
 function stopBottomPanelResize() {
@@ -350,6 +352,7 @@ function handleWindowResizeForBottomPanel() {
 function toggleBottomPanelCollapsed() {
   isBottomPanelCollapsed = !isBottomPanelCollapsed;
   applyBottomPanelLayout();
+  resizePreviewCanvas();
   saveBottomPanelLayout();
 }
 
@@ -434,6 +437,38 @@ function getPreviewSurfaceParent() {
   return isPreviewDockedInPanels() ? elements.previewStage : document.body;
 }
 
+function layoutDockedPreviewStage() {
+  const stage = elements.previewStage;
+  if (!stage) return;
+
+  if (!isPreviewDockedInPanels()) {
+    stage.style.width = '';
+    stage.style.height = '';
+    return;
+  }
+
+  const pane = stage.closest('.preview-pane');
+  if (!pane) return;
+
+  const header = pane.querySelector('.pane-header');
+  const availableWidth = Math.max(1, pane.clientWidth);
+  const availableHeight = Math.max(1, pane.clientHeight - (header?.offsetHeight || 0));
+  const availableAspect = availableWidth / availableHeight;
+
+  let width;
+  let height;
+  if (availableAspect > DOCKED_PREVIEW_ASPECT_RATIO) {
+    height = availableHeight;
+    width = height * DOCKED_PREVIEW_ASPECT_RATIO;
+  } else {
+    width = availableWidth;
+    height = width / DOCKED_PREVIEW_ASPECT_RATIO;
+  }
+
+  stage.style.width = `${Math.floor(width)}px`;
+  stage.style.height = `${Math.floor(height)}px`;
+}
+
 function mountPreviewSurface() {
   const parent = getPreviewSurfaceParent();
   if (!parent) return;
@@ -446,6 +481,7 @@ function mountPreviewSurface() {
 
 function getPreviewSurfaceSize() {
   if (isPreviewDockedInPanels()) {
+    layoutDockedPreviewStage();
     const rect = elements.previewStage.getBoundingClientRect();
     return {
       width: Math.max(1, Math.floor(rect.width)),
@@ -652,6 +688,7 @@ function resizeEditorSplit(event) {
     dslPaneWidth = clampDslPaneWidth(nextWidth);
   }
   applyEditorSplitLayout();
+  resizePreviewCanvas();
 }
 
 function stopEditorSplitResize() {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -261,6 +261,11 @@ body.preview-layout-docked:not(.panels-hidden) .preview-pane {
   display: flex;
   grid-column: 1;
   grid-row: 1 / 3;
+  align-items: center;
+}
+
+body.preview-layout-docked:not(.panels-hidden) .preview-pane > .pane-header {
+  width: 100%;
 }
 
 body.preview-layout-docked:not(.panels-hidden) .editor-split-resize-handle,
@@ -320,6 +325,14 @@ body.preview-layout-docked:not(.panels-hidden) .node-pane > .pane-header {
   min-height: 0;
   overflow: hidden;
   background: radial-gradient(120% 90% at 50% 18%, #141b2b 0%, #0a0d14 70%);
+}
+
+body.preview-layout-docked:not(.panels-hidden) .preview-stage {
+  flex: 0 0 auto;
+  align-self: center;
+  max-width: 100%;
+  max-height: 100%;
+  margin: auto 0;
 }
 
 body.preview-layout-docked:not(.panels-hidden) .preview-stage > .preview-canvas,


### PR DESCRIPTION
## Summary
- Keep the docked preview render surface at a fixed 16:9 aspect ratio while the pane itself remains resizable.
- Resize the preview canvas/three.js renderer during preview-pane and bottom-panel resizing.
- Center the fixed-ratio preview surface inside the available preview pane area.

## Why
Dragging the Docked layout splitter changed the preview surface aspect ratio, making the preview shape unstable when narrowing or widening the pane.

## Validation
- `npm run build` in `editor-studio`
- Browser smoke check at `http://127.0.0.1:5173/`: Docked preview stage stayed near 16:9 while dragging the splitter wider and narrower.