### PR TITLE
[codex] Cover docked preview while preserving aspect

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -429,36 +429,70 @@ function getPreviewSurfaceParent() {
   return isPreviewDockedInPanels() ? elements.previewStage : document.body;
 }
 
-function layoutDockedPreviewStage() {
+function getDockedPreviewRenderRect() {
   const stage = elements.previewStage;
-  if (!stage) return;
+  if (!stage) return null;
 
   if (!isPreviewDockedInPanels()) {
-    stage.style.width = '';
-    stage.style.height = '';
-    return;
+    return null;
   }
 
-  const pane = stage.closest('.preview-pane');
-  if (!pane) return;
-
-  const header = pane.querySelector('.pane-header');
-  const availableWidth = Math.max(1, pane.clientWidth);
-  const availableHeight = Math.max(1, pane.clientHeight - (header?.offsetHeight || 0));
+  const availableWidth = Math.max(1, stage.clientWidth);
+  const availableHeight = Math.max(1, stage.clientHeight);
   const availableAspect = availableWidth / availableHeight;
 
-  let width;
-  let height;
+  let width = availableWidth;
+  let height = availableHeight;
   if (availableAspect > DOCKED_PREVIEW_ASPECT_RATIO) {
-    height = availableHeight;
-    width = height * DOCKED_PREVIEW_ASPECT_RATIO;
-  } else {
     width = availableWidth;
     height = width / DOCKED_PREVIEW_ASPECT_RATIO;
+  } else {
+    height = availableHeight;
+    width = height * DOCKED_PREVIEW_ASPECT_RATIO;
   }
 
-  stage.style.width = `${Math.floor(width)}px`;
-  stage.style.height = `${Math.floor(height)}px`;
+  return {
+    width: Math.max(1, Math.floor(width)),
+    height: Math.max(1, Math.floor(height)),
+    left: Math.floor((availableWidth - width) / 2),
+    top: Math.floor((availableHeight - height) / 2)
+  };
+}
+
+function applyPreviewSurfaceLayout() {
+  if (isPreviewDockedInPanels()) {
+    const rect = getDockedPreviewRenderRect();
+    if (!rect) return { width: 1, height: 1 };
+
+    for (const element of [elements.previewCanvas, elements.scene3dHost]) {
+      if (!element) continue;
+      element.style.left = `${rect.left}px`;
+      element.style.top = `${rect.top}px`;
+      element.style.width = `${rect.width}px`;
+      element.style.height = `${rect.height}px`;
+    }
+
+    return { width: rect.width, height: rect.height };
+  }
+
+  if (elements.previewCanvas) {
+    elements.previewCanvas.style.left = '';
+    elements.previewCanvas.style.top = '';
+    elements.previewCanvas.style.width = `${window.innerWidth}px`;
+    elements.previewCanvas.style.height = `${window.innerHeight}px`;
+  }
+
+  if (elements.scene3dHost) {
+    elements.scene3dHost.style.left = '';
+    elements.scene3dHost.style.top = '';
+    elements.scene3dHost.style.width = '';
+    elements.scene3dHost.style.height = '';
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight
+  };
 }
 
 function mountPreviewSurface() {
@@ -472,19 +506,7 @@ function mountPreviewSurface() {
 }
 
 function getPreviewSurfaceSize() {
-  if (isPreviewDockedInPanels()) {
-    layoutDockedPreviewStage();
-    const rect = elements.previewStage.getBoundingClientRect();
-    return {
-      width: Math.max(1, Math.floor(rect.width)),
-      height: Math.max(1, Math.floor(rect.height))
-    };
-  }
-
-  return {
-    width: window.innerWidth,
-    height: window.innerHeight
-  };
+  return applyPreviewSurfaceLayout();
 }
 
 function applyDockedEditorTab() {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -261,7 +261,7 @@ body.preview-layout-docked:not(.panels-hidden) .preview-pane {
   display: flex;
   grid-column: 1;
   grid-row: 1 / 3;
-  align-items: center;
+  align-items: stretch;
 }
 
 body.preview-layout-docked:not(.panels-hidden) .preview-pane > .pane-header {
@@ -328,19 +328,17 @@ body.preview-layout-docked:not(.panels-hidden) .node-pane > .pane-header {
 }
 
 body.preview-layout-docked:not(.panels-hidden) .preview-stage {
-  flex: 0 0 auto;
-  align-self: center;
-  max-width: 100%;
-  max-height: 100%;
-  margin: auto 0;
+  flex: 1 1 auto;
+  align-self: stretch;
+  width: 100%;
+  height: auto;
+  margin: 0;
 }
 
 body.preview-layout-docked:not(.panels-hidden) .preview-stage > .preview-canvas,
 body.preview-layout-docked:not(.panels-hidden) .preview-stage > .scene3d-host {
   position: absolute;
-  inset: 0;
-  width: 100% !important;
-  height: 100% !important;
+  inset: auto;
 }
 
 body.preview-layout-docked:not(.panels-hidden) .preview-stage > .scene3d-host {


### PR DESCRIPTION
## Summary
- Change docked preview sizing from contain/letterbox to cover/crop behavior.
- Keep the preview pane fully filled while the rendered canvas/3D host preserves the 16:9 render aspect.
- Center the render surface so narrow panes crop horizontally and wide panes crop vertically.

## Validation
- `npm run build` in `editor-studio`
- `git diff --check`
- Browser smoke check on `http://127.0.0.1:5173/`: docked preview canvas stayed ~16:9 while covering the preview stage in both narrow and wide pane shapes.

Note: `npm test` is not available in `editor-studio` because no `test` script is defined.