### PR TITLE
DSL editor: live inline value overlay

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -68,6 +68,7 @@
         <div class="pane-header">
           <h2>DSL Editor</h2>
           <div class="pane-controls">
+            <button id="dslValueInlayBtn" class="btn-icon" data-action="toggle-value-inlay" title="Hide inline values" aria-pressed="true">⟦⟧</button>
             <button class="btn-icon" data-action="maximize-dsl" title="Maximize DSL Editor" style="display: none;">↗</button>
             <button class="btn-icon" data-action="restore-split" title="Restore Split View" style="display: none;">↙</button>
           </div>

--- a/editor-studio/src/dsl-value-inlay.js
+++ b/editor-studio/src/dsl-value-inlay.js
@@ -1,0 +1,108 @@
+import { StateField, StateEffect, RangeSetBuilder } from '@codemirror/state';
+import { Decoration, EditorView, WidgetType } from '@codemirror/view';
+
+// Effect used to push the latest set of inline values into the editor.
+// Payload: array of { line, text } where `line` is 1-based.
+export const setValueInlaysEffect = StateEffect.define();
+
+// Renders a single end-of-line value badge like ⟦0.42⟧.
+// It is decorative only: not editable, not selectable, and excluded from copy.
+class ValueInlayWidget extends WidgetType {
+  constructor(text) {
+    super();
+    this.text = text;
+  }
+
+  eq(other) {
+    return other instanceof ValueInlayWidget && other.text === this.text;
+  }
+
+  toDOM() {
+    const span = document.createElement('span');
+    span.className = 'cm-loom-value-inlay';
+    span.setAttribute('aria-hidden', 'true');
+    span.textContent = `⟦${this.text}⟧`;
+    return span;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
+function buildDecorations(doc, inlays) {
+  const builder = new RangeSetBuilder();
+  const lineCount = doc.lines;
+
+  const items = [];
+  for (const item of inlays || []) {
+    if (!item || typeof item.line !== 'number') continue;
+    if (item.line < 1 || item.line > lineCount) continue;
+    if (item.text == null || item.text === '') continue;
+    const line = doc.line(item.line);
+    items.push({ pos: line.to, text: item.text });
+  }
+
+  // RangeSetBuilder requires positions added in ascending order.
+  items.sort((a, b) => a.pos - b.pos);
+
+  for (const item of items) {
+    builder.add(
+      item.pos,
+      item.pos,
+      Decoration.widget({
+        widget: new ValueInlayWidget(item.text),
+        side: 1
+      })
+    );
+  }
+
+  return builder.finish();
+}
+
+// Holds the current decoration set. Decorations are mapped through document
+// changes so badges stay attached while typing, and fully rebuilt whenever a
+// fresh set of values arrives via setValueInlaysEffect.
+export const valueInlayField = StateField.define({
+  create() {
+    return Decoration.none;
+  },
+  update(decorations, tr) {
+    let next = decorations.map(tr.changes);
+    for (const effect of tr.effects) {
+      if (effect.is(setValueInlaysEffect)) {
+        next = buildDecorations(tr.state.doc, effect.value);
+      }
+    }
+    return next;
+  },
+  provide: (field) => EditorView.decorations.from(field)
+});
+
+const valueInlayTheme = EditorView.theme({
+  '.cm-loom-value-inlay': {
+    marginLeft: '1.5ch',
+    padding: '0 0.4ch',
+    color: 'rgba(130, 170, 255, 0.6)',
+    fontStyle: 'normal',
+    fontSize: '0.92em',
+    fontFamily: 'Monaco, Menlo, Consolas, monospace',
+    userSelect: 'none',
+    pointerEvents: 'none',
+    whiteSpace: 'pre'
+  }
+});
+
+export function valueInlayExtensions() {
+  return [valueInlayField, valueInlayTheme];
+}
+
+// Push a new set of inline values to the editor. `inlays` is an array of
+// { line, text }. Passing an empty array clears all badges.
+export function dispatchValueInlays(view, inlays) {
+  if (!view) return;
+  view.dispatch({ effects: setValueInlaysEffect.of(inlays || []) });
+}
+
+// Exposed for unit testing the line -> decoration mapping.
+export { buildDecorations as __buildDecorationsForTest };

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -8,8 +8,9 @@ import { forceLinting } from '@codemirror/lint';
 
 import { Loom, NODE_TYPES } from '../../src/loom.js';
 import { describeGraphHostCompatibility } from '../../src/runtime/capabilities.js';
-import { getLatestNodeValues } from '../../src/value-preview.js';
+import { getLatestNodeValues, formatValuePreview } from '../../src/value-preview.js';
 import { loomletDslExtensions } from './loomlet-codemirror.js';
+import { valueInlayExtensions, dispatchValueInlays } from './dsl-value-inlay.js';
 import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
 import { compileLoomToSceneSyncGraph } from '../../src/scenesync/graph-adapter.js';
 import { createSceneGraphSetPayload } from '../../src/scenesync/graphs.js';
@@ -99,6 +100,7 @@ const MAX_HISTORY_ENTRIES = 100;
 const MOVE_HISTORY_COALESCE_MS = 250;
 const PARAM_HISTORY_COALESCE_MS = 750;
 const NODE_VALUE_PREVIEW_INTERVAL_MS = 100;
+const VALUE_INLAY_STORAGE_KEY = 'loomlet.dslValueInlay';
 
 let outputEntries = [];
 const MAX_OUTPUT_ENTRIES = 500;
@@ -156,12 +158,14 @@ let editorMaximizeMode = 'split';
 let previewLayoutMode = 'background';
 let dockedEditorTab = 'node';
 let lastNodeValuePreviewAtMs = 0;
+let valueInlayEnabled = readValueInlayPreference();
 let previewEventQueue = [];
 let previewEventScopeId = '';
 let previewEventSequence = 0;
 
 const elements = {
   dslEditorHost: document.getElementById('dsl-editor-host'),
+  dslValueInlayBtn: document.getElementById('dslValueInlayBtn'),
   nodeEditorHost: document.getElementById('node-editor'),
   previewCanvas: document.getElementById('preview-canvas'),
   previewStage: document.getElementById('preview-stage'),
@@ -859,6 +863,7 @@ function initDslEditor() {
         nodeTypes: NODE_TYPES,
         getErrors: () => store.getState().errors || []
       }),
+      ...valueInlayExtensions(),
       EditorView.updateListener.of((update) => {
         if (!update.docChanged) return;
         if (isApplyingProgrammaticDslChange) return;
@@ -2369,12 +2374,105 @@ function tick(engine, graph) {
 }
 
 function postNodeValuePreviews(engineInstance, graph) {
-  if (!nodeEditor || !engineInstance || !graph) return;
+  if (!engineInstance || !graph) return;
   const now = performance.now();
   if (now - lastNodeValuePreviewAtMs < NODE_VALUE_PREVIEW_INTERVAL_MS) return;
   lastNodeValuePreviewAtMs = now;
 
-  nodeEditor.setNodeValuePreviews(getLatestNodeValues(engineInstance, graph, NODE_TYPES));
+  const values = getLatestNodeValues(engineInstance, graph, NODE_TYPES);
+  nodeEditor?.setNodeValuePreviews(values);
+  updateDslValueInlays(values, graph);
+}
+
+function readValueInlayPreference() {
+  try {
+    return localStorage.getItem(VALUE_INLAY_STORAGE_KEY) !== '0';
+  } catch {
+    return true;
+  }
+}
+
+// Walk top-level assignment statements. The DSL compiles each assignment's
+// target name into a graph node with the same id, so the left-hand name doubles
+// as the node id we look up runtime values by.
+function collectAssignmentInlayTargets(ast) {
+  const targets = [];
+  if (!ast || !Array.isArray(ast.body)) return targets;
+
+  for (const statement of ast.body) {
+    if (statement?.type !== 'AssignmentStatement') continue;
+    const nodeId = statement.target?.name;
+    const line = statement.span?.start?.line;
+    if (!nodeId || typeof line !== 'number') continue;
+    targets.push({ line, nodeId });
+  }
+
+  return targets;
+}
+
+function formatInlayValue(value, nodeType) {
+  // Event sources emit an array of events; the array contents are noise, so we
+  // summarize as a count instead.
+  if (nodeType === 'onEvent' && Array.isArray(value)) {
+    return value.length === 1 ? '1 event' : `${value.length} events`;
+  }
+  return formatValuePreview(value);
+}
+
+function updateDslValueInlays(values, graph) {
+  if (!dslEditor) return;
+  if (!valueInlayEnabled) return;
+
+  // While the editor text is ahead of the applied graph, the stored AST line
+  // numbers no longer match what is on screen. Leave the existing badges in
+  // place (the decoration field tracks them through edits) until the next
+  // apply re-syncs the source map.
+  if (hasUnsyncedDslText) return;
+
+  const ast = store.getState().sourceAst;
+  const targets = collectAssignmentInlayTargets(ast);
+  if (targets.length === 0) {
+    dispatchValueInlays(dslEditor, []);
+    return;
+  }
+
+  const nodeTypeById = new Map();
+  for (const node of graph?.nodes || []) {
+    nodeTypeById.set(node.id, node.type);
+  }
+
+  const inlays = [];
+  for (const { line, nodeId } of targets) {
+    if (!values.has(nodeId)) continue;
+    const value = values.get(nodeId);
+    if (value === undefined) continue;
+    inlays.push({ line, text: formatInlayValue(value, nodeTypeById.get(nodeId)) });
+  }
+
+  dispatchValueInlays(dslEditor, inlays);
+}
+
+function setValueInlayEnabled(enabled) {
+  valueInlayEnabled = enabled;
+  try {
+    localStorage.setItem(VALUE_INLAY_STORAGE_KEY, enabled ? '1' : '0');
+  } catch {
+    // Ignore storage failures (e.g. private mode); preference stays in-memory.
+  }
+  renderValueInlayToggle();
+  if (!enabled && dslEditor) {
+    dispatchValueInlays(dslEditor, []);
+  }
+}
+
+function renderValueInlayToggle() {
+  const btn = elements.dslValueInlayBtn;
+  if (!btn) return;
+  btn.classList.toggle('active', valueInlayEnabled);
+  btn.setAttribute('aria-pressed', valueInlayEnabled ? 'true' : 'false');
+  btn.title = valueInlayEnabled
+    ? 'Hide inline values'
+    : 'Show inline values';
 }
 
 function resolveValue(engine, ref) {
@@ -3211,6 +3309,10 @@ function setupEventListeners() {
   elements.saveFileBtn.addEventListener('click', saveDslFile);
   elements.saveAsFileBtn.addEventListener('click', saveDslAsFile);
 
+  elements.dslValueInlayBtn?.addEventListener('click', () => {
+    setValueInlayEnabled(!valueInlayEnabled);
+  });
+
   elements.editorPanels?.querySelectorAll('[data-action="maximize-dsl"]').forEach(btn => {
     btn.addEventListener('click', () => setEditorMaximizeMode('dsl'));
   });
@@ -3480,6 +3582,7 @@ async function init() {
   renderAutoApplyStatus();
   renderAutoSyncGraphToDslStatus();
   renderUndoRedoState();
+  renderValueInlayToggle();
   renderNodePaletteCategories();
   renderNodePalette();
   updateNodeListCategories();

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -11,7 +11,7 @@ import { describeGraphHostCompatibility } from '../../src/runtime/capabilities.j
 import { getLatestNodeValues, formatValuePreview } from '../../src/value-preview.js';
 import { loomletDslExtensions } from './loomlet-codemirror.js';
 import { valueInlayExtensions, dispatchValueInlays } from './dsl-value-inlay.js';
-import { parseDSLToAST, compileToGraph } from '../../src/loom-dsl.js';
+import { parseDSLToAST, compileToGraph, defaultOutputPort } from '../../src/loom-dsl.js';
 import { compileLoomToSceneSyncGraph } from '../../src/scenesync/graph-adapter.js';
 import { createSceneGraphSetPayload } from '../../src/scenesync/graphs.js';
 import { reduceSceneEffectsToObjects, graphHasSceneNodes } from '../../src/scenesync/preview-transform.js';
@@ -158,7 +158,8 @@ let editorMaximizeMode = 'split';
 let previewLayoutMode = 'background';
 let dockedEditorTab = 'node';
 let lastNodeValuePreviewAtMs = 0;
-let valueInlayEnabled = readValueInlayPreference();
+const VALUE_INLAY_MODES = ['off', 'compact', 'verbose'];
+let valueInlayMode = readValueInlayMode();
 let previewEventQueue = [];
 let previewEventScopeId = '';
 let previewEventSequence = 0;
@@ -2384,34 +2385,54 @@ function postNodeValuePreviews(engineInstance, graph) {
   updateDslValueInlays(values, graph);
 }
 
-function readValueInlayPreference() {
+function readValueInlayMode() {
   try {
-    return localStorage.getItem(VALUE_INLAY_STORAGE_KEY) !== '0';
+    const raw = localStorage.getItem(VALUE_INLAY_STORAGE_KEY);
+    if (raw === '0') return 'off';        // legacy boolean storage
+    if (raw === '1') return 'compact';    // legacy boolean storage
+    if (VALUE_INLAY_MODES.includes(raw)) return raw;
   } catch {
-    return true;
+    // Ignore storage failures; fall through to the default.
   }
+  return 'compact';
 }
 
-// Walk top-level assignment statements. The DSL compiles each assignment's
-// target name into a graph node with the same id, so the left-hand name doubles
-// as the node id we look up runtime values by.
-function collectAssignmentInlayTargets(ast) {
+function effectCallName(expr) {
+  if (!expr) return 'effect';
+  if (expr.type === 'CallExpression') return expr.callee?.name || 'effect';
+  if (expr.type === 'PipeExpression') return effectCallName(expr.right);
+  if (expr.type === 'MemberExpression') return expr.property?.name || 'effect';
+  return 'effect';
+}
+
+// Walk top-level statements and map each to the graph entity it produces:
+//  - assignments compile to a node whose id equals the target name
+//  - effect/sink expressions compile to sequential `_effectN` nodes
+//  - render statements populate graph.render (not a node)
+function collectInlayTargets(ast) {
   const targets = [];
   if (!ast || !Array.isArray(ast.body)) return targets;
 
+  let effectCounter = 0;
   for (const statement of ast.body) {
-    if (statement?.type !== 'AssignmentStatement') continue;
-    const nodeId = statement.target?.name;
-    const line = statement.span?.start?.line;
-    if (!nodeId || typeof line !== 'number') continue;
-    targets.push({ line, nodeId });
+    const line = statement?.span?.start?.line;
+    if (typeof line !== 'number') continue;
+
+    if (statement.type === 'AssignmentStatement' && statement.target?.name) {
+      targets.push({ kind: 'assignment', line, nodeId: statement.target.name, name: statement.target.name });
+    } else if (statement.type === 'ExpressionStatement') {
+      effectCounter += 1;
+      targets.push({ kind: 'effect', line, nodeId: `_effect${effectCounter}`, name: effectCallName(statement.expression) });
+    } else if (statement.type === 'RenderStatement') {
+      targets.push({ kind: 'render', line });
+    }
   }
 
   return targets;
 }
 
-function formatInlayValue(value, nodeType) {
-  // Event sources emit an array of events; the array contents are noise, so we
+function formatScalarValue(value, nodeType) {
+  // Event sources emit an array of events; the contents are noise, so we
   // summarize as a count instead.
   if (nodeType === 'onEvent' && Array.isArray(value)) {
     return value.length === 1 ? '1 event' : `${value.length} events`;
@@ -2419,9 +2440,68 @@ function formatInlayValue(value, nodeType) {
   return formatValuePreview(value);
 }
 
+// Resolve a graph ref (e.g. "x.out") or literal to its latest value.
+function resolveRefValue(values, ref) {
+  if (typeof ref === 'number') return ref;
+  if (typeof ref !== 'string') return undefined;
+  const dot = ref.indexOf('.');
+  const nodeId = dot >= 0 ? ref.slice(0, dot) : ref;
+  const port = dot >= 0 ? ref.slice(dot + 1) : null;
+  const value = values.get(nodeId);
+  if (port && value && typeof value === 'object' && !Array.isArray(value) && port in value) {
+    return value[port];
+  }
+  return value;
+}
+
+function formatInlayTarget(target, values, nodeTypeById, graph) {
+  const verbose = valueInlayMode === 'verbose';
+
+  if (target.kind === 'assignment') {
+    if (!values.has(target.nodeId)) return null;
+    const value = values.get(target.nodeId);
+    if (value === undefined) return null;
+    const nodeType = nodeTypeById.get(target.nodeId);
+    const text = formatScalarValue(value, nodeType);
+    if (verbose) {
+      return `${target.name}.${defaultOutputPort(nodeType, NODE_TYPES)} = ${text}`;
+    }
+    return text;
+  }
+
+  if (target.kind === 'effect') {
+    // Most sinks (scene.setColor, ...) have no output, so we just label the
+    // line with the effect name. Sinks that do expose a value (e.g. log) show
+    // it inline.
+    const value = values.get(target.nodeId);
+    const hasValue = value !== undefined;
+    if (verbose) {
+      return hasValue ? `effect: ${target.name} = ${formatValuePreview(value)}` : `effect: ${target.name}`;
+    }
+    return hasValue ? `${target.name}: ${formatValuePreview(value)}` : target.name;
+  }
+
+  if (target.kind === 'render') {
+    const render = graph?.render;
+    if (!render) return null;
+    const fmt = (v) => (v === undefined ? '—' : formatValuePreview(v));
+    let body;
+    if (render.type === 'point') {
+      body = `point(${fmt(resolveRefValue(values, render.x))}, ${fmt(resolveRefValue(values, render.y))})`;
+    } else if (render.type === 'bar') {
+      body = `bar(${fmt(resolveRefValue(values, render.width))})`;
+    } else {
+      body = String(render.type || 'render');
+    }
+    return verbose ? `render: ${body}` : body;
+  }
+
+  return null;
+}
+
 function updateDslValueInlays(values, graph) {
   if (!dslEditor) return;
-  if (!valueInlayEnabled) return;
+  if (valueInlayMode === 'off') return;
 
   // While the editor text is ahead of the applied graph, the stored AST line
   // numbers no longer match what is on screen. Leave the existing badges in
@@ -2430,7 +2510,7 @@ function updateDslValueInlays(values, graph) {
   if (hasUnsyncedDslText) return;
 
   const ast = store.getState().sourceAst;
-  const targets = collectAssignmentInlayTargets(ast);
+  const targets = collectInlayTargets(ast);
   if (targets.length === 0) {
     dispatchValueInlays(dslEditor, []);
     return;
@@ -2442,25 +2522,30 @@ function updateDslValueInlays(values, graph) {
   }
 
   const inlays = [];
-  for (const { line, nodeId } of targets) {
-    if (!values.has(nodeId)) continue;
-    const value = values.get(nodeId);
-    if (value === undefined) continue;
-    inlays.push({ line, text: formatInlayValue(value, nodeTypeById.get(nodeId)) });
+  for (const target of targets) {
+    const text = formatInlayTarget(target, values, nodeTypeById, graph);
+    if (text != null && text !== '') {
+      inlays.push({ line: target.line, text });
+    }
   }
 
   dispatchValueInlays(dslEditor, inlays);
 }
 
-function setValueInlayEnabled(enabled) {
-  valueInlayEnabled = enabled;
+function cycleValueInlayMode() {
+  const idx = VALUE_INLAY_MODES.indexOf(valueInlayMode);
+  setValueInlayMode(VALUE_INLAY_MODES[(idx + 1) % VALUE_INLAY_MODES.length]);
+}
+
+function setValueInlayMode(mode) {
+  valueInlayMode = VALUE_INLAY_MODES.includes(mode) ? mode : 'compact';
   try {
-    localStorage.setItem(VALUE_INLAY_STORAGE_KEY, enabled ? '1' : '0');
+    localStorage.setItem(VALUE_INLAY_STORAGE_KEY, valueInlayMode);
   } catch {
     // Ignore storage failures (e.g. private mode); preference stays in-memory.
   }
   renderValueInlayToggle();
-  if (!enabled && dslEditor) {
+  if (valueInlayMode === 'off' && dslEditor) {
     dispatchValueInlays(dslEditor, []);
   }
 }
@@ -2468,11 +2553,11 @@ function setValueInlayEnabled(enabled) {
 function renderValueInlayToggle() {
   const btn = elements.dslValueInlayBtn;
   if (!btn) return;
-  btn.classList.toggle('active', valueInlayEnabled);
-  btn.setAttribute('aria-pressed', valueInlayEnabled ? 'true' : 'false');
-  btn.title = valueInlayEnabled
-    ? 'Hide inline values'
-    : 'Show inline values';
+  const on = valueInlayMode !== 'off';
+  btn.classList.toggle('active', on);
+  btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+  btn.textContent = valueInlayMode === 'verbose' ? '⟦⟧+' : '⟦⟧';
+  btn.title = `Inline values: ${valueInlayMode} (click to change)`;
 }
 
 function resolveValue(engine, ref) {
@@ -3310,7 +3395,7 @@ function setupEventListeners() {
   elements.saveAsFileBtn.addEventListener('click', saveDslAsFile);
 
   elements.dslValueInlayBtn?.addEventListener('click', () => {
-    setValueInlayEnabled(!valueInlayEnabled);
+    cycleValueInlayMode();
   });
 
   elements.editorPanels?.querySelectorAll('[data-action="maximize-dsl"]').forEach(btn => {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -459,6 +459,12 @@ body.preview-layout-docked:not(.panels-hidden) .scene3d-click-status {
   transform: scale(0.95);
 }
 
+.btn-icon.active {
+  color: #82aaff;
+  border-color: rgba(130, 170, 255, 0.5);
+  background: rgba(130, 170, 255, 0.12);
+}
+
 .dsl-editor-host {
   flex: 1;
   overflow: hidden;

--- a/src/loom-dsl.js
+++ b/src/loom-dsl.js
@@ -331,7 +331,7 @@ export function parseDSLToAST(source) {
   }
 }
 
-function defaultOutputPort(nodeTypeName, nodeTypes = NODE_TYPES) {
+export function defaultOutputPort(nodeTypeName, nodeTypes = NODE_TYPES) {
   if (nodeTypeName === 'clock') return 't';
   if (nodeTypeName === 'pointerPosition') return 'pos';
   const def = nodeTypes[nodeTypeName];


### PR DESCRIPTION
## Summary

Shows each top-level statement's current runtime value as a faint, non-editable end-of-line badge (`⟦value⟧`) in the web DSL editor, updated live while the preview runs. This makes Loomlet's data flow visible directly in the source — the dataflow equivalent of removing `console.log`.

```loom
click = onEvent(channel: "pointer.click")          ⟦0 events⟧
clickCount = list.length(list: click)              ⟦0⟧
clicked = logic.greaterThan(value: clickCount, other: 0) ⟦false⟧
flash = integrate(value: drive, initial: 0, min: 0, max: 1) ⟦0.00⟧
scene.setColor(r: r, g: g, b: b)                   ⟦scene.setColor⟧
render point(x: x, y: y)                           ⟦point(0.42, 0.42)⟧
```

## What's covered

- **Assignments** — the left-hand name compiles to a graph node with the same id, so the name doubles as the node id we look up the latest value by.
- **Effect / sink statements** — each top-level expression statement maps to its compiled `_effectN` node; the line is labelled with the effect name (e.g. `scene.setColor`). Sinks that expose a value, like `log`, show it inline (`log: 0.42`).
- **Render statements** — the resolved render output is shown live, e.g. `point(x, y)` or `bar(width)`, by resolving the render config's refs against the latest value snapshot.

## Display modes

A three-state toggle in the DSL pane header cycles **off → compact → verbose** (persisted to localStorage):

- **Compact** — `0.42`, `false`, `1 event`, `scene.setColor`, `point(0.42, 0.42)`
- **Verbose** — prefixes each badge with the node id and output port: `flash.out = 0.42`, `click.event = 1 event`, `effect: log = 0.42`, `render: point(...)`

## Implementation notes

- New CodeMirror extension `dsl-value-inlay.js` renders the badges via a decoration `StateField` + `StateEffect`. Badges are decorative only (not selectable, excluded from copy) and track their line through edits.
- Values are pushed from the existing 100 ms preview throttle that already feeds the node editor, so DSL and node previews update from a single value snapshot.
- While the editor text is ahead of the applied graph, badges are left in place (position-tracked) rather than re-dispatched against stale line numbers.
- Event sources are summarized as `N events` instead of dumping the raw array.
- `defaultOutputPort` is exported from `loom-dsl.js` so verbose port labels reuse the compiler's own port resolution instead of duplicating its special cases.

## Intentionally out of scope (the "後回し" list)

Values inside function definitions, per-expression / per-argument values, history/time-series plots, event payload expansion, and per-frame effect-firing highlights (the runtime's effect stream doesn't carry node ids).

## Testing

- `editor-studio` production build passes (`npm run build`).
- End-to-end verification with the real parser / compiler / runtime confirms assignment, effect, render, and verbose formatting (`t.t = 0`, `x.out = 0`, `log: 0`, `effect: log = 0`, `point(0, 0)`).
- DSL test slices (`stabilization-fixtures`, `canonical-dsl-subgraphs`) pass with the new export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nK4RqRz1iUYLAzY5yHoAa)_