### PR TITLE
Route console.* sink output to the Output panel

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1406,11 +1406,41 @@ async function autoApplyDslFromEditor(requestId) {
   }
 }
 
+// Format a console.* effect's value the way a console would: strings print
+// bare, structured values as JSON, primitives via String().
+function formatConsoleEffectValue(value) {
+  if (typeof value === 'string') return value;
+  if (value === undefined) return 'undefined';
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 function appendOutput(entry) {
+  const level = entry.level || 'info';
+  const message = String(entry.message ?? '');
+
+  // Sink nodes (log / console.*) emit an effect every frame, so an unchanging
+  // value would otherwise flood the panel. Collapse consecutive identical
+  // lines into a single entry with a repeat counter, like browser devtools.
+  const last = outputEntries[outputEntries.length - 1];
+  if (last && last.level === level && last.message === message) {
+    last.count += 1;
+    last.time = new Date().toISOString();
+    renderOutput();
+    return;
+  }
+
   outputEntries.push({
     time: new Date().toISOString(),
-    level: entry.level || 'info',
-    message: String(entry.message ?? '')
+    level,
+    message,
+    count: 1
   });
 
   if (outputEntries.length > MAX_OUTPUT_ENTRIES) {
@@ -1442,7 +1472,8 @@ function renderOutput() {
   elements.outputLog.textContent = outputEntries
     .map((entry) => {
       const time = formatOutputTime(entry.time);
-      return `${time} [${entry.level}] ${entry.message}`;
+      const repeat = entry.count > 1 ? ` (x${entry.count})` : '';
+      return `${time} [${entry.level}] ${entry.message}${repeat}`;
     })
     .join('\n');
 }
@@ -2313,6 +2344,11 @@ function tick(engine, graph) {
     for (const effect of effects) {
       if (effect.type === 'log' && effect.message) {
         appendOutput({ level: 'log', message: effect.message });
+      } else if (typeof effect.type === 'string' && effect.type.startsWith('console.')) {
+        appendOutput({
+          level: effect.level || 'log',
+          message: formatConsoleEffectValue(effect.value)
+        });
       } else if (effect.kind === 'event.send') {
         const target = effect.target ? ` -> ${effect.target}` : '';
         const payload = effect.payload !== undefined


### PR DESCRIPTION
## Summary

`console.log` / `console.warn` / `console.error` / `console.table` nodes never showed up anywhere in the editor. They record effects of type `console.*` carrying a `value`, but the studio preview loop only handled the `log` node's `message` effects (and `event.send`), so console output was silently dropped.

This routes the `console.*` effect family to the **Output** panel.

## Changes

- **Route console.* effects** — in the preview tick loop, any effect whose `type` starts with `console.` is appended to the Output panel. The effect's `level` (`log` / `warn` / `error` / `table`) becomes the log line's level, and its `value` is formatted console-style (strings printed bare, structured values as JSON, primitives via `String()`).
- **Collapse repeated lines** — sink nodes evaluate every frame, so logging a steady value would otherwise flood the panel at ~60 lines/sec. `appendOutput` now collapses consecutive identical lines into a single entry with a repeat counter (`(xN)`), matching browser devtools. This also tidies the existing `log` node's output.

## Before / after

```
# before: console.log(value: t) → nothing in Output

# after (a steady value collapses into one line with a counter):
12:00:01 [log] 0.5 (x142)
12:00:03 [error] boom
```

## Testing

- `editor-studio` production build passes (`npm run build`).
- Runtime check confirms `console.log(value: t)` and `console.error(value: "boom")` emit `console.log` / `console.error` effects with the expected `level` and `value`, which now render as `[log] …` / `[error] boom` in the panel.

## Out of scope

Per-level color styling in the Output panel, and routing console output to the browser devtools console (kept to the in-app panel as requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)