### PR TITLE
Fix collapsed docked preview on mobile layout

### DIFF
--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1811,6 +1811,22 @@ button:disabled:hover,
     height: min(260px, 38vh);
   }
 
+  /* Docked preview on mobile: the desktop layout places the preview in a grid
+     column, but the mobile flex-column layout above gives it no size, so the
+     preview stage collapses to zero height and nothing renders. Pin the
+     preview to a visible band at the top and let the active editor (node or
+     DSL, switched via the docked tabs) take the remaining space. */
+  body.preview-layout-docked:not(.panels-hidden) .editor-panels .preview-pane {
+    display: flex;
+    flex: 0 0 auto;
+    height: clamp(160px, 30vh, 320px);
+    width: auto;
+  }
+  body.preview-layout-docked:not(.panels-hidden) .editor-panels .docked-editor-tabs {
+    flex: 0 0 auto;
+    width: auto;
+  }
+
   /* Slightly tighter tab buttons in the bottom panel. */
   .tab-btn {
     padding: 8px 11px;


### PR DESCRIPTION
## Summary

On a phone-width viewport, selecting the **Docked** preview layout showed no preview at all.

In the mobile layout (`@media (max-width: 720px)`) the editor panels switch from a CSS grid to a flex column. The docked-mode preview pane was never given a flex size in that layout, so its `preview-stage` collapsed to zero height. Because the preview canvas is sized from `stage.clientHeight` (`getDockedPreviewRenderRect`), the canvas ended up ~0px tall and nothing rendered.

## Fix

CSS only, inside the existing mobile media query:

- Pin the docked preview to a visible band at the top of the column — `height: clamp(160px, 30vh, 320px)` — so the stage has a real height.
- Keep the docked editor tabs compact (`flex: 0 0 auto`).
- The active editor (node or DSL, switched via the docked tabs) fills the remaining space via the existing `flex: 1 1 0` rule.

The node editor already resizes on layout changes (`notifyNodeEditorLayoutChanged` dispatches a resize and calls `nodeEditor.resize()`), so it picks up the new size with no JS change.

## Verification

Driven with Chromium at a 390×800 viewport against the production build:

- Before the fix the preview stage collapses; after it, the stage measures **376×197** and the canvas **376×211** (real, non-zero).
- Screenshot confirms the preview (the sample's green bar) renders at the top, with the Node/DSL tab switcher and a usable node editor below.
- `editor-studio` production build passes (`npm run build`).

## Out of scope

Background (fullscreen) preview mode on mobile already worked and is unchanged. Tuning the exact preview/editor height split is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nK4RqRz1iUYLAzY5yHoAa)_