### PR TITLE
ノードエディタのOutput値表示をInputと区別できるようにする

### DIFF
--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -542,6 +542,23 @@ body.preview-layout-docked:not(.panels-hidden) .scene3d-click-status {
   user-select: text;
 }
 
+/* Output value readout.
+   The node's computed output value is rendered as a read-only field, which by
+   default looks identical to an editable input. Style it as a green-tinted
+   monospace readout (matching the output socket colour) so it reads as a
+   non-editable output rather than an input field. */
+.node-editor-canvas input[readonly] {
+  background: rgba(76, 175, 80, 0.22) !important;
+  color: #b6f0b3 !important;
+  border: 1px solid rgba(118, 214, 122, 0.75) !important;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace !important;
+  font-weight: 600 !important;
+  text-align: right !important;
+  cursor: default !important;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 /* Graph/Errors panel */
 .graph-errors-panel {
   grid-column: 1 / -1;


### PR DESCRIPTION
## 概要

ノードエディタで、ノードが計算した **Output値の表示** が編集可能な **Input（パラメータ）フィールド** と見た目で区別できなかった問題を修正します。

Output値は内部的に `<input readonly>` としてレンダリングされており、編集可能なInputフィールドと同じ見た目になっていました。これを読み取り専用の出力値だと分かるように、独自スタイルを適用します。

## 変更内容

`editor-studio/src/style.css` の `input[readonly]`（Output値の読み取り表示）に以下を適用:

- 緑系の背景（`rgba(76, 175, 80, 0.22)`）
- 明るい緑＋太字の文字（`#b6f0b3`）
- 緑の枠線（`rgba(118, 214, 122, 0.75)`）
- 等幅フォント・右寄せ

編集可能なInputフィールド（黒背景）はそのままで、Output値だけが緑のリードアウト表示になり一目で区別できます。

## 確認

editor-studio をローカル起動し、computed style とスクリーンショットで適用を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_