### PR TITLE
ノードエディタのノードタイトルにIDを表示する

### DIFF
--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -38,9 +38,19 @@ function getNodeControl(node, key) {
   return node.controls[key] ?? null;
 }
 
+// Title shown on a node. The node id (the DSL variable name, e.g. `wave`) is
+// the most useful identifier when reading a graph, so surface it alongside the
+// label/type descriptor instead of only showing the type.
+function getNodeTitle(editorNode) {
+  const descriptor = editorNode.label || editorNode.type;
+  const id = editorNode.id;
+  if (!id || id === descriptor) return descriptor;
+  return `${id} · ${descriptor}`;
+}
+
 function createReteNode(editorNode, onControl, previewText) {
   const nodeTypeDef = NODE_TYPES[editorNode.type];
-  const displayLabel = editorNode.label || editorNode.type;
+  const displayLabel = getNodeTitle(editorNode);
   const node = new ClassicPreset.Node(displayLabel);
   node.id = editorNode.id;
   node._editorNode = editorNode;


### PR DESCRIPTION
## 概要

ノードエディタのノードタイトルは type のみ（例: `clock`, `sine`）を表示しており、ID（DSLの変数名 `t`, `wave` など）がキャンバス上で見えませんでした。グラフを読む際に最も役立つ識別子であるIDをタイトルに表示します。

## 変更内容

`editor-studio/src/node-editor-view.js`:

- `getNodeTitle()` ヘルパーを追加し、タイトルを **`ID · type`** 形式で表示（例: `wave · sine`, `width · map`, `smooth · smoothLerp`）
- IDを先頭に置き、ノードを識別しやすく
- IDとdescriptor（label || type）が一致する場合は重複を避けてdescriptorのみ表示

タイトル表示のみの変更で、ノードIDによる内部的なエッジ管理などのロジックには影響しません。

## 確認

editor-studio をローカル起動し、表示文字列（`t · clock`, `wave · sine`, ...）とスクリーンショットで確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_