### PR TITLE
ノードエディタ: 自動レイアウト（重なり解消）とパラメータ名ラベル表示

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -97,6 +97,7 @@
           <button id="node-zoom-in-btn" class="node-canvas-btn" title="Zoom in">＋</button>
           <button id="node-zoom-out-btn" class="node-canvas-btn" title="Zoom out">－</button>
           <button id="node-zoom-fit-btn" class="node-canvas-btn" title="Fit all nodes in view">⛶</button>
+          <button id="node-auto-layout-btn" class="node-canvas-btn" title="Auto-arrange nodes to remove overlaps">Auto Layout</button>
           <button id="node-add-btn" class="node-canvas-btn" title="Add node (or right-click on canvas)">Add Node</button>
         </div>
         <div class="node-canvas-hint">Right-click: add node / Drag from Palette / Ctrl+click: multi-select / Del: delete</div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -227,6 +227,7 @@ const elements = {
   nodeZoomInBtn: document.getElementById('node-zoom-in-btn'),
   nodeZoomOutBtn: document.getElementById('node-zoom-out-btn'),
   nodeZoomFitBtn: document.getElementById('node-zoom-fit-btn'),
+  nodeAutoLayoutBtn: document.getElementById('node-auto-layout-btn'),
   nodeAddBtn: document.getElementById('node-add-btn')
 };
 
@@ -3384,6 +3385,7 @@ function setupEventListeners() {
   elements.nodeZoomInBtn?.addEventListener('click', () => nodeEditor?.zoomBy(1.25));
   elements.nodeZoomOutBtn?.addEventListener('click', () => nodeEditor?.zoomBy(0.8));
   elements.nodeZoomFitBtn?.addEventListener('click', () => nodeEditor?.zoomToFit());
+  elements.nodeAutoLayoutBtn?.addEventListener('click', () => nodeEditor?.autoLayout());
   elements.nodeAddBtn?.addEventListener('click', (event) => {
     const rect = event.currentTarget.getBoundingClientRect();
     openCanvasContextMenu({

--- a/editor-studio/src/node-editor-view.js
+++ b/editor-studio/src/node-editor-view.js
@@ -1,8 +1,10 @@
+import React from 'react';
 import { NodeEditor, ClassicPreset } from 'rete';
 import { AreaPlugin, AreaExtensions } from 'rete-area-plugin';
 import { ConnectionPlugin, Presets as ConnectionPresets } from 'rete-connection-plugin';
 import { ReactPlugin, Presets } from 'rete-react-plugin';
 import { NODE_TYPES } from '../../src/loom.js';
+import { layoutFallback } from '../../src/loom-editor-model.js';
 import { extractFormulaVars } from '../../src/nodes/math.js';
 import { formatValuePreview } from '../../src/value-preview.js';
 import {
@@ -25,6 +27,23 @@ import {
 
 const socket = new ClassicPreset.Socket('value');
 const VALUE_PREVIEW_CONTROL_KEY = '__preview';
+
+// Custom control component that renders a parameter name beside its value, so a
+// node's editable fields (e.g. `freq: 0.35`) are self-describing instead of
+// showing a bare value. The control instance carries the label via `paramLabel`
+// (set in createReteNode); controls without one render only the input.
+function LabeledControl(props) {
+  const control = props.data;
+  const label = control?.paramLabel;
+  return React.createElement(
+    'div',
+    { className: 'node-param' },
+    label
+      ? React.createElement('span', { className: 'node-param-label', title: label }, label)
+      : null,
+    React.createElement(Presets.classic.Control, { data: control })
+  );
+}
 
 function getPortName(port) {
   return typeof port === 'string' ? port : port.name;
@@ -94,6 +113,7 @@ function createReteNode(editorNode, onControl, previewText) {
         });
       }
     });
+    ctrl.paramLabel = key;
     node.addControl(key, ctrl);
   }
 
@@ -136,7 +156,13 @@ export class NodeEditorView {
     this.connectionPlugin = new ConnectionPlugin();
     this.renderPlugin = new ReactPlugin();
 
-    this.renderPlugin.addPreset(Presets.classic.setup());
+    this.renderPlugin.addPreset(Presets.classic.setup({
+      customize: {
+        control(data) {
+          return data.payload instanceof ClassicPreset.InputControl ? LabeledControl : null;
+        }
+      }
+    }));
     this.connectionPlugin.addPreset(ConnectionPresets.classic.setup());
 
     this.editor.use(this.area);
@@ -301,6 +327,33 @@ export class NodeEditorView {
       console.warn('zoomToFit failed:', e.message);
       return false;
     }
+  }
+
+  // Re-flow every node using the shared column layout, ignoring current
+  // positions, and persist the result via moveNode operations so the new
+  // layout round-trips through the model/DSL. Returns the number of nodes moved.
+  async autoLayout() {
+    if (!this.currentEditorModel) return 0;
+    const order = this.currentEditorModel.order || [];
+    const nodes = order
+      .map((id) => this.currentEditorModel.nodesById[id])
+      .filter(Boolean)
+      .map((node) => ({
+        id: node.id,
+        type: node.type,
+        category: node.category,
+        params: node.params,
+        inputPorts: node.inputPorts,
+        position: null
+      }));
+    if (nodes.length === 0) return 0;
+
+    const laidOut = layoutFallback(nodes);
+    for (const node of laidOut) {
+      this.onOperation({ type: 'moveNode', id: node.id, position: node.position, source: 'autoLayout' });
+    }
+    await this.zoomToFit();
+    return laidOut.length;
   }
 
   async zoomBy(factor) {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -542,6 +542,33 @@ body.preview-layout-docked:not(.panels-hidden) .scene3d-click-status {
   user-select: text;
 }
 
+/* Parameter row: a small name label next to the value field so each control is
+   self-describing (e.g. "freq" beside its 0.35 input). */
+.node-editor-canvas .node-param {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+.node-editor-canvas .node-param-label {
+  flex: 0 0 auto;
+  min-width: 48px;
+  max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  font-size: 11px;
+  color: #9aa0a6;
+  user-select: none;
+}
+
+.node-editor-canvas .node-param input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 /* Output value readout.
    The node's computed output value is rendered as a read-only field, which by
    default looks identical to an editable input. Style it as a green-tinted

--- a/src/loom-editor-model.js
+++ b/src/loom-editor-model.js
@@ -8,6 +8,30 @@ export const NODE_LAYOUT_STEP_Y = 160;
 export const NODE_LAYOUT_MAX_ROWS = 50;
 export const NODE_LAYOUT_MAX_COLS = 50;
 
+// Vertical breathing room added below a node when stacking the next one in the
+// same column. Chosen so a default-height node reproduces the legacy
+// NODE_LAYOUT_STEP_Y spacing (DEFAULT_NODE_HEIGHT + this gap === STEP_Y).
+export const NODE_LAYOUT_VERTICAL_GAP = NODE_LAYOUT_STEP_Y - DEFAULT_NODE_HEIGHT;
+const NODE_TITLE_ROW = 40;
+const NODE_PORT_ROW = 38;
+const NODE_BODY_PADDING = 20;
+
+// Estimate a node's rendered height from its port/param count so the fallback
+// layout can space tall nodes (e.g. `map`, with many params) without
+// overlapping their neighbours. Nodes with an unknown type fall back to the
+// default height, which keeps spacing identical to the legacy behaviour.
+export function estimateNodeHeight(node) {
+  const def = NODE_TYPES[node?.type];
+  if (!def) return DEFAULT_NODE_HEIGHT;
+  const inputCount = node?.inputPorts?.length ?? def.inputs?.length ?? 0;
+  const outputCount = def.outputs?.length ?? 0;
+  const paramCount = Object.keys(node?.params || {}).length;
+  const valueReadoutRow = 1;
+  const rows = inputCount + outputCount + paramCount + valueReadoutRow;
+  const estimated = NODE_TITLE_ROW + rows * NODE_PORT_ROW + NODE_BODY_PADDING;
+  return Math.max(DEFAULT_NODE_HEIGHT, estimated);
+}
+
 /**
  * @typedef {Object} EditorNode
  * @property {string} id
@@ -121,7 +145,7 @@ export function layoutFallback(nodes) {
     state: 600,
     sink: 900
   };
-  const counts = {};
+  const columnY = {};
   const occupiedPositions = [];
 
   return nodes.map((node) => {
@@ -132,10 +156,13 @@ export function layoutFallback(nodes) {
 
     const category = node.category;
     const x = Object.prototype.hasOwnProperty.call(categoryX, category) ? categoryX[category] : 1200;
-    const idx = counts[category] || 0;
-    counts[category] = idx + 1;
+    const y = columnY[category] || 0;
+    // Advance the column by the actual (estimated) node height so the next node
+    // clears tall nodes. A default-height node keeps the legacy STEP_Y spacing.
+    const step = Math.max(NODE_LAYOUT_STEP_Y, estimateNodeHeight(node) + NODE_LAYOUT_VERTICAL_GAP);
+    columnY[category] = y + step;
 
-    const desiredPosition = { x, y: idx * NODE_LAYOUT_STEP_Y };
+    const desiredPosition = { x, y };
     const finalPosition = findNonOverlappingPosition(desiredPosition, occupiedPositions);
     occupiedPositions.push(finalPosition);
 


### PR DESCRIPTION
## 概要

ノードエディタのUI/UX改善2点です。

### 1. ノード自動レイアウト（重なり解消）

- **根因**: フォールバックレイアウトが全ノードを高さ120px固定で扱っていたため、`map` のようなパラメータの多い背の高いノードが同じ列の隣ノードに重なっていました。
- **対応**: `estimateNodeHeight()` でノードの高さをポート/パラメータ数から推定し、列ごとに累積高さで配置するよう `layoutFallback` を変更。デフォルト高さのノードは従来の `NODE_LAYOUT_STEP_Y` 間隔を維持するため、既存の位置アサーションテストには影響しません。
- **追加**: 現在のグラフを再整列してビューにフィットする「Auto Layout」ボタンを追加。結果は `moveNode` op で永続化され、DSL（meta.position）にも反映されます。

### 2. パラメータ名ラベル表示

- 編集可能なパラメータ欄が値のみの表示で、どのパラメータか判別できませんでした。
- rete のカスタムコントロール（`customize.control`）で各値の横にパラメータ名を表示（例: `freq` 0.35、`inMin` -1）。読み取り専用の出力リードアウト（緑）はラベルなしのまま維持しています。

## 変更ファイル

- `src/loom-editor-model.js` — `estimateNodeHeight()` 追加、`layoutFallback` を高さ考慮の累積配置に変更
- `editor-studio/src/node-editor-view.js` — ラベル付きコントロール、`autoLayout()` メソッド
- `editor-studio/src/style.css` — パラメータ行のスタイル
- `editor-studio/index.html` / `editor-studio/src/main.js` — Auto Layout ボタンと配線

## 確認

- editor-studio ビルド成功
- `loom-editor-model` ブラウザテスト 40/40 パス、subgraph テストもパス
- 実機で重なり解消・パラメータ名表示・Auto Layout ボタン動作をスクリーンショットで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_