### PR TITLE
ノードエディタ: ツールバーの整理（ドロップダウン化・ステータス集約）

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -15,38 +15,46 @@
 
   <div class="studio-overlay">
     <div class="studio-toolbar">
-      <button id="toggle-panels">Hide Editors</button>
-      <button id="openFileBtn" class="btn">Open .loom</button>
-      <button id="saveFileBtn" class="btn btn-primary">Save .loom</button>
-      <button id="saveAsFileBtn" class="btn">Save As</button>
-      <span id="file-status" class="file-status">No file</span>
+      <!-- Primary action -->
       <button id="runPreviewBtn" class="btn btn-success">Run Preview</button>
+
+      <!-- Edit history -->
+      <button id="undo-btn" class="btn btn-icon-text" title="Undo graph edit (Ctrl/Cmd+Z)" disabled>↶</button>
+      <button id="redo-btn" class="btn btn-icon-text" title="Redo graph edit (Ctrl/Cmd+Shift+Z)" disabled>↷</button>
+
+      <!-- File menu -->
+      <div class="toolbar-menu" data-menu="file">
+        <button type="button" class="btn toolbar-menu-trigger" aria-haspopup="true" aria-expanded="false">File ▾</button>
+        <div class="toolbar-menu-list" role="menu">
+          <button id="openFileBtn" type="button" class="toolbar-menu-item" role="menuitem">Open .loom…</button>
+          <button id="saveFileBtn" type="button" class="toolbar-menu-item" role="menuitem">Save .loom</button>
+          <button id="saveAsFileBtn" type="button" class="toolbar-menu-item" role="menuitem">Save As…</button>
+          <div class="toolbar-menu-sep" role="separator"></div>
+          <button id="resetSampleBtn" type="button" class="toolbar-menu-item" role="menuitem">Reset Sample</button>
+        </div>
+      </div>
+
+      <!-- DSL sync menu -->
+      <div class="toolbar-menu" data-menu="dsl">
+        <button type="button" class="btn toolbar-menu-trigger" aria-haspopup="true" aria-expanded="false">DSL ▾</button>
+        <div class="toolbar-menu-list" role="menu">
+          <button id="applyDslBtn" type="button" class="toolbar-menu-item" role="menuitem" title="Apply DSL text to the node graph (also clears edit history)">Apply DSL → Node</button>
+          <button id="generateDslBtn" type="button" class="toolbar-menu-item" role="menuitem" title="Rewrite the DSL editor as canonical text from the graph">Generate Canonical DSL</button>
+        </div>
+      </div>
+
+      <!-- View -->
+      <button id="toggle-panels" class="btn">Hide Editors</button>
       <div class="segmented-control preview-layout-switch" aria-label="Preview layout">
         <button class="segmented-btn active" data-preview-layout="background" title="Use preview as the background">Background</button>
         <button class="segmented-btn" data-preview-layout="docked" title="Dock preview beside the editor">Docked</button>
       </div>
-      <button id="resetSampleBtn" class="btn">Reset Sample</button>
-      <button id="undo-btn" class="btn" title="Undo graph edit (Ctrl/Cmd+Z)" disabled>
-        Undo
-      </button>
-      <button id="redo-btn" class="btn" title="Redo graph edit (Ctrl/Cmd+Shift+Z)" disabled>
-        Redo
-      </button>
-      <button id="applyDslBtn" class="btn btn-primary">Apply DSL → Node</button>
-      <button id="generateDslBtn" class="btn btn-primary">Generate Canonical DSL</button>
-      <div class="toolbar-status" aria-label="Editor status">
-        <span id="dirty-status" class="status-pill">Saved</span>
-        <span
-          id="auto-sync-status-pill"
-          class="status-pill is-on"
-          title="Node edits rewrite DSL as canonical text. Layout-only node moves preserve the current DSL text."
-        >Node-&gt;DSL: live</span>
+
+      <!-- Status (pushed to the right) -->
+      <div class="toolbar-status-cluster" aria-label="Editor status">
+        <span id="file-status" class="file-status" title="Current file">No file</span>
+        <span id="sync-status" class="sync-status" title="DSL ↔ Node sync">Sync: live</span>
       </div>
-      <span
-        id="auto-apply-status"
-        class="auto-apply-status"
-        title="DSL edits apply to the node editor automatically. Fix DSL errors before editing the graph."
-      >DSL-&gt;Node: live</span>
     </div>
 
     <div id="editor-panels" class="editor-panels">

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -204,7 +204,7 @@ const elements = {
   nodeListSearch: document.getElementById('node-list-search'),
   nodeListCategory: document.getElementById('node-list-category'),
   nodeList: document.getElementById('node-list'),
-  autoApplyStatus: document.getElementById('auto-apply-status'),
+  syncStatus: document.getElementById('sync-status'),
   bottomPanel: document.getElementById('bottom-panel'),
   bottomPanelResizeHandle: document.getElementById('bottom-panel-resize-handle'),
   bottomPanelCollapseBtn: document.getElementById('bottom-panel-collapse-btn'),
@@ -212,8 +212,6 @@ const elements = {
   editorSplitResizeHandle: document.getElementById('editor-split-resize-handle'),
   undoBtn: document.getElementById('undo-btn'),
   redoBtn: document.getElementById('redo-btn'),
-  dirtyStatus: document.getElementById('dirty-status'),
-  autoSyncStatusPill: document.getElementById('auto-sync-status-pill'),
   outputLog: document.getElementById('output-log'),
   clearOutputBtn: document.getElementById('clear-output-btn'),
   sceneSyncScope: document.getElementById('sceneSyncScope'),
@@ -909,57 +907,58 @@ function setDirty(dirty) {
 }
 
 function renderFileStatus() {
+  if (!elements.fileStatus) return;
   const label = currentFileName || 'No file';
-  const dirtyMark = isDirty ? ' *' : '';
-  elements.fileStatus.textContent = `${label}${dirtyMark}`;
+  elements.fileStatus.textContent = label;
+  elements.fileStatus.classList.toggle('is-dirty', isDirty);
+  elements.fileStatus.title = isDirty ? `${label} — unsaved changes` : label;
+}
+
+// The two sync directions (DSL->Node auto-apply and Node->DSL auto-sync) are
+// surfaced through a single consolidated "Sync" indicator. Each direction
+// reports independently; the badge reflects the most urgent state and the
+// tooltip spells out both directions.
+let syncApplyState = 'live';
+let syncGraphState = 'live';
+
+function renderSyncStatus() {
+  const el = elements.syncStatus;
+  if (!el) return;
+
+  let label = 'Sync: live';
+  let modifier = '';
+  if (syncApplyState === 'error') {
+    label = 'Sync: error';
+    modifier = ' error';
+  } else if (syncApplyState === 'pending') {
+    label = 'Sync: pending';
+    modifier = ' pending';
+  } else if (syncApplyState === 'ok' || syncGraphState === 'ok') {
+    label = 'Sync: synced';
+    modifier = ' ok';
+  }
+
+  el.textContent = label;
+  el.className = `sync-status${modifier}`;
+
+  const applyText = { pending: 'pending', ok: 'synced', error: 'error' }[syncApplyState] || 'live';
+  const graphText = syncGraphState === 'ok' ? 'synced' : 'live';
+  el.title = `DSL → Node: ${applyText}\nNode → DSL: ${graphText}`;
 }
 
 function renderAutoApplyStatus(status = null) {
-  if (!elements.autoApplyStatus) return;
-
-  if (status === 'pending') {
-    elements.autoApplyStatus.textContent = 'DSL->Node: pending';
-    elements.autoApplyStatus.className = 'auto-apply-status pending';
-    return;
-  }
-
-  if (status === 'ok') {
-    elements.autoApplyStatus.textContent = 'DSL->Node: synced';
-    elements.autoApplyStatus.className = 'auto-apply-status ok';
-    return;
-  }
-
-  if (status === 'error') {
-    elements.autoApplyStatus.textContent = 'DSL->Node: error';
-    elements.autoApplyStatus.className = 'auto-apply-status error';
-    return;
-  }
-
-  elements.autoApplyStatus.textContent = 'DSL->Node: live';
-  elements.autoApplyStatus.className = 'auto-apply-status';
+  syncApplyState = status || 'live';
+  renderSyncStatus();
 }
 
 function renderAutoSyncGraphToDslStatus(status = null) {
-  if (!elements.autoSyncStatusPill) return;
-
-  elements.autoSyncStatusPill.className = 'status-pill';
-
-  if (status === 'ok') {
-    elements.autoSyncStatusPill.textContent = 'Node->DSL: synced';
-    elements.autoSyncStatusPill.classList.add('is-on');
-    return;
-  }
-
-  elements.autoSyncStatusPill.textContent = 'Node->DSL: live';
-  elements.autoSyncStatusPill.classList.add('is-on');
+  syncGraphState = status || 'live';
+  renderSyncStatus();
 }
 
 function renderDirtyStatus() {
-  if (!elements.dirtyStatus) return;
-
-  elements.dirtyStatus.textContent = isDirty ? 'Dirty' : 'Saved';
-  elements.dirtyStatus.classList.toggle('is-dirty', isDirty);
-  elements.dirtyStatus.classList.toggle('is-saved', !isDirty);
+  // Dirty state is shown inline on the file status badge (see renderFileStatus).
+  renderFileStatus();
 }
 
 
@@ -3381,7 +3380,48 @@ function clearEditorHistory() {
   renderUndoRedoState();
 }
 
+// Wire up the toolbar dropdown menus (File ▾, DSL ▾): the trigger toggles its
+// menu, selecting an item or clicking elsewhere closes it. The menu items keep
+// their original IDs, so their actions are wired separately like before.
+function setupToolbarMenus() {
+  const menus = Array.from(document.querySelectorAll('.toolbar-menu'));
+  if (menus.length === 0) return;
+
+  const closeAll = (except = null) => {
+    for (const menu of menus) {
+      if (menu === except) continue;
+      menu.classList.remove('open');
+      menu.querySelector('.toolbar-menu-trigger')?.setAttribute('aria-expanded', 'false');
+    }
+  };
+
+  for (const menu of menus) {
+    const trigger = menu.querySelector('.toolbar-menu-trigger');
+    trigger?.addEventListener('click', () => {
+      const willOpen = !menu.classList.contains('open');
+      closeAll(menu);
+      menu.classList.toggle('open', willOpen);
+      trigger.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    });
+    menu.querySelector('.toolbar-menu-list')?.addEventListener('click', (event) => {
+      if (event.target.closest('.toolbar-menu-item')) closeAll();
+    });
+  }
+
+  // Capture-phase so a pointerdown on the node editor canvas (which stops
+  // propagation) still closes open menus. Pointerdowns inside a menu are left
+  // to the per-menu handlers above.
+  document.addEventListener('pointerdown', (event) => {
+    if (event.target.closest?.('.toolbar-menu')) return;
+    closeAll();
+  }, true);
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') closeAll();
+  });
+}
+
 function setupEventListeners() {
+  setupToolbarMenus();
   elements.nodeZoomInBtn?.addEventListener('click', () => nodeEditor?.zoomBy(1.25));
   elements.nodeZoomOutBtn?.addEventListener('click', () => nodeEditor?.zoomBy(0.8));
   elements.nodeZoomFitBtn?.addEventListener('click', () => nodeEditor?.zoomToFit());

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -3387,12 +3387,21 @@ function setupToolbarMenus() {
   const menus = Array.from(document.querySelectorAll('.toolbar-menu'));
   if (menus.length === 0) return;
 
+  const toolbar = menus[0].closest('.studio-toolbar');
+  // The mobile toolbar is an overflow-clipped horizontal scroll strip, which
+  // would clip an open dropdown. Flag the toolbar while any menu is open so CSS
+  // can lift the clipping (see the .has-open-menu rule).
+  const syncOpenState = () => {
+    toolbar?.classList.toggle('has-open-menu', menus.some((m) => m.classList.contains('open')));
+  };
+
   const closeAll = (except = null) => {
     for (const menu of menus) {
       if (menu === except) continue;
       menu.classList.remove('open');
       menu.querySelector('.toolbar-menu-trigger')?.setAttribute('aria-expanded', 'false');
     }
+    syncOpenState();
   };
 
   for (const menu of menus) {
@@ -3402,6 +3411,7 @@ function setupToolbarMenus() {
       closeAll(menu);
       menu.classList.toggle('open', willOpen);
       trigger.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+      syncOpenState();
     });
     menu.querySelector('.toolbar-menu-list')?.addEventListener('click', (event) => {
       if (event.target.closest('.toolbar-menu-item')) closeAll();

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1900,6 +1900,11 @@ button:disabled:hover,
     scrollbar-width: thin;
     -webkit-overflow-scrolling: touch;
   }
+  /* While a dropdown is open, stop clipping so the menu is visible (the strip
+     is not scrolled during menu interaction). */
+  .studio-toolbar.has-open-menu {
+    overflow: visible;
+  }
   .studio-toolbar > * {
     flex: 0 0 auto;
   }

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -163,6 +163,73 @@ html, body {
   background: rgba(74, 144, 226, 0.35);
 }
 
+/* Compact icon-style toolbar button (Undo / Redo). */
+.btn-icon-text {
+  min-width: 32px;
+  padding: 0 8px;
+  font-size: 16px;
+  line-height: 1;
+}
+
+/* Toolbar dropdown menus (File ▾, DSL ▾). */
+.toolbar-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.toolbar-menu-trigger {
+  white-space: nowrap;
+}
+
+.toolbar-menu.open > .toolbar-menu-trigger {
+  background: rgba(74, 144, 226, 0.35);
+  color: #ffffff;
+}
+
+.toolbar-menu-list {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 180px;
+  display: none;
+  flex-direction: column;
+  padding: 4px;
+  gap: 1px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(28, 28, 30, 0.98);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  z-index: 30;
+}
+
+.toolbar-menu.open > .toolbar-menu-list {
+  display: flex;
+}
+
+.toolbar-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-color);
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.toolbar-menu-item:hover {
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.toolbar-menu-sep {
+  height: 1px;
+  margin: 4px 6px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
 /* Editor panels */
 .editor-panels {
   position: fixed;
@@ -922,13 +989,34 @@ button:disabled:hover,
 }
 
 .file-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   color: var(--text-dim);
   font-size: 12px;
-  padding: 0 8px;
+  padding: 0 4px;
   white-space: nowrap;
-  max-width: 220px;
+  max-width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Dirty indicator dot: dim when saved, amber when there are unsaved changes. */
+.file-status::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.file-status.is-dirty {
+  color: #e7c66b;
+}
+
+.file-status.is-dirty::before {
+  background: #e7c66b;
 }
 
 /* Node Palette */
@@ -1122,22 +1210,45 @@ button:disabled:hover,
   cursor: pointer;
 }
 
-.auto-apply-status {
-  color: var(--text-dim);
+/* Consolidated DSL<->Node sync indicator. Colour reflects the live state;
+   the full per-direction detail is in the tooltip. */
+.sync-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
   white-space: nowrap;
+  color: var(--text-dim);
+  cursor: default;
 }
 
-.auto-apply-status.pending {
+.sync-status::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #80ed99;
+}
+
+.sync-status.pending {
   color: #e7c66b;
 }
 
-.auto-apply-status.ok {
-  color: #80ed99;
+.sync-status.pending::before {
+  background: #e7c66b;
 }
 
-.auto-apply-status.error {
+.sync-status.ok::before {
+  background: #80ed99;
+}
+
+.sync-status.error {
   color: #ff9b9b;
+}
+
+.sync-status.error::before {
+  background: #ff9b9b;
 }
 
 /* Node List */
@@ -1294,41 +1405,13 @@ button:disabled:hover,
   text-align: center;
 }
 
-.toolbar-status {
+/* Status cluster, pushed to the right edge of the toolbar. */
+.toolbar-status-cluster {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   margin-left: auto;
-}
-
-.status-pill {
-  display: inline-block;
-  padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.58);
-  white-space: nowrap;
-}
-
-.status-pill.is-dirty {
-  color: #ff9b9b;
-  border-color: rgba(255, 155, 155, 0.3);
-  background: rgba(255, 155, 155, 0.08);
-}
-
-.status-pill.is-saved {
-  color: #80ed99;
-  border-color: rgba(128, 237, 153, 0.3);
-  background: rgba(128, 237, 153, 0.08);
-}
-
-.status-pill.is-on {
-  color: #80ed99;
-  border-color: rgba(128, 237, 153, 0.3);
-  background: rgba(128, 237, 153, 0.08);
+  padding: 0 4px;
 }
 
 /* Output panel */


### PR DESCRIPTION
## 概要

メインツールバーが約15項目＋ステータス3で過密になり、~1440px以下で見切れていた問題を、機能カテゴリ別に整理しました。

## 変更内容

**ドロップダウン化**
- **File ▾**: Open / Save / Save As / Reset Sample
- **DSL ▾**: Apply DSL → Node / Generate Canonical DSL

**ステータス集約（右寄せ）**
- ファイル状態: `● ファイル名`（未保存時はドット琥珀＋文字色変化）の1要素に
- 同期状態: DSL→Node と Node→DSL を1つの `Sync` インジケータに統合（両方向はツールチップで表示）

**省スペース化**
- Undo / Redo をアイコンボタン（↶ ↷）に
- Run Preview・Hide Editors・Background/Docked はインライン維持

15項目＋3ステータス →「Run Preview｜↶ ↷｜File▾｜DSL▾｜Hide Editors｜Background/Docked｜● ファイル｜● Sync」に圧縮。

## 実装メモ

- メニュー項目は既存IDを維持し、各アクションの配線は無変更
- メニューは「項目選択／外側 pointerdown（capture phase でノードキャンバスの stopPropagation を回避）／Esc」で閉じる
- 不要になった `status-pill` / `auto-apply-status` / `toolbar-status` のCSSを削除

## モバイル対応

- ≤720px のツールバーは横スクロール式（`overflow` クリップ）でドロップダウンが隠れるため、メニュー表示中だけ `.has-open-menu` でクリップを解除
- 390px 幅で、ドロップダウン全面表示・項目タップ動作・横スクロールでの右側項目到達・未保存ドット表示を確認

## 確認

- editor-studio ビルド成功
- デスクトップ/モバイル両方で Playwright によりメニュー開閉・アクション実行・排他制御・外側クリック/Esc クローズ・エラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_