### PR TITLE
Syncインジケータをエラー時のみ表示に変更

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -53,7 +53,7 @@
       <!-- Status (pushed to the right) -->
       <div class="toolbar-status-cluster" aria-label="Editor status">
         <span id="file-status" class="file-status" title="Current file">No file</span>
-        <span id="sync-status" class="sync-status" title="DSL ↔ Node sync">Sync: live</span>
+        <span id="sync-status" class="sync-status" style="display: none;"></span>
       </div>
     </div>
 

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -914,10 +914,10 @@ function renderFileStatus() {
   elements.fileStatus.title = isDirty ? `${label} — unsaved changes` : label;
 }
 
-// The two sync directions (DSL->Node auto-apply and Node->DSL auto-sync) are
-// surfaced through a single consolidated "Sync" indicator. Each direction
-// reports independently; the badge reflects the most urgent state and the
-// tooltip spells out both directions.
+// DSL<->Node stays in sync automatically, so a constant "synced" badge is just
+// noise. The indicator is therefore quiet by default and only appears when the
+// DSL has errors and changes can't be applied to the graph — the one state the
+// user needs to act on.
 let syncApplyState = 'live';
 let syncGraphState = 'live';
 
@@ -925,25 +925,13 @@ function renderSyncStatus() {
   const el = elements.syncStatus;
   if (!el) return;
 
-  let label = 'Sync: live';
-  let modifier = '';
   if (syncApplyState === 'error') {
-    label = 'Sync: error';
-    modifier = ' error';
-  } else if (syncApplyState === 'pending') {
-    label = 'Sync: pending';
-    modifier = ' pending';
-  } else if (syncApplyState === 'ok' || syncGraphState === 'ok') {
-    label = 'Sync: synced';
-    modifier = ' ok';
+    el.style.display = '';
+    el.textContent = '⚠ DSL error';
+    el.title = 'The DSL has errors, so changes are not applied to the node graph.\nFix the DSL to resume automatic sync.';
+  } else {
+    el.style.display = 'none';
   }
-
-  el.textContent = label;
-  el.className = `sync-status${modifier}`;
-
-  const applyText = { pending: 'pending', ok: 'synced', error: 'error' }[syncApplyState] || 'live';
-  const graphText = syncGraphState === 'ok' ? 'synced' : 'live';
-  el.title = `DSL → Node: ${applyText}\nNode → DSL: ${graphText}`;
 }
 
 function renderAutoApplyStatus(status = null) {

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1210,45 +1210,17 @@ button:disabled:hover,
   cursor: pointer;
 }
 
-/* Consolidated DSL<->Node sync indicator. Colour reflects the live state;
-   the full per-direction detail is in the tooltip. */
+/* DSL<->Node sync indicator. Hidden while sync is healthy (toggled via inline
+   display from JS); only shown when the DSL has errors and can't be applied. */
 .sync-status {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: 12px;
+  font-weight: 600;
   white-space: nowrap;
-  color: var(--text-dim);
-  cursor: default;
-}
-
-.sync-status::before {
-  content: "";
-  flex: 0 0 auto;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #80ed99;
-}
-
-.sync-status.pending {
-  color: #e7c66b;
-}
-
-.sync-status.pending::before {
-  background: #e7c66b;
-}
-
-.sync-status.ok::before {
-  background: #80ed99;
-}
-
-.sync-status.error {
   color: #ff9b9b;
-}
-
-.sync-status.error::before {
-  background: #ff9b9b;
+  cursor: default;
 }
 
 /* Node List */


### PR DESCRIPTION
## 概要

ツールバーの「Sync」インジケータが分かりにくいという指摘を受けた改善です。

DSL↔Nodeは自動同期されており常に正常なため、`Sync: live / synced` を常時表示しても情報量が薄く、かえって「何の同期？」という混乱を生んでいました。

## 変更内容

- 正常時（live / pending / synced）は**非表示**にし、ノイズを排除
- **DSLエラーで反映できない時だけ**、ユーザーが対処すべき状態として赤い `⚠ DSL error` バッジを表示
- ツールチップで「DSLにエラーがあり、ノードグラフへ反映されていない。DSLを直すと自動同期が再開する」旨を説明
- 不要になった pending/ok 用のCSS・ドット装飾を削除

## 確認

- 正常時: Sync非表示（右側は「● ファイル状態」のみ）
- DSLエラー時: 赤い `⚠ DSL error` が出現
- editor-studio ビルド成功、Playwrightで両状態をスクリーンショット確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_