### PR TITLE
SceneSyncタブをグラフJSONペースト運用に簡素化

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -182,43 +182,32 @@
           </div>
           <div id="scene-sync-tab" class="tab-pane">
             <div class="scene-sync-panel">
-              <div class="scene-sync-form-grid">
-                <label>
-                  Scope
-                  <select id="sceneSyncScope">
-                    <option value="object">Object Behavior Graph</option>
-                    <option value="scene">Scene Behavior Graph</option>
-                  </select>
-                </label>
-
-                <label>
-                  Object ID
-                  <input id="sceneSyncObjectId" type="text" placeholder="sample-cube" />
-                </label>
-              </div>
+              <p class="scene-sync-note">
+                Build your motion graph and confirm it in the preview, then
+                <strong>Copy Graph JSON</strong> and paste it onto a selected object in
+                Scene Sync. Pasting an empty graph removes the behavior.
+              </p>
 
               <div class="scene-sync-actions">
-                <button id="compileSceneSyncPayloadBtn" type="button" class="btn">Compile Payload</button>
-                <button id="copySceneSyncPayloadBtn" type="button" class="btn btn-primary" title="Copy the scene-graph-set message JSON, ready to paste onto a Scene Sync object">Copy Payload</button>
-                <button id="copySceneSyncGraphBtn" type="button" class="btn" title="Copy only the behavior graph (nodes/edges) JSON">Copy Graph JSON</button>
+                <button id="copySceneSyncGraphBtn" type="button" class="btn btn-primary" title="Copy the behavior graph JSON (nodes/edges), ready to paste onto a selected Scene Sync object">Copy Graph JSON</button>
               </div>
 
               <div class="scene-sync-preset-actions">
-                <button id="loadSceneSyncJumpPresetBtn" type="button" class="btn">Load Jump Preview</button>
-                <button id="loadSceneSyncCirclePresetBtn" type="button" class="btn">Load Circle Preview</button>
+                <label for="sceneSyncPresetSelect">Sample</label>
+                <select id="sceneSyncPresetSelect">
+                  <option value="">Select a sample…</option>
+                  <option value="jump">Jump (vertical bounce)</option>
+                  <option value="circle">Circle (orbit)</option>
+                </select>
+                <button id="loadSceneSyncPresetBtn" type="button" class="btn">Load</button>
               </div>
-
-              <p class="scene-sync-note">
-                Recommended flow: build your motion graph, confirm it in the preview, then
-                <strong>Copy Payload</strong> and paste it onto your Scene Sync object.
-              </p>
 
               <p class="scene-sync-note">
                 Note: sceneSetPosition currently writes absolute world positions.
                 Use explicit base values in your graph if you want to keep the object near its current location.
               </p>
 
-              <pre id="sceneSyncPayloadPreview" class="scene-sync-payload-preview"></pre>
+              <pre id="sceneSyncGraphPreview" class="scene-sync-payload-preview"></pre>
             </div>
           </div>
         </div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -13,7 +13,6 @@ import { loomletDslExtensions } from './loomlet-codemirror.js';
 import { valueInlayExtensions, dispatchValueInlays } from './dsl-value-inlay.js';
 import { parseDSLToAST, compileToGraph, defaultOutputPort } from '../../src/loom-dsl.js';
 import { compileLoomToSceneSyncGraph } from '../../src/scenesync/graph-adapter.js';
-import { createSceneGraphSetPayload } from '../../src/scenesync/graphs.js';
 import { reduceSceneEffectsToObjects, graphHasSceneNodes } from '../../src/scenesync/preview-transform.js';
 import { Scene3DPreview } from './scene3d-preview.js';
 import {
@@ -91,9 +90,9 @@ const EDITOR_MAXIMIZE_MODE_KEY = 'loomlet.editorStudio.editorMaximizeMode';
 const PREVIEW_LAYOUT_MODE_KEY = 'loomlet.editorStudio.previewLayoutMode';
 const DOCKED_EDITOR_TAB_KEY = 'loomlet.editorStudio.dockedEditorTab';
 
-const SCENE_SYNC_STORAGE_KEYS = {
-  scope: 'loomlet.editorStudio.sceneSync.scope',
-  objectId: 'loomlet.editorStudio.sceneSync.objectId'
+const SCENE_SYNC_PRESETS = {
+  jump: { label: 'Jump (vertical bounce)', source: SCENE_SYNC_JUMP_PRESET },
+  circle: { label: 'Circle (orbit)', source: SCENE_SYNC_CIRCLE_PRESET }
 };
 
 const MAX_HISTORY_ENTRIES = 100;
@@ -214,14 +213,10 @@ const elements = {
   redoBtn: document.getElementById('redo-btn'),
   outputLog: document.getElementById('output-log'),
   clearOutputBtn: document.getElementById('clear-output-btn'),
-  sceneSyncScope: document.getElementById('sceneSyncScope'),
-  sceneSyncObjectId: document.getElementById('sceneSyncObjectId'),
-  compileSceneSyncPayloadBtn: document.getElementById('compileSceneSyncPayloadBtn'),
-  copySceneSyncPayloadBtn: document.getElementById('copySceneSyncPayloadBtn'),
   copySceneSyncGraphBtn: document.getElementById('copySceneSyncGraphBtn'),
-  sceneSyncPayloadPreview: document.getElementById('sceneSyncPayloadPreview'),
-  loadSceneSyncJumpPresetBtn: document.getElementById('loadSceneSyncJumpPresetBtn'),
-  loadSceneSyncCirclePresetBtn: document.getElementById('loadSceneSyncCirclePresetBtn'),
+  sceneSyncGraphPreview: document.getElementById('sceneSyncGraphPreview'),
+  sceneSyncPresetSelect: document.getElementById('sceneSyncPresetSelect'),
+  loadSceneSyncPresetBtn: document.getElementById('loadSceneSyncPresetBtn'),
   nodeZoomInBtn: document.getElementById('node-zoom-in-btn'),
   nodeZoomOutBtn: document.getElementById('node-zoom-out-btn'),
   nodeZoomFitBtn: document.getElementById('node-zoom-fit-btn'),
@@ -1685,32 +1680,6 @@ function setEditorError(message) {
 
 /* Scene Sync panel functions */
 
-function loadSceneSyncSettings() {
-  elements.sceneSyncScope.value =
-    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.scope) || 'object';
-
-  elements.sceneSyncObjectId.value =
-    localStorage.getItem(SCENE_SYNC_STORAGE_KEYS.objectId) || 'sample-cube';
-
-  updateSceneSyncScopeUi();
-}
-
-function saveSceneSyncSettings() {
-  localStorage.setItem(
-    SCENE_SYNC_STORAGE_KEYS.scope,
-    elements.sceneSyncScope.value
-  );
-  localStorage.setItem(
-    SCENE_SYNC_STORAGE_KEYS.objectId,
-    elements.sceneSyncObjectId.value.trim()
-  );
-}
-
-function updateSceneSyncScopeUi() {
-  const isObjectScope = elements.sceneSyncScope.value === 'object';
-  elements.sceneSyncObjectId.disabled = !isObjectScope;
-}
-
 function getCurrentSceneSyncSourceText() {
   const state = store.getState();
 
@@ -1721,66 +1690,23 @@ function getCurrentSceneSyncSourceText() {
   return getDslText();
 }
 
-function getSceneSyncScopeFromUi() {
-  const scope = elements.sceneSyncScope.value;
-
-  if (scope === 'scene') {
-    return 'scene';
-  }
-
-  const objectId = elements.sceneSyncObjectId.value.trim();
-
-  if (!objectId) {
-    throw new Error('Object ID is required for Object Behavior Graph.');
-  }
-
-  return { object: objectId };
-}
-
-function compileCurrentSceneSyncPayload() {
+// Compile the current DSL into a Scene Sync behavior graph ({ nodes, edges }).
+// Scene Sync's paste flow applies the graph to the currently selected object
+// and ignores any envelope/scope, so the editor only needs to emit the graph.
+function compileCurrentSceneSyncGraph() {
   const source = getCurrentSceneSyncSourceText();
-  const scope = getSceneSyncScopeFromUi();
-
-  const result = compileLoomToSceneSyncGraph(source, { scope });
-
-  return createSceneGraphSetPayload(result.scope || scope, result.graph);
+  const result = compileLoomToSceneSyncGraph(source);
+  return result.graph;
 }
 
-function renderSceneSyncPayloadPreview(payload) {
-  if (!elements.sceneSyncPayloadPreview) {
+function renderSceneSyncGraphPreview(graph) {
+  if (!elements.sceneSyncGraphPreview) {
     return;
   }
 
-  elements.sceneSyncPayloadPreview.textContent = payload
-    ? JSON.stringify(payload, null, 2)
+  elements.sceneSyncGraphPreview.textContent = graph
+    ? JSON.stringify(graph, null, 2)
     : '';
-}
-
-async function handleCompileSceneSyncPayload() {
-  try {
-    saveSceneSyncSettings();
-
-    const payload = compileCurrentSceneSyncPayload();
-
-    renderSceneSyncPayloadPreview(payload);
-
-    const state = store.getState();
-    const source = (!hasUnsyncedDslText && state.editorModel)
-      ? 'graph'
-      : 'DSL editor';
-
-    appendOutput({
-      level: 'info',
-      message: `Compiled Scene Sync payload from ${source}.`
-    });
-  } catch (error) {
-    renderSceneSyncPayloadPreview(null);
-
-    appendOutput({
-      level: 'error',
-      message: `Scene Sync compile failed: ${error.message}`
-    });
-  }
 }
 
 async function copyTextToClipboard(text) {
@@ -1806,39 +1732,16 @@ async function copyTextToClipboard(text) {
   }
 }
 
-async function handleCopySceneSyncPayload() {
-  try {
-    saveSceneSyncSettings();
-
-    const payload = compileCurrentSceneSyncPayload();
-    renderSceneSyncPayloadPreview(payload);
-
-    await copyTextToClipboard(JSON.stringify(payload, null, 2));
-
-    appendOutput({
-      level: 'info',
-      message: 'Copied Scene Sync payload (scene-graph-set) to clipboard. Paste it onto your Scene Sync object.'
-    });
-  } catch (error) {
-    appendOutput({
-      level: 'error',
-      message: `Copy Scene Sync payload failed: ${error.message}`
-    });
-  }
-}
-
 async function handleCopySceneSyncGraphJson() {
   try {
-    saveSceneSyncSettings();
+    const graph = compileCurrentSceneSyncGraph();
+    renderSceneSyncGraphPreview(graph);
 
-    const payload = compileCurrentSceneSyncPayload();
-    renderSceneSyncPayloadPreview(payload);
-
-    await copyTextToClipboard(JSON.stringify(payload.graph, null, 2));
+    await copyTextToClipboard(JSON.stringify(graph, null, 2));
 
     appendOutput({
       level: 'info',
-      message: 'Copied Scene Sync behavior graph (nodes/edges) to clipboard.'
+      message: 'Copied Scene Sync behavior graph (nodes/edges). Select an object in Scene Sync and paste to apply.'
     });
   } catch (error) {
     appendOutput({
@@ -2628,6 +2531,16 @@ function loadSceneSyncPreset(name, source) {
     level: 'info',
     message: `Loaded Scene Sync preset: ${name}.`
   });
+}
+
+function handleLoadSceneSyncPreset() {
+  const key = elements.sceneSyncPresetSelect?.value;
+  const preset = key && SCENE_SYNC_PRESETS[key];
+  if (!preset) {
+    appendOutput({ level: 'info', message: 'Select a Scene Sync sample to load.' });
+    return;
+  }
+  loadSceneSyncPreset(preset.label, preset.source);
 }
 
 function renderNodeListItem(node) {
@@ -3548,24 +3461,8 @@ function setupEventListeners() {
   }, true);
 
   // Scene Sync event listeners
-  elements.sceneSyncObjectId?.addEventListener('input', saveSceneSyncSettings);
-
-  elements.sceneSyncScope?.addEventListener('change', () => {
-    updateSceneSyncScopeUi();
-    saveSceneSyncSettings();
-  });
-
-  elements.compileSceneSyncPayloadBtn?.addEventListener('click', handleCompileSceneSyncPayload);
-  elements.copySceneSyncPayloadBtn?.addEventListener('click', handleCopySceneSyncPayload);
   elements.copySceneSyncGraphBtn?.addEventListener('click', handleCopySceneSyncGraphJson);
-
-  elements.loadSceneSyncJumpPresetBtn?.addEventListener('click', () => {
-    loadSceneSyncPreset('Jump Preview', SCENE_SYNC_JUMP_PRESET);
-  });
-
-  elements.loadSceneSyncCirclePresetBtn?.addEventListener('click', () => {
-    loadSceneSyncPreset('Circle Preview', SCENE_SYNC_CIRCLE_PRESET);
-  });
+  elements.loadSceneSyncPresetBtn?.addEventListener('click', handleLoadSceneSyncPreset);
 
   elements.nodePaletteSearch?.addEventListener('input', renderNodePalette);
   elements.nodePaletteCategory?.addEventListener('change', renderNodePalette);
@@ -3737,7 +3634,6 @@ async function init() {
   loadActiveBottomTab();
   loadEditorMaximizeMode();
   loadPreviewLayoutMode();
-  loadSceneSyncSettings();
   renderFileStatus();
   renderDirtyStatus();
   renderAutoApplyStatus();

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1428,43 +1428,6 @@ button:disabled:hover,
   padding: 12px;
 }
 
-.scene-sync-form-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-}
-
-.scene-sync-form-grid label {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.86);
-}
-
-.scene-sync-form-grid input,
-.scene-sync-form-grid select {
-  padding: 6px 8px;
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 3px;
-  color: rgba(255, 255, 255, 0.86);
-  font-family: inherit;
-  font-size: 12px;
-}
-
-.scene-sync-form-grid input:focus,
-.scene-sync-form-grid select:focus {
-  outline: none;
-  border-color: rgba(74, 144, 226, 0.5);
-  background: rgba(0, 0, 0, 0.3);
-}
-
-.scene-sync-form-grid input:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .scene-sync-actions {
   display: flex;
   flex-wrap: wrap;
@@ -1474,8 +1437,28 @@ button:disabled:hover,
 .scene-sync-preset-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
-  margin-top: 12px;
+}
+
+.scene-sync-preset-actions label {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.scene-sync-preset-actions select {
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.86);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.scene-sync-preset-actions select:focus {
+  outline: none;
+  border-color: rgba(74, 144, 226, 0.5);
 }
 
 .scene-sync-note {


### PR DESCRIPTION
## 概要

SceneSync との連携を「直接プロトコル封筒を組む」方式から、「**グラフJSONをコピーして SceneSync 側で選択オブジェクトにペースト**」する運用に切り替えます。

afjk.jp 側の実装（`html/assets/js/scenesync/components/loomlet-graph-clipboard.js` の `parseLoomletGraphClipboardText` と `scene.js` の `tryHandleLoomletGraphPaste`）を確認し、以下を検証しました：

- ペーストされたグラフは **常に選択中オブジェクトへ適用**され、JSON内の `scope`/`objectId` は無視される（MVP仕様）
- **裸のグラフ `{nodes, edges}` だけで適用可能**（`isGraph` は nodes/edges 配列のみ判定）
- `graph.version` は不要、**空グラフ = 振る舞い解除（clear）**

## 変更内容

**削除**（ペーストでは無視される要素）
- `Copy Payload` / `Compile Payload` ボタン
- `Scope` セレクト、`Object ID` 入力、関連の設定保存・localStorageキー
- `createSceneGraphSetPayload` の import（コア関数 `src/scenesync/graphs.js` 自体は他経路用に温存）

**変更・追加**
- `Copy Graph JSON` を主操作に昇格。出力は**裸のグラフ `{nodes, edges}`**（`compileLoomToSceneSyncGraph(source).graph` を直接使用、封筒を作らない）
- プリセットを2ボタンから **サンプル選択ドロップダウン ＋ Load** に変更
- 説明文を「オブジェクト選択 → Copy → ペースト（空グラフで解除）」に更新
- 未使用になった `.scene-sync-form-grid` CSS を削除

## 確認

- editor-studio ビルド成功、削除シンボルの残存参照ゼロ
- 実機（Playwright）：Jumpプリセットをドロップダウンから読込 → Copy Graph JSON が `type`/`scope` を含まない `{nodes:3, edges:2}` の裸グラフを出力することを確認。プレビュー表示・エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_