### PR TITLE
Add four new Scene Sync behavior presets to editor studio

### DIFF
--- a/editor-studio/index.html
+++ b/editor-studio/index.html
@@ -198,6 +198,10 @@
                   <option value="">Select a sample…</option>
                   <option value="jump">Jump (vertical bounce)</option>
                   <option value="circle">Circle (orbit)</option>
+                  <option value="click-color">Click color flash</option>
+                  <option value="float-y">Float Y</option>
+                  <option value="orbit-offset">Orbit offset</option>
+                  <option value="breathing-scale">Breathing scale</option>
                 </select>
                 <button id="loadSceneSyncPresetBtn" type="button" class="btn">Load</button>
               </div>

--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -14,6 +14,12 @@ import { valueInlayExtensions, dispatchValueInlays } from './dsl-value-inlay.js'
 import { parseDSLToAST, compileToGraph, defaultOutputPort } from '../../src/loom-dsl.js';
 import { compileLoomToSceneSyncGraph } from '../../src/scenesync/graph-adapter.js';
 import { reduceSceneEffectsToObjects, graphHasSceneNodes } from '../../src/scenesync/preview-transform.js';
+// Object-scoped Scene Sync behavior samples (omit objectId; the host applies
+// them to the attached/selected object). Imported as raw text from the tour.
+import behaviorClickColor from '../../examples/tour/scenesync/behaviors/01-click-color.loom?raw';
+import behaviorFloatY from '../../examples/tour/scenesync/behaviors/02-float-y.loom?raw';
+import behaviorOrbitOffset from '../../examples/tour/scenesync/behaviors/03-orbit-offset.loom?raw';
+import behaviorBreathingScale from '../../examples/tour/scenesync/behaviors/04-breathing-scale.loom?raw';
 import { Scene3DPreview } from './scene3d-preview.js';
 import {
   graphToEditorModel,
@@ -92,7 +98,11 @@ const DOCKED_EDITOR_TAB_KEY = 'loomlet.editorStudio.dockedEditorTab';
 
 const SCENE_SYNC_PRESETS = {
   jump: { label: 'Jump (vertical bounce)', source: SCENE_SYNC_JUMP_PRESET },
-  circle: { label: 'Circle (orbit)', source: SCENE_SYNC_CIRCLE_PRESET }
+  circle: { label: 'Circle (orbit)', source: SCENE_SYNC_CIRCLE_PRESET },
+  'click-color': { label: 'Click color flash', source: behaviorClickColor },
+  'float-y': { label: 'Float Y', source: behaviorFloatY },
+  'orbit-offset': { label: 'Orbit offset', source: behaviorOrbitOffset },
+  'breathing-scale': { label: 'Breathing scale', source: behaviorBreathingScale }
 };
 
 const MAX_HISTORY_ENTRIES = 100;


### PR DESCRIPTION
## Summary
This PR adds four new object-scoped Scene Sync behavior presets to the editor studio, making them available as loadable samples in the preset dropdown menu.

## Key Changes
- Imported four new behavior sample files as raw text:
  - `01-click-color.loom` - Click color flash behavior
  - `02-float-y.loom` - Float Y behavior
  - `03-orbit-offset.loom` - Orbit offset behavior
  - `04-breathing-scale.loom` - Breathing scale behavior

- Added four new preset entries to the `SCENE_SYNC_PRESETS` configuration object with corresponding labels and source code

- Updated the HTML preset selector dropdown to include the four new behavior options alongside the existing Jump and Circle presets

## Implementation Details
The new behaviors are imported from the tour examples directory using Vite's `?raw` query parameter to load them as raw text strings. These object-scoped behaviors omit the objectId parameter, allowing the host application to apply them to the attached or selected object. The presets follow the same pattern as the existing Jump and Circle presets, making them immediately available in the editor's preset loading interface.

https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv