### PR TITLE
SceneSync: インライン演算対応とプリセット読込ダイアログ削除（#342の取りこぼし再マージ）

### DIFF
--- a/editor-studio/src/main.js
+++ b/editor-studio/src/main.js
@@ -1714,9 +1714,18 @@ function renderSceneSyncGraphPreview(graph) {
     return;
   }
 
+  elements.sceneSyncGraphPreview.classList.remove('is-error');
   elements.sceneSyncGraphPreview.textContent = graph
     ? JSON.stringify(graph, null, 2)
     : '';
+}
+
+function renderSceneSyncGraphPreviewError(message) {
+  if (!elements.sceneSyncGraphPreview) {
+    return;
+  }
+  elements.sceneSyncGraphPreview.classList.add('is-error');
+  elements.sceneSyncGraphPreview.textContent = `⚠ ${message}`;
 }
 
 async function copyTextToClipboard(text) {
@@ -1754,6 +1763,9 @@ async function handleCopySceneSyncGraphJson() {
       message: 'Copied Scene Sync behavior graph (nodes/edges). Select an object in Scene Sync and paste to apply.'
     });
   } catch (error) {
+    // Surface the failure in the preview so a stale graph isn't mistaken for a
+    // successful copy (the clipboard is intentionally left untouched on error).
+    renderSceneSyncGraphPreviewError(error.message);
     appendOutput({
       level: 'error',
       message: `Copy Scene Sync graph failed: ${error.message}`
@@ -2516,22 +2528,6 @@ async function resetSample() {
 }
 
 function loadSceneSyncPreset(name, source) {
-  const currentText = getDslText();
-
-  if (currentText.trim()) {
-    const ok = window.confirm(
-      `Loading "${name}" will replace the DSL editor content. Continue?`
-    );
-
-    if (!ok) {
-      appendOutput({
-        level: 'info',
-        message: `Canceled loading Scene Sync preset: ${name}.`
-      });
-      return;
-    }
-  }
-
   setDslText(source);
   hasUnsyncedDslText = true;
   setDirty(true);

--- a/editor-studio/src/style.css
+++ b/editor-studio/src/style.css
@@ -1482,6 +1482,13 @@ button:disabled:hover,
   color: rgba(255, 255, 255, 0.7);
 }
 
+.scene-sync-payload-preview.is-error {
+  color: #ff9b9b;
+  border-color: rgba(255, 155, 155, 0.4);
+  background: rgba(255, 155, 155, 0.08);
+  white-space: pre-wrap;
+}
+
 /* Node canvas toolbar and hint */
 
 .node-pane {

--- a/src/scenesync/graph-adapter.js
+++ b/src/scenesync/graph-adapter.js
@@ -9,11 +9,15 @@ const SUPPORTED_NODES = new Set([
   'logic.select',
   'integrate',
   'add',
+  'subtract',
   'multiply',
+  'divide',
   'math.sine',
   'math.cosine',
   'math.add',
+  'math.subtract',
   'math.multiply',
+  'math.divide',
   'math.lerp',
   'scene.setPosition',
   'scene.offsetPosition',
@@ -41,11 +45,15 @@ const NODE_TYPE_MAPPING = {
   'logic.select': 'logic.select',
   'integrate': 'integrate',
   'add': 'add',
+  'subtract': 'subtract',
   'multiply': 'multiply',
+  'divide': 'divide',
   'math.sine': 'sine',
   'math.cosine': 'cosine',
   'math.add': 'add',
+  'math.subtract': 'subtract',
   'math.multiply': 'multiply',
+  'math.divide': 'divide',
   'math.lerp': 'lerp',
   'scene.setPosition': 'sceneSetPosition',
   'scene.offsetPosition': 'sceneOffsetPosition',
@@ -78,7 +86,11 @@ const OUTPUT_PORT_MAPPING = {
   'logic.select': 'out',
   'integrate': 'out',
   'add': 'out',
+  'subtract': 'out',
   'multiply': 'out',
+  'divide': 'out',
+  'math.subtract': 'out',
+  'math.divide': 'out',
   'math.sine': 'out',
   'sine': 'out',
   'math.cosine': 'out',
@@ -191,9 +203,13 @@ function pickParams(nodeType, params = {}) {
     nodeType === 'onEvent' ||
     nodeType === 'integrate' ||
     nodeType === 'add' ||
+    nodeType === 'subtract' ||
     nodeType === 'multiply' ||
+    nodeType === 'divide' ||
     nodeType === 'math.add' ||
+    nodeType === 'math.subtract' ||
     nodeType === 'math.multiply' ||
+    nodeType === 'math.divide' ||
     nodeType === 'math.lerp' ||
     nodeType === 'logic.greaterThan' ||
     nodeType === 'logic.select' ||
@@ -248,6 +264,168 @@ function pickParams(nodeType, params = {}) {
   return {};
 }
 
+// --- Formula lowering -------------------------------------------------------
+//
+// Inline arithmetic in the DSL (e.g. `dy / 10`) compiles to a single `formula`
+// node, which the Scene Sync runtime does not implement. Before mapping to the
+// Scene Sync graph we expand every `formula` node into the equivalent tree of
+// runtime-supported math nodes (add / subtract / multiply / divide) plus
+// `constant` nodes for literals, so inline operators "just work" on export.
+
+// Recursive-descent parser for the formula grammar:
+//   expr := add ; add := mul (('+'|'-') mul)* ; mul := unary (('*'|'/') unary)*
+//   unary := '-' unary | primary ; primary := number | ident | '(' expr ')'
+function parseFormulaExpression(formula) {
+  const text = String(formula);
+  let pos = 0;
+  const skipWs = () => { while (pos < text.length && /\s/.test(text[pos])) pos++; };
+
+  function parseExpr() { return parseAdd(); }
+  function parseAdd() {
+    let node = parseMul();
+    skipWs();
+    while (text[pos] === '+' || text[pos] === '-') {
+      const op = text[pos++];
+      node = { t: 'op', op, l: node, r: parseMul() };
+      skipWs();
+    }
+    return node;
+  }
+  function parseMul() {
+    let node = parseUnary();
+    skipWs();
+    while (text[pos] === '*' || text[pos] === '/') {
+      const op = text[pos++];
+      node = { t: 'op', op, l: node, r: parseUnary() };
+      skipWs();
+    }
+    return node;
+  }
+  function parseUnary() {
+    skipWs();
+    if (text[pos] === '-') { pos++; return { t: 'neg', x: parseUnary() }; }
+    if (text[pos] === '+') { pos++; return parseUnary(); }
+    return parsePrimary();
+  }
+  function parsePrimary() {
+    skipWs();
+    const ch = text[pos];
+    if (ch === '(') {
+      pos++;
+      const node = parseExpr();
+      skipWs();
+      if (text[pos] !== ')') throw new Error(`Unbalanced parentheses in formula: ${formula}`);
+      pos++;
+      return node;
+    }
+    if (/[0-9.]/.test(ch)) {
+      let num = '';
+      while (pos < text.length && /[0-9.]/.test(text[pos])) num += text[pos++];
+      return { t: 'num', value: Number(num) };
+    }
+    if (/[a-zA-Z_]/.test(ch)) {
+      let name = '';
+      while (pos < text.length && /[a-zA-Z0-9_]/.test(text[pos])) name += text[pos++];
+      return { t: 'var', name };
+    }
+    throw new Error(`Unsupported character '${ch ?? ''}' in formula: ${formula}`);
+  }
+
+  const ast = parseExpr();
+  skipWs();
+  if (pos < text.length) throw new Error(`Unexpected '${text[pos]}' in formula: ${formula}`);
+  return ast;
+}
+
+const FORMULA_OP_TYPE = { '+': 'add', '-': 'subtract', '*': 'multiply', '/': 'divide' };
+
+// Expand every `formula` node in a loom graph into supported math/constant
+// nodes. The expression root reuses the formula node's id so downstream edges
+// (formula.out -> ...) stay valid. Returns a new graph; non-formula graphs are
+// returned unchanged.
+export function expandFormulaNodes(loomGraph) {
+  const formulaNodes = loomGraph.nodes.filter((n) => n.type === 'formula');
+  if (formulaNodes.length === 0) return loomGraph;
+
+  const usedIds = new Set(loomGraph.nodes.map((n) => n.id));
+  const removedNodeIds = new Set();
+  const removedEdgeKeys = new Set();
+  const newNodes = [];
+  const newEdges = [];
+
+  for (const formula of formulaNodes) {
+    const fid = formula.id;
+
+    // Map each formula input variable to the endpoint feeding it.
+    const varSources = new Map();
+    for (const edge of loomGraph.edges) {
+      const [toNode, toPort] = edge.to.split('.');
+      if (toNode === fid) {
+        varSources.set(toPort, edge.from);
+        removedEdgeKeys.add(`${edge.from}->${edge.to}`);
+      }
+    }
+
+    const uniqueId = (base) => {
+      let id = `${fid}_${base}`;
+      let i = 2;
+      while (usedIds.has(id)) id = `${fid}_${base}_${i++}`;
+      usedIds.add(id);
+      return id;
+    };
+    const constNode = (value) => {
+      const id = uniqueId('const');
+      newNodes.push({ id, type: 'constant', params: { value } });
+      return `${id}.out`;
+    };
+
+    // Lower an AST node, returning its output endpoint. `forcedId` pins the
+    // root to the formula node's id.
+    const lower = (ast, forcedId = null) => {
+      if (ast.t === 'num') {
+        if (!forcedId) return constNode(ast.value);
+        newNodes.push({ id: forcedId, type: 'constant', params: { value: ast.value } });
+        return `${forcedId}.out`;
+      }
+      if (ast.t === 'var') {
+        const src = varSources.get(ast.name);
+        if (!src) throw new Error(`Formula references unconnected variable '${ast.name}'`);
+        if (!forcedId) return src;
+        // Bare-variable root: identity via add(var, 0) so the root keeps fid.
+        newNodes.push({ id: forcedId, type: 'add' });
+        newEdges.push({ from: src, to: `${forcedId}.a` });
+        newEdges.push({ from: constNode(0), to: `${forcedId}.b` });
+        return `${forcedId}.out`;
+      }
+      if (ast.t === 'neg') {
+        const id = forcedId || uniqueId('subtract');
+        newNodes.push({ id, type: 'subtract' });
+        newEdges.push({ from: constNode(0), to: `${id}.a` });
+        newEdges.push({ from: lower(ast.x), to: `${id}.b` });
+        return `${id}.out`;
+      }
+      if (ast.t === 'op') {
+        const type = FORMULA_OP_TYPE[ast.op];
+        const id = forcedId || uniqueId(type);
+        const left = lower(ast.l);
+        const right = lower(ast.r);
+        newNodes.push({ id, type });
+        newEdges.push({ from: left, to: `${id}.a` });
+        newEdges.push({ from: right, to: `${id}.b` });
+        return `${id}.out`;
+      }
+      throw new Error('Unsupported formula expression');
+    };
+
+    lower(parseFormulaExpression(formula.params?.formula ?? '0'), fid);
+    removedNodeIds.add(fid);
+  }
+
+  const nodes = loomGraph.nodes.filter((n) => !removedNodeIds.has(n.id)).concat(newNodes);
+  const edges = loomGraph.edges.filter((e) => !removedEdgeKeys.has(`${e.from}->${e.to}`)).concat(newEdges);
+  return { ...loomGraph, nodes, edges };
+}
+
 export function compileLoomToSceneSyncGraph(source, options = {}) {
   const result = compileLoomSource(source, { target: 'scenesync' });
   if (!result.ok) throw new Error(`Compilation failed: ${result.errors.map((e) => e.message).join(', ')}`);
@@ -256,6 +434,9 @@ export function compileLoomToSceneSyncGraph(source, options = {}) {
 
 export function loomGraphToSceneSyncGraph(loomGraph, options = {}) {
   if (!loomGraph || !loomGraph.nodes || !loomGraph.edges) throw new Error('loomGraph must have nodes and edges arrays');
+
+  // Expand inline-arithmetic `formula` nodes into runtime-supported math nodes.
+  loomGraph = expandFormulaNodes(loomGraph);
 
   // Phase 1: Find all Scene Sync sink nodes (scene.* and audioSource.* nodes)
   const sinkNodeIds = new Set();

--- a/test/scenesync-graph-adapter.test.mjs
+++ b/test/scenesync-graph-adapter.test.mjs
@@ -511,3 +511,51 @@ test('scene sink depending on unsupported node throws error', () => {
     /Unsupported Scene Sync graph node: unsupportedNode/
   );
 });
+
+test('expands inline arithmetic (formula) into supported math nodes', () => {
+  const source = `
+import math
+import scene
+
+t = clock()
+dy = math.sine(t, freq: 0.5, amplitude: 0.5)
+dy2 = dy / 10
+scene.offsetPosition(y: dy2)
+`;
+
+  const { graph } = compileLoomToSceneSyncGraph(source);
+
+  // No formula node survives; a divide + constant(10) replace it.
+  assert.ok(!graph.nodes.some((n) => n.type === 'formula'), 'formula node should be expanded');
+  const divide = graph.nodes.find((n) => n.type === 'divide');
+  assert.ok(divide, 'divide node should exist');
+  const constTen = graph.nodes.find((n) => n.type === 'constant' && n.params?.value === 10);
+  assert.ok(constTen, 'constant(10) should exist');
+
+  // Numerator is the sine output, denominator is the constant.
+  const sine = graph.nodes.find((n) => n.type === 'sine');
+  assert.ok(graph.edges.some((e) => e.from === `${sine.id}.out` && e.to === `${divide.id}.a`), 'sine -> divide.a');
+  assert.ok(graph.edges.some((e) => e.from === `${constTen.id}.out` && e.to === `${divide.id}.b`), 'constant -> divide.b');
+  assertEdgesReferToExistingNodes(graph);
+});
+
+test('expands nested arithmetic with correct precedence', () => {
+  const source = `
+import math
+import scene
+
+t = clock()
+a = math.sine(t, freq: 0.5)
+b = math.cosine(t, freq: 0.3)
+c = a * b - 0.5
+scene.offsetPosition(y: c)
+`;
+
+  const { graph } = compileLoomToSceneSyncGraph(source);
+  assert.ok(!graph.nodes.some((n) => n.type === 'formula'));
+  // a * b - 0.5  =>  subtract(multiply(a, b), 0.5)
+  assert.ok(graph.nodes.some((n) => n.type === 'multiply'), 'has multiply');
+  assert.ok(graph.nodes.some((n) => n.type === 'subtract'), 'has subtract');
+  assert.ok(graph.nodes.some((n) => n.type === 'constant' && n.params?.value === 0.5));
+  assertEdgesReferToExistingNodes(graph);
+});


### PR DESCRIPTION
## 概要

PR #342 のマージ時に取りこぼされたコミット `8f33015` を main へ反映し直すPRです。当該修正はブランチに push 済みでしたが、#342 のマージコミットの親が1つ前（サンプル追加のみ）で、本修正が main に入っていませんでした。そのため「プリセット読込時の確認ダイアログ」が残り、`dy / 10` などのインライン演算も反映されない状態でした。

## 含まれる修正

1. **インライン演算（`dy / 10` 等）のSceneSync対応**
   - `formula` ノードは SceneSync ランタイム未対応のため、`add/subtract/multiply/divide` ＋ リテラル用 `constant` ノードへ自動展開（`src/scenesync/graph-adapter.js` の `expandFormulaNodes`）。演算子優先順位・括弧・単項マイナス・変数の複数利用に対応。式のルートは元 formula の id を継承し下流の配線を維持。
2. **divide/subtract（＋`math.*`）をアダプタに追加**（許可リスト・型マッピング・パラメータ）。ランタイム（`src/scenesync-runtime.browser.js`）が登録済みであることを確認。
3. **Copy失敗時にプレビューへエラー表示**（古いグラフが残って成功と誤認されるのを防止）。
4. **プリセット読込時の確認ダイアログを削除**（テンポ改善）。

## 確認

- `loom-editor-model` / `scenesync-graph-adapter`(27) / `scenesync-graphs`(30) など関連テスト全パス（formula展開のユニットテストを追加）
- editor-studio ビルド成功
- 実機：`dy / 10` のコピー結果が formula を含まない裸グラフ（clock/sine/constant/divide/sceneOffsetPosition）、プリセット連続ロードでダイアログ0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZwwNBcZUe8SfxMWvwNJLv)_